### PR TITLE
chore: add Husky pre-push hook to enforce tests and build

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo "Running tests before push..."
+npm test || exit 1
+
+echo "Running build before push..."
+npm run build || exit 1
+
+echo "✓ Tests and build passed. Proceeding with push."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,29 @@ We welcome feature suggestions! Use the [feature request template](.github/ISSUE
    ```
    Then create a PR on GitHub using the [pull request template](.github/pull_request_template.md).
 
+   **Note:** A pre-push hook will automatically run `npm test` and `npm run build` before allowing the push. If either fails, the push will be blocked. This ensures code quality and prevents broken builds from being pushed. To bypass the hook in emergency situations (not recommended), you can use `git push --no-verify`.
+
 ## Development Workflow
+
+### Git Hooks
+
+This project uses [Husky](https://typicode.github.io/husky/) to enforce code quality through git hooks:
+
+**Pre-push Hook:**
+- Automatically runs before every `git push`
+- Executes `npm test` to ensure all tests pass
+- Executes `npm run build` to ensure the project builds successfully
+- Blocks the push if either command fails
+
+**Setup:**
+Git hooks are automatically installed when you run `npm install` (via the `prepare` script).
+
+**Bypassing Hooks:**
+In emergency situations, you can bypass the hooks with:
+```bash
+git push --no-verify
+```
+⚠️ **Warning:** This is strongly discouraged as it can introduce broken code into the repository.
 
 ### Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "css-loader": "^6.8.1",
         "esbuild": "^0.24.0",
         "eslint": "^8.45.0",
+        "husky": "^9.1.7",
         "mocha": "^10.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -8110,6 +8111,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -785,7 +785,8 @@
     "prepackage": "npm run build",
     "package": "vsce package",
     "release": "semantic-release",
-    "release:dry-run": "semantic-release --dry-run"
+    "release:dry-run": "semantic-release --dry-run",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",
@@ -812,6 +813,7 @@
     "css-loader": "^6.8.1",
     "esbuild": "^0.24.0",
     "eslint": "^8.45.0",
+    "husky": "^9.1.7",
     "mocha": "^10.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Description

This PR implements Husky git hooks to prevent push without successful tests and build, addressing issue #76.

## Changes

- ✅ Installed Husky v9+ as dev dependency
- ✅ Configured pre-push hook that runs \`npm test\` and \`npm run build\` sequentially
- ✅ Both commands must exit with code 0 for push to proceed
- ✅ Updated CONTRIBUTING.md with comprehensive git hooks documentation
- ✅ Hook is committed to repository (not in .gitignore)
- ✅ Hooks are auto-installed via prepare script when running \`npm install\`

## Benefits

- 🛡️ Prevents broken builds from being pushed to the repository
- ✅ Ensures all tests pass before code is pushed
- 🚀 Provides fast feedback to developers before attempting to push
- 📉 Reduces CI/CD pipeline failures
- 💰 Saves CI resources by catching issues locally

## Testing

The pre-push hook was successfully tested during the push of this branch:
1. Hook automatically ran \`npm test\` - ✅ Passed
2. Hook automatically ran \`npm run build\` - ✅ Passed
3. Push proceeded after both commands succeeded

## Documentation

Added comprehensive documentation to CONTRIBUTING.md including:
- Explanation of the pre-push hook behavior
- Setup instructions (automatic via npm install)
- How to bypass in emergency situations (with warning)

## Bypass Option

Developers can bypass the hook in emergency situations using:
\`\`\`bash
git push --no-verify
\`\`\`
⚠️ This is strongly discouraged as documented in CONTRIBUTING.md

Closes #76