### PR TITLE
Implement Describe Webview for Persistent Volume Claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Kube9 VS Code
 
-**Visual Kubernetes Cluster Management - Right in Your IDE**
+**Kubernetes Management in Your Favorite IDE**
 
 ![kube9 Logo](https://img.shields.io/badge/Status-Active-green) ![VS Code](https://img.shields.io/badge/VS%20Code-Extension-blue) ![Kubernetes](https://img.shields.io/badge/Kubernetes-Supported-blue)
 
 ## Overview
 
-Kube9 VS Code is a VS Code extension that brings visual Kubernetes cluster management directly into your development environment. It provides a modern, intuitive interface for managing your Kubernetes resources without leaving your IDE.
+Kube9 VS Code is an extension that brings visual Kubernetes cluster management directly into your development environment. It provides a modern, intuitive interface for managing your Kubernetes resources without leaving your IDE.
 
 ### Key Features
 

--- a/ai/features/webview/pvc-describe-webview.feature.md
+++ b/ai/features/webview/pvc-describe-webview.feature.md
@@ -1,0 +1,302 @@
+---
+feature_id: pvc-describe-webview
+name: PVC Describe Webview
+description: Graphical kubectl describe functionality for PersistentVolumeClaim resources with detailed information display
+spec_id:
+  - pvc-describe-webview-spec
+---
+
+# PVC Describe Webview
+
+```gherkin
+Background:
+  Given the kube9 VS Code extension is installed and activated
+  And the user has a valid kubeconfig file
+  And the user is connected to a cluster
+  And the cluster contains PersistentVolumeClaim resources
+```
+
+## Opening Describe Webview
+
+```gherkin
+Scenario: Left-click PVC opens Describe webview
+  Given a user has expanded the "Storage" category in the tree view
+  And they have expanded the "Persistent Volume Claims" subcategory
+  And a PVC named "data-pvc" exists in namespace "default"
+  When they left-click on "data-pvc"
+  Then a Describe webview should open or reveal
+  And the webview title should show "PersistentVolumeClaim / data-pvc"
+  And the webview should display detailed PVC information in a graphical format
+  And the Overview tab should be selected by default
+```
+
+```gherkin
+Scenario: Reuse webview for same cluster
+  Given a Describe webview is already open showing "data-pvc"
+  And the webview is for cluster context "my-cluster"
+  When the user left-clicks on another PVC "backup-pvc" in the same cluster
+  Then the existing webview should update its content
+  And the webview title should change to "PersistentVolumeClaim / backup-pvc"
+  And the webview should display information for "backup-pvc"
+  And no additional webview panels should be created
+```
+
+## Overview Tab
+
+```gherkin
+Scenario: Overview displays PVC status information
+  Given a user has opened the Describe webview for a PVC named "data-pvc"
+  And the PVC has status "Bound" and phase "Bound"
+  When they view the Overview tab
+  Then they should see the PVC name "data-pvc"
+  And they should see the namespace "default"
+  And they should see the status badge showing "Bound" with a green indicator
+  And they should see the health status "Healthy" with appropriate color
+  And they should see the PVC phase "Bound"
+```
+
+```gherkin
+Scenario: Overview shows capacity and storage information
+  Given a PVC "data-pvc" with requested capacity "10Gi"
+  And actual capacity "10Gi" (if bound)
+  And storage class "fast-ssd"
+  When a user views the Overview tab
+  Then they should see:
+    | Field              | Value      |
+    | Requested Capacity | 10Gi       |
+    | Actual Capacity    | 10Gi       |
+    | Storage Class      | fast-ssd   |
+```
+
+```gherkin
+Scenario: Overview shows access modes
+  Given a PVC "data-pvc" with access modes ["ReadWriteOnce"]
+  When a user views the Overview tab
+  Then they should see Access Modes showing "ReadWriteOnce"
+  
+  Given a PVC "shared-pvc" with access modes ["ReadWriteMany"]
+  Then they should see Access Modes showing "ReadWriteMany"
+  
+  Given a PVC "readonly-pvc" with access modes ["ReadOnlyMany"]
+  Then they should see Access Modes showing "ReadOnlyMany"
+```
+
+```gherkin
+Scenario: Overview shows bound PV information
+  Given a PVC "data-pvc" is bound to PV "pv-data-001"
+  When a user views the Overview tab
+  Then they should see Bound PV field showing "pv-data-001"
+  
+  Given a PVC "pending-pvc" is not bound
+  Then they should not see a Bound PV field
+```
+
+```gherkin
+Scenario: Overview calculates and displays PVC age
+  Given a PVC "old-pvc" was created 3 days, 5 hours, and 23 minutes ago
+  When a user views the Overview tab
+  Then they should see the Age field showing "3d"
+  And the Creation Timestamp field showing the exact timestamp
+  And the age should update if they refresh the webview
+```
+
+```gherkin
+Scenario: Health status reflects PVC phase
+  Given a PVC with phase "Bound"
+  And no problematic conditions
+  When a user views the Overview tab
+  Then the health status should show "Healthy" with a green indicator
+  
+  Given a PVC with phase "Pending"
+  Then the health status should show "Degraded" with a yellow indicator
+  
+  Given a PVC with phase "Lost"
+  Then the health status should show "Unhealthy" with a red indicator
+```
+
+## Volume Details Tab
+
+```gherkin
+Scenario: Volume Details tab displays volume configuration
+  Given a PVC "data-pvc" with volume mode "Filesystem"
+  And storage class "fast-ssd"
+  And requested capacity "10Gi"
+  When a user clicks on the Volume Details tab
+  Then they should see:
+    | Field              | Value        |
+    | Volume Mode        | Filesystem   |
+    | Storage Class      | fast-ssd     |
+    | Requested Capacity | 10Gi         |
+```
+
+```gherkin
+Scenario: Volume Details shows finalizers
+  Given a PVC "data-pvc" has finalizers ["kubernetes.io/pv-protection"]
+  When a user views the Volume Details tab
+  Then they should see a Finalizers section
+  And the finalizer "kubernetes.io/pv-protection" should be listed
+```
+
+```gherkin
+Scenario: Volume Details shows Block volume mode
+  Given a PVC "block-pvc" has volume mode "Block"
+  When a user views the Volume Details tab
+  Then they should see Volume Mode showing "Block"
+```
+
+## Usage Tab
+
+```gherkin
+Scenario: Usage tab shows Pods using PVC
+  Given a PVC "data-pvc" is mounted by Pod "app-pod" in namespace "default"
+  And the Pod mounts the PVC at "/data" with read-only false
+  When a user clicks on the Usage tab
+  Then they should see a table with Pod information
+  And the table should show:
+    | Pod Name | Namespace | Phase  | Mount Path | Read-Only |
+    | app-pod  | default   | Running| /data      | No        |
+```
+
+```gherkin
+Scenario: Usage tab shows multiple Pods
+  Given a PVC "shared-pvc" is mounted by:
+    | Pod Name  | Namespace | Mount Path |
+    | pod-1     | default   | /data      |
+    | pod-2     | default   | /backup    |
+  When a user views the Usage tab
+  Then they should see both Pods listed in the table
+  And the tab badge should show "Usage (2 Pods)"
+```
+
+```gherkin
+Scenario: Usage tab shows read-only mounts
+  Given a PVC "readonly-pvc" is mounted by Pod "reader-pod" with read-only true
+  When a user views the Usage tab
+  Then the Read-Only column should show "Yes" with appropriate styling
+```
+
+```gherkin
+Scenario: Usage tab allows navigation to Pods
+  Given a PVC "data-pvc" is mounted by Pod "app-pod"
+  When a user views the Usage tab
+  And clicks the "View Pod" button for "app-pod"
+  Then the Pod describe webview should open for "app-pod"
+```
+
+```gherkin
+Scenario: Usage tab shows empty state
+  Given a PVC "unused-pvc" is not mounted by any Pods
+  When a user views the Usage tab
+  Then they should see a message "No Pods are currently using this PVC"
+  And a hint "Pods that mount this PVC will appear here"
+```
+
+## Conditions Tab
+
+```gherkin
+Scenario: Conditions tab displays PVC conditions
+  Given a PVC has conditions:
+    | Type                  | Status | Last Transition      | Reason |
+    | Resizing              | True   | 2025-12-30T10:00:00 | -      |
+    | FileSystemResizePending| True  | 2025-12-30T10:01:00 | -      |
+  When a user clicks on the Conditions tab
+  Then they should see a table with all conditions
+  And each row should show Type, Status, Last Transition, Reason, and Message
+  And "True" status should have a green indicator
+  And "False" status should have a red indicator
+```
+
+## Events Tab
+
+```gherkin
+Scenario: Events tab shows PVC events in timeline
+  Given a PVC "data-pvc" has events:
+    | Type    | Reason      | Message                            | Count | Age  |
+    | Normal  | Provisioning| External provisioner is provisioning| 1     | 10m  |
+    | Normal  | Provisioned | Successfully provisioned volume     | 1     | 9m   |
+    | Normal  | Bound       | Bound to volume pv-data-001         | 1     | 8m   |
+  When a user clicks on the Events tab
+  Then they should see all events in a timeline view
+  And events should be ordered by most recent first
+  And each event should show Type, Reason, Message, Count, and Age
+```
+
+```gherkin
+Scenario: Warning events visually distinct
+  Given a PVC has events including:
+    | Type    | Reason          | Message                        |
+    | Normal  | Bound           | Successfully bound             |
+    | Warning | FailedBinding   | No persistent volumes available|
+  When displayed in the Events tab
+  Then Normal events should have a blue/gray indicator
+  And Warning events should have a yellow/orange indicator
+```
+
+## Metadata Tab
+
+```gherkin
+Scenario: Metadata tab displays labels and annotations
+  Given a PVC "data-pvc" has labels:
+    | Key           | Value    |
+    | app           | database |
+    | storage-tier  | fast     |
+  And annotations:
+    | Key                    | Value              |
+    | volume.beta.kubernetes.io| storage-class     |
+  When a user clicks on the Metadata tab
+  Then they should see a Labels section with all labels
+  And they should see an Annotations section with all annotations
+  And each label/annotation should show key and value
+```
+
+```gherkin
+Scenario: Metadata tab shows basic information
+  Given a PVC "data-pvc" has UID "abc-123-def"
+  And resource version "456789"
+  And creation timestamp "2025-12-30T10:00:00Z"
+  When a user views the Metadata tab
+  Then they should see:
+    | Field                | Value                    |
+    | UID                  | abc-123-def              |
+    | Resource Version     | 456789                   |
+    | Creation Timestamp   | 2025-12-30T10:00:00Z    |
+```
+
+## Header Actions
+
+```gherkin
+Scenario: Refresh button updates PVC data
+  Given a user has the Describe webview open for "data-pvc"
+  When they click the "Refresh" button in the header
+  Then a loading indicator should appear
+  And the extension should fetch fresh PVC data from the API
+  And all tabs should update with the latest information
+```
+
+```gherkin
+Scenario: View YAML button opens editor
+  Given a user has the Describe webview open for "data-pvc"
+  When they click the "View YAML" button in the header
+  Then a new editor tab should open
+  And the editor should contain the full YAML manifest for "data-pvc"
+  And the editor should use YAML syntax highlighting
+```
+
+## Error Handling
+
+```gherkin
+Scenario: PVC not found error
+  Given a user has the Describe webview open for "data-pvc"
+  When the PVC "data-pvc" is deleted from the cluster
+  And they click Refresh
+  Then an error message should appear in the webview
+  And the message should say "PVC 'data-pvc' not found in namespace 'default'"
+```
+
+```gherkin
+Scenario: Permission denied error
+  Given a user lacks permissions to read PVCs in namespace "production"
+  When they attempt to open Describe webview for a PVC in "production"
+  Then an error message should appear
+  And the message should say "Permission denied: Unable to read PVC. Check your RBAC permissions."
+```

--- a/ai/specs/webview/pvc-describe-webview-spec.spec.md
+++ b/ai/specs/webview/pvc-describe-webview-spec.spec.md
@@ -1,0 +1,303 @@
+---
+spec_id: pvc-describe-webview-spec
+name: PVC Describe Webview Specification
+description: Technical specification for implementing graphical PersistentVolumeClaim describe functionality
+feature_id:
+  - pvc-describe-webview
+---
+
+# PVC Describe Webview Specification
+
+## Overview
+
+The PVC Describe Webview provides a graphical, user-friendly interface for viewing detailed PersistentVolumeClaim information. It displays PVC status, capacity, access modes, storage class, bound PV, volume mode, Pods using the PVC, conditions, events, and metadata.
+
+## Architecture
+
+The PVC describe webview follows the same architecture pattern as Pod and Namespace describe webviews:
+- Uses shared DescribeWebview panel infrastructure
+- React-based webview components
+- Data provider pattern for fetching and formatting data
+- Message-based communication between extension and webview
+
+## Implementation Details
+
+### PVCDescribeProvider
+
+**File**: `src/providers/PVCDescribeProvider.ts`
+
+Data provider that fetches and formats PVC information:
+
+```typescript
+interface PVCDescribeData {
+  overview: PVCOverview;
+  volumeDetails: VolumeDetails;
+  usage: PVCUsage;
+  conditions: PVCCondition[];
+  events: PVCEvent[];
+  metadata: PVCMetadata;
+}
+
+interface PVCOverview {
+  name: string;
+  namespace: string;
+  status: PVCStatus;
+  phase: string;
+  requestedCapacity: string;
+  actualCapacity?: string;
+  accessModes: string[];
+  storageClass: string;
+  boundPV?: string;
+  age: string;
+  creationTimestamp: string;
+}
+
+interface PVCStatus {
+  phase: 'Pending' | 'Bound' | 'Lost';
+  reason?: string;
+  message?: string;
+  health: 'Healthy' | 'Degraded' | 'Unhealthy' | 'Unknown';
+}
+
+interface VolumeDetails {
+  volumeMode: string;
+  finalizers: string[];
+  requestedCapacity: string;
+  actualCapacity?: string;
+  storageClass: string;
+  accessModes: string[];
+}
+
+interface PVCUsage {
+  pods: PodUsageInfo[];
+  totalPods: number;
+}
+
+interface PodUsageInfo {
+  name: string;
+  namespace: string;
+  phase: string;
+  mountPath?: string;
+  readOnly?: boolean;
+}
+
+interface PVCCondition {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  lastTransitionTime: string;
+  reason?: string;
+  message?: string;
+}
+
+interface PVCEvent {
+  type: 'Normal' | 'Warning';
+  reason: string;
+  message: string;
+  count: number;
+  firstTimestamp: string;
+  lastTimestamp: string;
+  source: string;
+  age: string;
+}
+
+interface PVCMetadata {
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+  uid: string;
+  resourceVersion: string;
+  creationTimestamp: string;
+}
+```
+
+### DescribeWebview Integration
+
+**File**: `src/webview/DescribeWebview.ts`
+
+Add PVC support to DescribeWebview:
+
+```typescript
+// Add PVC provider and config
+private static pvcProvider: PVCDescribeProvider | undefined;
+private static currentPVCConfig: PVCTreeItemConfig | undefined;
+
+// Add showPVCDescribe method
+public static async showPVCDescribe(
+  context: vscode.ExtensionContext,
+  pvcConfig: PVCTreeItemConfig
+): Promise<void>
+
+// Route PersistentVolumeClaim resources in showFromTreeItem
+if (kind === 'PersistentVolumeClaim') {
+  await DescribeWebview.showPVCDescribe(context, {
+    name,
+    namespace,
+    context: contextName
+  });
+  return;
+}
+```
+
+### React Components
+
+**Files**: `src/webview/pvc-describe/`
+
+- `index.tsx` - Entry point that renders PVCDescribeApp
+- `PVCDescribeApp.tsx` - Main app component managing state and tabs
+- `types.ts` - Type definitions for messages and data
+- `components/OverviewTab.tsx` - Overview tab component
+- `components/VolumeDetailsTab.tsx` - Volume details tab component
+- `components/UsageTab.tsx` - Usage tab showing Pods using PVC
+- `components/ConditionsTab.tsx` - Conditions tab component
+- `components/EventsTab.tsx` - Events tab component
+- `components/MetadataTab.tsx` - Metadata tab component
+
+### Webpack Configuration
+
+**File**: `webpack.config.js`
+
+Add PVC describe webview entry:
+
+```javascript
+const pvcDescribeConfig = {
+  target: 'web',
+  entry: './src/webview/pvc-describe/index.tsx',
+  output: {
+    path: path.resolve(__dirname, 'dist', 'media', 'pvc-describe'),
+    filename: 'index.js',
+    devtoolModuleFilenameTemplate: '../[resource-path]'
+  },
+  // ... rest of config
+};
+```
+
+## Data Fetching
+
+### PVC Details
+
+- Use `apiClient.core.readNamespacedPersistentVolumeClaim()` to fetch PVC
+- Extract status, spec, and metadata
+- Format overview information including phase, capacity, access modes, storage class
+
+### Bound PV
+
+- If PVC is bound (has `spec.volumeName`), fetch the PV using `apiClient.core.readPersistentVolume()`
+- Extract PV details for display
+
+### Pods Using PVC
+
+- List all Pods in the PVC's namespace using `apiClient.core.listNamespacedPod()`
+- For each Pod, check `spec.volumes[]` for volumes with `persistentVolumeClaim.claimName` matching the PVC name
+- For matching volumes, find containers that mount the volume via `volumeMounts`
+- Extract Pod name, namespace, phase, mount path, and read-only status
+
+### Events
+
+- Fetch PVC-related events using field selector: `involvedObject.name={pvcName},involvedObject.uid={pvcUid}`
+- Group events by type and reason
+- Format with timestamps and age calculations
+
+### Conditions
+
+- Extract conditions from `pvc.status.conditions`
+- Format with type, status, last transition time, reason, and message
+
+## UI Components
+
+### Overview Tab
+
+Displays:
+- Status and health badge
+- Namespace
+- Requested and actual capacity
+- Access modes
+- Storage class
+- Bound PV (if bound)
+- Age and creation timestamp
+
+### Volume Details Tab
+
+Displays:
+- Volume mode (Filesystem/Block)
+- Storage class
+- Requested and actual capacity
+- Access modes
+- Finalizers (if any)
+
+### Usage Tab
+
+Displays table of Pods using the PVC:
+- Pod name (clickable to navigate)
+- Namespace
+- Phase
+- Mount path
+- Read-only indicator
+- "View Pod" action button
+
+### Conditions Tab
+
+Displays table of PVC conditions:
+- Type
+- Status (with color indicator)
+- Last transition time
+- Reason
+- Message
+
+### Events Tab
+
+Displays timeline of PVC events:
+- Event type (Normal/Warning)
+- Reason
+- Message
+- Count (if grouped)
+- Age
+- Source component
+- Timestamps
+
+### Metadata Tab
+
+Displays:
+- Basic information (UID, resource version, creation timestamp)
+- Labels (key-value pairs)
+- Annotations (key-value pairs)
+
+## Message Protocol
+
+### Extension to Webview
+
+```typescript
+{ command: 'updatePVCData', data: PVCDescribeData }
+{ command: 'showError', data: { message: string } }
+```
+
+### Webview to Extension
+
+```typescript
+{ command: 'refresh' }
+{ command: 'viewYaml' }
+{ command: 'ready' }
+{ command: 'navigateToPod', data: { name: string, namespace: string } }
+```
+
+## Error Handling
+
+- Handle PVC not found errors gracefully
+- Handle permission denied errors with helpful messages
+- Handle network connectivity errors
+- Show "N/A" or "Unknown" for missing optional fields
+- Log errors to console for debugging
+
+## Performance Considerations
+
+- Cache PVC data where appropriate
+- Fetch Pods and events in parallel where possible
+- Use efficient field selectors for event queries
+- Implement loading states during data fetch
+- Cancel in-flight requests when switching PVCs
+
+## Accessibility
+
+- Use semantic HTML elements
+- Provide ARIA labels for interactive elements
+- Support keyboard navigation
+- Ensure sufficient color contrast
+- Support screen readers

--- a/media/describe/podDescribe.css
+++ b/media/describe/podDescribe.css
@@ -788,3 +788,136 @@ body {
     }
 }
 
+/* ==========================================================================
+   PVC Describe Specific Styles
+   ========================================================================== */
+
+.usage-tab,
+.volume-details-tab,
+.metadata-tab {
+    width: 100%;
+}
+
+.section-description {
+    color: var(--vscode-descriptionForeground);
+    font-size: 0.9em;
+    margin-bottom: 16px;
+}
+
+.phase-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: 500;
+}
+
+.phase-badge.phase-running {
+    background-color: rgba(73, 194, 109, 0.2);
+    color: var(--vscode-testing-iconPassed);
+}
+
+.phase-badge.phase-pending {
+    background-color: rgba(255, 191, 0, 0.2);
+    color: var(--vscode-editorWarning-foreground);
+}
+
+.phase-badge.phase-failed {
+    background-color: rgba(242, 76, 76, 0.2);
+    color: var(--vscode-testing-iconFailed);
+}
+
+.phase-badge.phase-succeeded {
+    background-color: rgba(73, 194, 109, 0.2);
+    color: var(--vscode-testing-iconPassed);
+}
+
+.read-only-badge,
+.read-write-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: 0.8em;
+    font-weight: 500;
+}
+
+.read-only-badge {
+    background-color: rgba(255, 191, 0, 0.2);
+    color: var(--vscode-editorWarning-foreground);
+}
+
+.read-write-badge {
+    background-color: rgba(73, 194, 109, 0.2);
+    color: var(--vscode-testing-iconPassed);
+}
+
+.link-button {
+    background: transparent;
+    border: none;
+    color: var(--vscode-textLink-foreground);
+    cursor: pointer;
+    font-size: 0.9em;
+    text-decoration: underline;
+    padding: 4px 8px;
+    border-radius: 3px;
+}
+
+.link-button:hover {
+    background-color: var(--vscode-list-hoverBackground);
+}
+
+.link-button:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 2px;
+}
+
+.finalizers-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.finalizer-item {
+    padding: 8px 12px;
+    background-color: var(--vscode-textBlockQuote-background);
+    border-radius: 4px;
+    font-family: var(--vscode-editor-font-family);
+    font-size: 0.9em;
+    color: var(--vscode-foreground);
+}
+
+.key-value-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.key-value-item {
+    display: flex;
+    gap: 12px;
+    padding: 8px 12px;
+    background-color: var(--vscode-textBlockQuote-background);
+    border-radius: 4px;
+}
+
+.key-value-item .key {
+    font-weight: 600;
+    color: var(--vscode-foreground);
+    min-width: 150px;
+}
+
+.key-value-item .value {
+    color: var(--vscode-foreground);
+    word-break: break-word;
+    flex: 1;
+}
+
+.empty-message {
+    color: var(--vscode-descriptionForeground);
+    font-size: 0.9em;
+    font-style: italic;
+    padding: 20px;
+}
+

--- a/src/providers/PVCDescribeProvider.ts
+++ b/src/providers/PVCDescribeProvider.ts
@@ -1,0 +1,522 @@
+/**
+ * PVC Describe Provider interfaces.
+ * Type definitions for PersistentVolumeClaim information data structures used in the Describe webview.
+ */
+
+/**
+ * Main data structure containing all PVC information for display in the webview.
+ */
+export interface PVCDescribeData {
+    /** Overview information including status, capacity, access modes, and storage class */
+    overview: PVCOverview;
+    /** Volume details including volume mode, finalizers, and capacity */
+    volumeDetails: VolumeDetails;
+    /** Usage information showing which Pods are using this PVC */
+    usage: PVCUsage;
+    /** PVC conditions for tracking state */
+    conditions: PVCCondition[];
+    /** Events related to the PVC */
+    events: PVCEvent[];
+    /** PVC metadata including labels and annotations */
+    metadata: PVCMetadata;
+}
+
+/**
+ * Overview information for a PVC including status, capacity, access modes, and storage class.
+ */
+export interface PVCOverview {
+    /** PVC name */
+    name: string;
+    /** Namespace where the PVC is located */
+    namespace: string;
+    /** PVC status (Pending, Bound, Lost) */
+    status: PVCStatus;
+    /** PVC phase */
+    phase: string;
+    /** Requested storage capacity (e.g., "5Gi") */
+    requestedCapacity: string;
+    /** Actual capacity if bound (e.g., "5Gi") */
+    actualCapacity?: string;
+    /** Access modes (ReadWriteOnce, ReadOnlyMany, ReadWriteMany) */
+    accessModes: string[];
+    /** Storage class name (or "default" if not specified) */
+    storageClass: string;
+    /** Bound PV name if PVC is bound */
+    boundPV?: string;
+    /** Age of the PVC (formatted string like "3d", "5h", "23m") */
+    age: string;
+    /** Creation timestamp */
+    creationTimestamp: string;
+}
+
+/**
+ * PVC status information with phase and health calculation.
+ */
+export interface PVCStatus {
+    /** PVC phase */
+    phase: 'Pending' | 'Bound' | 'Lost';
+    /** Optional reason for the current phase */
+    reason?: string;
+    /** Optional message describing the status */
+    message?: string;
+    /** Health status calculated from phase and conditions */
+    health: 'Healthy' | 'Degraded' | 'Unhealthy' | 'Unknown';
+}
+
+/**
+ * Volume details including volume mode, finalizers, and capacity information.
+ */
+export interface VolumeDetails {
+    /** Volume mode (Filesystem, Block) */
+    volumeMode: string;
+    /** Finalizers on the PVC */
+    finalizers: string[];
+    /** Requested storage capacity */
+    requestedCapacity: string;
+    /** Actual capacity if bound */
+    actualCapacity?: string;
+    /** Storage class name */
+    storageClass: string;
+    /** Access modes */
+    accessModes: string[];
+}
+
+/**
+ * Usage information showing which Pods are using this PVC.
+ */
+export interface PVCUsage {
+    /** List of Pods using this PVC */
+    pods: PodUsageInfo[];
+    /** Total number of Pods using this PVC */
+    totalPods: number;
+}
+
+/**
+ * Information about a Pod using the PVC.
+ */
+export interface PodUsageInfo {
+    /** Pod name */
+    name: string;
+    /** Pod namespace */
+    namespace: string;
+    /** Pod phase */
+    phase: string;
+    /** Volume mount path in the Pod */
+    mountPath?: string;
+    /** Whether the mount is read-only */
+    readOnly?: boolean;
+}
+
+/**
+ * PVC condition for tracking state.
+ */
+export interface PVCCondition {
+    /** Condition type (e.g., "Resizing", "FileSystemResizePending") */
+    type: string;
+    /** Condition status */
+    status: 'True' | 'False' | 'Unknown';
+    /** Last transition time */
+    lastTransitionTime: string;
+    /** Optional reason for the condition */
+    reason?: string;
+    /** Optional message describing the condition */
+    message?: string;
+}
+
+/**
+ * PVC event information for timeline display.
+ */
+export interface PVCEvent {
+    /** Event type */
+    type: 'Normal' | 'Warning';
+    /** Event reason */
+    reason: string;
+    /** Event message */
+    message: string;
+    /** Number of times this event occurred (for grouped events) */
+    count: number;
+    /** First occurrence timestamp */
+    firstTimestamp: string;
+    /** Last occurrence timestamp */
+    lastTimestamp: string;
+    /** Source component that generated the event */
+    source: string;
+    /** Age of the event (formatted string) */
+    age: string;
+}
+
+/**
+ * PVC metadata including labels and annotations.
+ */
+export interface PVCMetadata {
+    /** Labels applied to the PVC */
+    labels: Record<string, string>;
+    /** Annotations applied to the PVC */
+    annotations: Record<string, string>;
+    /** PVC UID */
+    uid: string;
+    /** Resource version */
+    resourceVersion: string;
+    /** Creation timestamp */
+    creationTimestamp: string;
+}
+
+import * as k8s from '@kubernetes/client-node';
+import { KubernetesApiClient } from '../kubernetes/apiClient';
+
+/**
+ * Provider for fetching and formatting PVC information for the Describe webview.
+ * Fetches PVC data from Kubernetes API and transforms it into structured data structures.
+ */
+export class PVCDescribeProvider {
+    constructor(private k8sClient: KubernetesApiClient) {}
+
+    /**
+     * Fetches PVC details from Kubernetes API and formats them for display.
+     * 
+     * @param name - PVC name
+     * @param namespace - PVC namespace
+     * @param context - Kubernetes context name
+     * @returns Promise resolving to formatted PVC data
+     * @throws Error if PVC cannot be fetched or if API calls fail
+     */
+    async getPVCDetails(
+        name: string,
+        namespace: string,
+        context: string
+    ): Promise<PVCDescribeData> {
+        // Set context before API calls
+        this.k8sClient.setContext(context);
+
+        // Fetch PVC object
+        let pvc: k8s.V1PersistentVolumeClaim;
+        try {
+            pvc = await this.k8sClient.core.readNamespacedPersistentVolumeClaim({
+                name: name,
+                namespace: namespace
+            });
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`Failed to fetch PVC ${name} in namespace ${namespace}: ${errorMessage}`);
+        }
+
+        // Fetch bound PV if PVC is bound
+        let boundPV: k8s.V1PersistentVolume | undefined;
+        const volumeName = pvc.spec?.volumeName;
+        if (volumeName) {
+            try {
+                boundPV = await this.k8sClient.core.readPersistentVolume({
+                    name: volumeName
+                });
+            } catch (error) {
+                // Log but don't fail if PV can't be fetched
+                console.warn(`Failed to fetch bound PV ${volumeName} for PVC ${name}:`, error);
+            }
+        }
+
+        // Find Pods using this PVC
+        let podsUsingPVC: PodUsageInfo[] = [];
+        try {
+            podsUsingPVC = await this.findPodsUsingPVC(name, namespace);
+        } catch (error) {
+            // Log but don't fail if Pods can't be fetched
+            console.warn(`Failed to find Pods using PVC ${name}:`, error);
+        }
+
+        // Fetch PVC-related events
+        let events: k8s.CoreV1Event[] = [];
+        try {
+            const pvcUid = pvc.metadata?.uid;
+            if (pvcUid && namespace) {
+                const fieldSelector = `involvedObject.name=${name},involvedObject.uid=${pvcUid}`;
+                const eventsResponse = await this.k8sClient.core.listNamespacedEvent({
+                    namespace: namespace,
+                    fieldSelector: fieldSelector
+                });
+                events = eventsResponse.items || [];
+                
+                // Defensive filter to ensure PVC-level events only
+                events = events.filter(event => 
+                    event.involvedObject?.kind === 'PersistentVolumeClaim' && 
+                    event.involvedObject?.name === name
+                );
+            }
+        } catch (error) {
+            // Log but don't fail if events can't be fetched
+            console.warn(`Failed to fetch events for PVC ${name}:`, error);
+        }
+
+        // Format data
+        return {
+            overview: this.formatOverview(pvc, boundPV),
+            volumeDetails: this.formatVolumeDetails(pvc),
+            usage: {
+                pods: podsUsingPVC,
+                totalPods: podsUsingPVC.length
+            },
+            conditions: this.formatConditions(pvc.status?.conditions || []),
+            events: this.formatEvents(events),
+            metadata: this.formatMetadata(pvc.metadata!)
+        };
+    }
+
+    /**
+     * Formats PVC overview information.
+     */
+    private formatOverview(pvc: k8s.V1PersistentVolumeClaim, boundPV?: k8s.V1PersistentVolume): PVCOverview {
+        const status = pvc.status;
+        const spec = pvc.spec;
+        const metadata = pvc.metadata;
+
+        const phase = status?.phase || 'Pending';
+        const requestedCapacity = spec?.resources?.requests?.storage || 'Unknown';
+        const actualCapacity = status?.capacity?.storage || boundPV?.spec?.capacity?.storage || undefined;
+        const accessModes = spec?.accessModes || [];
+        const storageClass = spec?.storageClassName || '(default)';
+        const volumeName = spec?.volumeName;
+
+        return {
+            name: metadata?.name || 'Unknown',
+            namespace: metadata?.namespace || 'Unknown',
+            status: this.calculatePVCStatus(pvc),
+            phase: phase,
+            requestedCapacity: requestedCapacity,
+            actualCapacity: actualCapacity,
+            accessModes: accessModes,
+            storageClass: storageClass,
+            boundPV: volumeName,
+            age: this.calculateAge(metadata?.creationTimestamp),
+            creationTimestamp: this.formatTimestamp(metadata?.creationTimestamp)
+        };
+    }
+
+    /**
+     * Calculates PVC health status based on phase and conditions.
+     */
+    private calculatePVCStatus(pvc: k8s.V1PersistentVolumeClaim): PVCStatus {
+        const phase = pvc.status?.phase || 'Pending';
+        const conditions = pvc.status?.conditions || [];
+
+        let health: PVCStatus['health'] = 'Unknown';
+
+        if (phase === 'Bound') {
+            // Check for problematic conditions
+            const hasErrorCondition = conditions.some(c => 
+                c.status === 'True' && 
+                (c.type === 'Resizing' || c.type === 'FileSystemResizePending')
+            );
+            health = hasErrorCondition ? 'Degraded' : 'Healthy';
+        } else if (phase === 'Pending') {
+            health = 'Degraded';
+        } else if (phase === 'Lost') {
+            health = 'Unhealthy';
+        }
+
+        return {
+            phase: phase as PVCStatus['phase'],
+            health
+        };
+    }
+
+    /**
+     * Formats volume details information.
+     */
+    private formatVolumeDetails(pvc: k8s.V1PersistentVolumeClaim): VolumeDetails {
+        const spec = pvc.spec;
+        const status = pvc.status;
+        const metadata = pvc.metadata;
+
+        return {
+            volumeMode: spec?.volumeMode || 'Filesystem',
+            finalizers: metadata?.finalizers || [],
+            requestedCapacity: spec?.resources?.requests?.storage || 'Unknown',
+            actualCapacity: status?.capacity?.storage,
+            storageClass: spec?.storageClassName || '(default)',
+            accessModes: spec?.accessModes || []
+        };
+    }
+
+    /**
+     * Finds Pods using this PVC by listing all Pods in the namespace and checking volume mounts.
+     */
+    private async findPodsUsingPVC(pvcName: string, namespace: string): Promise<PodUsageInfo[]> {
+        try {
+            const response = await this.k8sClient.core.listNamespacedPod({
+                namespace: namespace
+            });
+            const pods = response.items || [];
+
+            const podsUsingPVC: PodUsageInfo[] = [];
+
+            pods.forEach((pod: k8s.V1Pod) => {
+                const volumes = pod.spec?.volumes || [];
+                const containers = [
+                    ...(pod.spec?.containers || []),
+                    ...(pod.spec?.initContainers || [])
+                ];
+
+                // Check if any volume references this PVC
+                volumes.forEach(volume => {
+                    if (volume.persistentVolumeClaim?.claimName === pvcName) {
+                        // Find containers that mount this volume
+                        containers.forEach(container => {
+                            const volumeMount = container.volumeMounts?.find(
+                                mount => mount.name === volume.name
+                            );
+                            if (volumeMount) {
+                                podsUsingPVC.push({
+                                    name: pod.metadata?.name || 'Unknown',
+                                    namespace: pod.metadata?.namespace || namespace,
+                                    phase: pod.status?.phase || 'Unknown',
+                                    mountPath: volumeMount.mountPath,
+                                    readOnly: volumeMount.readOnly || false
+                                });
+                            }
+                        });
+                    }
+                });
+            });
+
+            // Remove duplicates (same Pod might mount the PVC multiple times)
+            const uniquePods = new Map<string, PodUsageInfo>();
+            podsUsingPVC.forEach(pod => {
+                const key = `${pod.namespace}/${pod.name}`;
+                if (!uniquePods.has(key)) {
+                    uniquePods.set(key, pod);
+                }
+            });
+
+            return Array.from(uniquePods.values());
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`Failed to find Pods using PVC ${pvcName}: ${errorMessage}`);
+        }
+    }
+
+    /**
+     * Formats PVC conditions.
+     */
+    private formatConditions(conditions: k8s.V1PersistentVolumeClaimCondition[]): PVCCondition[] {
+        return conditions.map(c => ({
+            type: c.type,
+            status: c.status as 'True' | 'False' | 'Unknown',
+            lastTransitionTime: c.lastTransitionTime ? this.formatTimestamp(c.lastTransitionTime) : 'Unknown',
+            reason: c.reason,
+            message: c.message
+        }));
+    }
+
+    /**
+     * Formats and groups PVC events by type and reason.
+     */
+    private formatEvents(events: k8s.CoreV1Event[]): PVCEvent[] {
+        // Group events by type and reason
+        const grouped = new Map<string, k8s.CoreV1Event[]>();
+
+        events.forEach(event => {
+            const key = `${event.type || 'Normal'}-${event.reason || 'Unknown'}`;
+            if (!grouped.has(key)) {
+                grouped.set(key, []);
+            }
+            grouped.get(key)!.push(event);
+        });
+
+        // Format grouped events
+        return Array.from(grouped.values()).map(group => {
+            const first = group[0];
+            const sorted = group.sort((a, b) => {
+                const aTime = this.getEventTimestamp(a.lastTimestamp || a.firstTimestamp);
+                const bTime = this.getEventTimestamp(b.lastTimestamp || b.firstTimestamp);
+                return bTime.getTime() - aTime.getTime();
+            });
+            const last = sorted[0];
+
+            return {
+                type: (first.type || 'Normal') as 'Normal' | 'Warning',
+                reason: first.reason || 'Unknown',
+                message: first.message || 'No message',
+                count: first.count || group.length,
+                firstTimestamp: this.formatTimestamp(first.firstTimestamp) || 'Unknown',
+                lastTimestamp: this.formatTimestamp(last.lastTimestamp || last.firstTimestamp) || 'Unknown',
+                source: first.source?.component || 'Unknown',
+                age: this.calculateAge(this.getEventTimestamp(last.lastTimestamp || last.firstTimestamp))
+            };
+        });
+    }
+
+    /**
+     * Formats PVC metadata including labels and annotations.
+     */
+    private formatMetadata(metadata: k8s.V1ObjectMeta): PVCMetadata {
+        return {
+            labels: metadata.labels || {},
+            annotations: metadata.annotations || {},
+            uid: metadata.uid || 'Unknown',
+            resourceVersion: metadata.resourceVersion || 'Unknown',
+            creationTimestamp: metadata.creationTimestamp ? this.formatTimestamp(metadata.creationTimestamp) : 'Unknown'
+        };
+    }
+
+    /**
+     * Formats a timestamp (Date or string) to ISO string.
+     */
+    private formatTimestamp(timestamp?: string | Date): string {
+        if (!timestamp) {
+            return 'Unknown';
+        }
+        if (timestamp instanceof Date) {
+            return timestamp.toISOString();
+        }
+        return timestamp;
+    }
+
+    /**
+     * Gets a Date object from a timestamp (Date or string).
+     */
+    private getEventTimestamp(timestamp?: string | Date): Date {
+        if (!timestamp) {
+            return new Date();
+        }
+        if (timestamp instanceof Date) {
+            return timestamp;
+        }
+        return new Date(timestamp);
+    }
+
+    /**
+     * Calculates age from timestamp and formats as human-readable string.
+     */
+    private calculateAge(timestamp?: string | Date): string {
+        if (!timestamp) {
+            return 'Unknown';
+        }
+
+        try {
+            const now = new Date();
+            const then = timestamp instanceof Date ? timestamp : new Date(timestamp);
+            const diffMs = now.getTime() - then.getTime();
+
+            if (isNaN(diffMs) || diffMs < 0) {
+                return 'Unknown';
+            }
+
+            const seconds = Math.floor(diffMs / 1000);
+            const minutes = Math.floor(seconds / 60);
+            const hours = Math.floor(minutes / 60);
+            const days = Math.floor(hours / 24);
+
+            if (days > 0) {
+                return `${days}d`;
+            }
+            if (hours > 0) {
+                return `${hours}h`;
+            }
+            if (minutes > 0) {
+                return `${minutes}m`;
+            }
+            return `${seconds}s`;
+        } catch {
+            return 'Unknown';
+        }
+    }
+}

--- a/src/webview/pvc-describe/PVCDescribeApp.tsx
+++ b/src/webview/pvc-describe/PVCDescribeApp.tsx
@@ -1,0 +1,236 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { PVCDescribeData, ExtensionToWebviewMessage, WebviewToExtensionMessage, VSCodeAPI } from './types';
+import { WebviewHeader, WebviewHeaderAction } from '../components/WebviewHeader';
+import { OverviewTab } from './components/OverviewTab';
+import { VolumeDetailsTab } from './components/VolumeDetailsTab';
+import { UsageTab } from './components/UsageTab';
+import { EventsTab } from './components/EventsTab';
+import { ConditionsTab } from './components/ConditionsTab';
+import { MetadataTab } from './components/MetadataTab';
+
+// Acquire VS Code API and expose on window for shared use
+const vscode: VSCodeAPI | undefined = typeof acquireVsCodeApi !== 'undefined' ? acquireVsCodeApi() : undefined;
+if (vscode && typeof window !== 'undefined') {
+    (window as any).vscodeApi = vscode;
+}
+
+/**
+ * Tab type for PVC Describe webview.
+ */
+type PVCDescribeTab = 'overview' | 'volumeDetails' | 'usage' | 'conditions' | 'events' | 'metadata';
+
+/**
+ * Root component for PVC Describe webview.
+ * Manages all UI state, message handling, and renders child components.
+ */
+export const PVCDescribeApp: React.FC = () => {
+    const [pvcData, setPvcData] = useState<PVCDescribeData | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [activeTab, setActiveTab] = useState<PVCDescribeTab>('overview');
+
+    // Derive loading state from pvcData and error
+    const loading = pvcData === null && error === null;
+
+    // Send message to extension
+    const sendMessage = useCallback((message: WebviewToExtensionMessage) => {
+        if (vscode) {
+            vscode.postMessage(message);
+        }
+    }, []);
+
+    // Handle messages from extension
+    useEffect(() => {
+        if (!vscode) {
+            return;
+        }
+
+        const handleMessage = (event: MessageEvent) => {
+            const message = event.data as ExtensionToWebviewMessage;
+            console.log('[PVCDescribeApp] Received message:', message.command);
+
+            switch (message.command) {
+                case 'updatePVCData':
+                    setPvcData(message.data as PVCDescribeData);
+                    setError(null);
+                    break;
+
+                case 'showError':
+                    setError((message.data as { message: string }).message);
+                    setPvcData(null);
+                    break;
+
+                default:
+                    console.log('Unknown message command:', (message as any).command);
+            }
+        };
+
+        window.addEventListener('message', handleMessage);
+
+        // Notify extension that webview is ready
+        console.log('[PVCDescribeApp] Sending ready message');
+        sendMessage({ command: 'ready' });
+
+        return () => {
+            console.log('[PVCDescribeApp] Cleaning up message listener');
+            window.removeEventListener('message', handleMessage);
+        };
+    }, [sendMessage]);
+
+    // Handle refresh button click
+    const handleRefresh = useCallback(() => {
+        sendMessage({ command: 'refresh' });
+    }, [sendMessage]);
+
+    // Handle view YAML button click
+    const handleViewYaml = useCallback(() => {
+        sendMessage({ command: 'viewYaml' });
+    }, [sendMessage]);
+
+    // Handle tab change
+    const handleTabChange = useCallback((tab: PVCDescribeTab) => {
+        setActiveTab(tab);
+    }, []);
+
+    // Render loading state
+    if (loading) {
+        return (
+            <div className="pod-describe-container">
+                <div className="loading-state">
+                    <div className="loading-spinner"></div>
+                    <div className="loading-message">Loading PVC details...</div>
+                </div>
+            </div>
+        );
+    }
+
+    // Render error state
+    if (error) {
+        return (
+            <div className="pod-describe-container">
+                <div className="error-state">
+                    <div className="error-icon">⚠️</div>
+                    <div className="error-message">{error}</div>
+                </div>
+            </div>
+        );
+    }
+
+    // Render main UI
+    if (!pvcData) {
+        return null;
+    }
+
+    // Get status banner class and content
+    const getStatusBannerClass = (health: string): string => {
+        const healthLower = health.toLowerCase();
+        return `status-banner status-${healthLower}`;
+    };
+
+    const getStatusIcon = (health: string): string => {
+        const healthLower = health.toLowerCase();
+        if (healthLower === 'healthy') return '✓';
+        if (healthLower === 'degraded') return '⚠';
+        if (healthLower === 'unhealthy') return '⚠';
+        return '?';
+    };
+
+    const getStatusText = (health: string): string => {
+        const healthLower = health.toLowerCase();
+        if (healthLower === 'healthy') return 'PVC is Healthy';
+        if (healthLower === 'degraded') return 'PVC is Degraded';
+        if (healthLower === 'unhealthy') return 'PVC is Unhealthy';
+        return 'PVC status is Unknown';
+    };
+
+    const healthStatus = pvcData.overview.status.health || 'Unknown';
+
+    const headerActions: WebviewHeaderAction[] = [
+        {
+            label: 'Refresh',
+            icon: 'codicon-refresh',
+            onClick: handleRefresh
+        },
+        {
+            label: 'View YAML',
+            icon: 'codicon-file-code',
+            onClick: handleViewYaml
+        }
+    ];
+
+    return (
+        <div className="pod-describe-container">
+            <div className="container">
+                {/* Header */}
+                <WebviewHeader
+                    title={`PersistentVolumeClaim / ${pvcData.overview.name}`}
+                    actions={headerActions}
+                    helpContext="describe-webview"
+                />
+
+                {/* Status Banner */}
+                <div className={getStatusBannerClass(healthStatus)}>
+                    <span className="status-icon">{getStatusIcon(healthStatus)}</span>
+                    <span className="status-text">{getStatusText(healthStatus)}</span>
+                </div>
+
+                {/* Tab Navigation */}
+                <nav className="tab-navigation">
+                    <button
+                        className={`tab-btn ${activeTab === 'overview' ? 'active' : ''}`}
+                        onClick={() => handleTabChange('overview')}
+                    >
+                        Overview
+                    </button>
+                    <button
+                        className={`tab-btn ${activeTab === 'volumeDetails' ? 'active' : ''}`}
+                        onClick={() => handleTabChange('volumeDetails')}
+                    >
+                        Volume Details
+                    </button>
+                    <button
+                        className={`tab-btn ${activeTab === 'usage' ? 'active' : ''}`}
+                        onClick={() => handleTabChange('usage')}
+                    >
+                        Usage ({pvcData.usage.totalPods} Pod{pvcData.usage.totalPods !== 1 ? 's' : ''})
+                    </button>
+                    <button
+                        className={`tab-btn ${activeTab === 'conditions' ? 'active' : ''}`}
+                        onClick={() => handleTabChange('conditions')}
+                    >
+                        Conditions
+                    </button>
+                    <button
+                        className={`tab-btn ${activeTab === 'events' ? 'active' : ''}`}
+                        onClick={() => handleTabChange('events')}
+                    >
+                        Events ({pvcData.events.length})
+                    </button>
+                    <button
+                        className={`tab-btn ${activeTab === 'metadata' ? 'active' : ''}`}
+                        onClick={() => handleTabChange('metadata')}
+                    >
+                        Metadata
+                    </button>
+                </nav>
+
+                {/* Tab Content */}
+                <main className="tab-content">
+                    {activeTab === 'overview' && (
+                        <OverviewTab data={pvcData.overview} />
+                    )}
+                    {activeTab === 'volumeDetails' && (
+                        <VolumeDetailsTab data={pvcData.volumeDetails} />
+                    )}
+                    {activeTab === 'usage' && (
+                        <UsageTab data={pvcData.usage} namespace={pvcData.overview.namespace} />
+                    )}
+                    {activeTab === 'conditions' && (
+                        <ConditionsTab conditions={pvcData.conditions} />
+                    )}
+                    {activeTab === 'events' && <EventsTab events={pvcData.events} />}
+                    {activeTab === 'metadata' && <MetadataTab metadata={pvcData.metadata} />}
+                </main>
+            </div>
+        </div>
+    );
+};

--- a/src/webview/pvc-describe/components/ConditionsTab.tsx
+++ b/src/webview/pvc-describe/components/ConditionsTab.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { PVCCondition } from '../../../providers/PVCDescribeProvider';
+import { formatRelativeTime } from '../../pod-describe/utils/dateUtils';
+
+/**
+ * Props for ConditionsTab component.
+ */
+interface ConditionsTabProps {
+    /** Array of PVC conditions to display */
+    conditions: PVCCondition[];
+}
+
+/**
+ * Conditions tab component that displays PVC conditions in a table format.
+ * Shows condition type, status with color indicators, last transition time,
+ * reason, and message. Conditions are sorted by last transition time (most recent first).
+ */
+export const ConditionsTab: React.FC<ConditionsTabProps> = ({ conditions }) => {
+    // Sort conditions by last transition time (most recent first)
+    const sortedConditions = [...conditions].sort((a, b) => {
+        const timeA = new Date(a.lastTransitionTime).getTime();
+        const timeB = new Date(b.lastTransitionTime).getTime();
+        return timeB - timeA;
+    });
+
+    // Handle empty conditions array
+    if (sortedConditions.length === 0) {
+        return (
+            <div className="conditions-tab">
+                <p style={{ color: 'var(--vscode-descriptionForeground)', fontSize: '13px' }}>
+                    No conditions found for this PVC.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="conditions-tab">
+            <table className="conditions-table">
+                <thead>
+                    <tr>
+                        <th>Type</th>
+                        <th>Status</th>
+                        <th>Last Transition</th>
+                        <th>Reason</th>
+                        <th>Message</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {sortedConditions.map((condition, index) => (
+                        <tr
+                            key={`${condition.type}-${index}`}
+                            className={condition.status === 'False' ? 'condition-failed' : ''}
+                        >
+                            <td>{condition.type}</td>
+                            <td>
+                                <span className={`status-indicator status-${condition.status.toLowerCase()}`}>
+                                    {condition.status}
+                                </span>
+                            </td>
+                            <td>{formatRelativeTime(condition.lastTransitionTime)}</td>
+                            <td>{condition.reason || '-'}</td>
+                            <td>{condition.message || '-'}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};

--- a/src/webview/pvc-describe/components/EventsTab.tsx
+++ b/src/webview/pvc-describe/components/EventsTab.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import type { PVCEvent } from '../../../providers/PVCDescribeProvider';
+
+/**
+ * Props for EventsTab component.
+ */
+interface EventsTabProps {
+    /** Array of PVC events to display */
+    events: PVCEvent[];
+}
+
+/**
+ * Formats an ISO 8601 timestamp into a human-readable relative time string.
+ * For recent times, shows relative time (e.g., "5m ago", "2h ago").
+ * For older times, shows formatted date string.
+ * 
+ * @param timestamp ISO 8601 timestamp string
+ * @returns Human-readable timestamp string
+ */
+function formatRelativeTime(timestamp: string): string {
+    if (!timestamp || timestamp === 'Unknown') {
+        return 'Unknown';
+    }
+
+    try {
+        const date = new Date(timestamp);
+        const now = new Date();
+        const diffMs = now.getTime() - date.getTime();
+        const diffSeconds = Math.floor(diffMs / 1000);
+        const diffMinutes = Math.floor(diffMs / 60000);
+        const diffHours = Math.floor(diffMs / 3600000);
+        const diffDays = Math.floor(diffMs / 86400000);
+
+        // Show relative time for recent updates
+        if (diffSeconds < 60) {
+            return 'Just now';
+        } else if (diffMinutes < 60) {
+            return `${diffMinutes}m ago`;
+        } else if (diffHours < 24) {
+            return `${diffHours}h ago`;
+        } else if (diffDays < 7) {
+            return `${diffDays}d ago`;
+        }
+
+        // For older times, show formatted date
+        return date.toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit'
+        });
+    } catch (error) {
+        // Fall back to original timestamp if parsing fails
+        return timestamp;
+    }
+}
+
+/**
+ * Events tab component that displays PVC events in a timeline format.
+ * Shows events sorted by most recent first, with visual distinction
+ * between Normal and Warning events.
+ */
+export const EventsTab: React.FC<EventsTabProps> = ({ events }) => {
+    // Handle empty state
+    if (events.length === 0) {
+        return (
+            <div className="empty-state">
+                <p>No events found for this PVC</p>
+                <p className="hint">Events are retained for ~1 hour by Kubernetes</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="events-tab">
+            <div className="events-timeline">
+                {events.map((event, index) => (
+                    <div
+                        key={index}
+                        className={`event-item event-${event.type.toLowerCase()}`}
+                    >
+                        <div className="event-icon">
+                            {event.type === 'Warning' ? '⚠️' : 'ℹ️'}
+                        </div>
+                        <div className="event-content">
+                            <div className="event-header">
+                                <span className="event-reason">{event.reason}</span>
+                                {event.count > 1 && (
+                                    <span className="event-count">×{event.count}</span>
+                                )}
+                                <span className="event-age">{event.age}</span>
+                            </div>
+                            <div className="event-message">{event.message}</div>
+                            <div className="event-meta">
+                                Source: {event.source} | First: {formatRelativeTime(event.firstTimestamp)} | Last: {formatRelativeTime(event.lastTimestamp)}
+                            </div>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/src/webview/pvc-describe/components/MetadataTab.tsx
+++ b/src/webview/pvc-describe/components/MetadataTab.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { PVCMetadata } from '../../../providers/PVCDescribeProvider';
+
+/**
+ * Props for MetadataTab component.
+ */
+interface MetadataTabProps {
+    /** PVC metadata to display */
+    metadata: PVCMetadata;
+}
+
+/**
+ * Metadata tab component that displays PVC labels, annotations, and other metadata.
+ */
+export const MetadataTab: React.FC<MetadataTabProps> = ({ metadata }) => {
+    const hasLabels = Object.keys(metadata.labels || {}).length > 0;
+    const hasAnnotations = Object.keys(metadata.annotations || {}).length > 0;
+
+    return (
+        <div className="metadata-tab">
+            {/* Basic Metadata */}
+            <div className="section">
+                <h2>Basic Information</h2>
+                <div className="info-grid">
+                    <div className="info-item">
+                        <div className="info-label">UID</div>
+                        <div className="info-value">{metadata.uid}</div>
+                    </div>
+                    <div className="info-item">
+                        <div className="info-label">Resource Version</div>
+                        <div className="info-value">{metadata.resourceVersion}</div>
+                    </div>
+                    <div className="info-item">
+                        <div className="info-label">Creation Timestamp</div>
+                        <div className="info-value">{metadata.creationTimestamp}</div>
+                    </div>
+                </div>
+            </div>
+
+            {/* Labels */}
+            <div className="section">
+                <h2>Labels</h2>
+                {hasLabels ? (
+                    <div className="key-value-list">
+                        {Object.entries(metadata.labels).map(([key, value]) => (
+                            <div key={key} className="key-value-item">
+                                <span className="key">{key}</span>
+                                <span className="value">{value}</span>
+                            </div>
+                        ))}
+                    </div>
+                ) : (
+                    <p className="empty-message">No labels</p>
+                )}
+            </div>
+
+            {/* Annotations */}
+            <div className="section">
+                <h2>Annotations</h2>
+                {hasAnnotations ? (
+                    <div className="key-value-list">
+                        {Object.entries(metadata.annotations).map(([key, value]) => (
+                            <div key={key} className="key-value-item">
+                                <span className="key">{key}</span>
+                                <span className="value">{value}</span>
+                            </div>
+                        ))}
+                    </div>
+                ) : (
+                    <p className="empty-message">No annotations</p>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/src/webview/pvc-describe/components/OverviewTab.tsx
+++ b/src/webview/pvc-describe/components/OverviewTab.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { PVCOverview } from '../../../providers/PVCDescribeProvider';
+import { formatDate } from '../../pod-describe/utils/dateUtils';
+
+/**
+ * Props for OverviewTab component.
+ */
+interface OverviewTabProps {
+    /** PVC overview data to display */
+    data: PVCOverview;
+}
+
+/**
+ * Helper function to format a value, showing "N/A" or "Unknown" for empty/null values.
+ */
+function formatValue(value: string | undefined | null, fallback: string = 'N/A'): string {
+    if (!value || value.trim() === '') {
+        return fallback;
+    }
+    return value;
+}
+
+/**
+ * Overview tab component that displays PVC status, capacity, access modes, and storage class information.
+ * Uses an info-grid layout to organize information in a readable format.
+ */
+export const OverviewTab: React.FC<OverviewTabProps> = ({ data }) => {
+    // Get status badge class based on health status
+    const getStatusBadgeClass = (health: string): string => {
+        const healthLower = health.toLowerCase();
+        return `status-badge ${healthLower}`;
+    };
+
+    // Format phase for display
+    const phaseDisplay = formatValue(data.phase, 'Unknown');
+    const healthDisplay = formatValue(data.status.health, 'Unknown');
+
+    return (
+        <div className="overview-tab">
+            <div className="section">
+                <h2>Overview</h2>
+                <div className="info-grid">
+                    {/* Status and Phase */}
+                    <div className="info-item">
+                        <div className="info-label">Status</div>
+                        <div className="info-value">{phaseDisplay}</div>
+                    </div>
+
+                    {/* Health Status */}
+                    <div className="info-item">
+                        <div className="info-label">Health</div>
+                        <div className="info-value">
+                            <span className={getStatusBadgeClass(healthDisplay)}>
+                                {healthDisplay}
+                            </span>
+                        </div>
+                    </div>
+
+                    {/* Namespace */}
+                    <div className="info-item">
+                        <div className="info-label">Namespace</div>
+                        <div className="info-value">{formatValue(data.namespace)}</div>
+                    </div>
+
+                    {/* Requested Capacity */}
+                    <div className="info-item">
+                        <div className="info-label">Requested Capacity</div>
+                        <div className="info-value">{formatValue(data.requestedCapacity)}</div>
+                    </div>
+
+                    {/* Actual Capacity */}
+                    {data.actualCapacity && (
+                        <div className="info-item">
+                            <div className="info-label">Actual Capacity</div>
+                            <div className="info-value">{formatValue(data.actualCapacity)}</div>
+                        </div>
+                    )}
+
+                    {/* Access Modes */}
+                    <div className="info-item">
+                        <div className="info-label">Access Modes</div>
+                        <div className="info-value">
+                            {data.accessModes.length > 0 ? data.accessModes.join(', ') : 'N/A'}
+                        </div>
+                    </div>
+
+                    {/* Storage Class */}
+                    <div className="info-item">
+                        <div className="info-label">Storage Class</div>
+                        <div className="info-value">{formatValue(data.storageClass)}</div>
+                    </div>
+
+                    {/* Bound PV */}
+                    {data.boundPV && (
+                        <div className="info-item">
+                            <div className="info-label">Bound PV</div>
+                            <div className="info-value">{formatValue(data.boundPV)}</div>
+                        </div>
+                    )}
+
+                    {/* Age */}
+                    <div className="info-item">
+                        <div className="info-label">Age</div>
+                        <div className="info-value">{formatValue(data.age)}</div>
+                    </div>
+
+                    {/* Creation Timestamp */}
+                    <div className="info-item">
+                        <div className="info-label">Created</div>
+                        <div className="info-value">
+                            {data.creationTimestamp ? formatDate(data.creationTimestamp) : 'N/A'}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/webview/pvc-describe/components/UsageTab.tsx
+++ b/src/webview/pvc-describe/components/UsageTab.tsx
@@ -1,0 +1,108 @@
+import React, { useCallback } from 'react';
+import { PVCUsage, PodUsageInfo } from '../../../providers/PVCDescribeProvider';
+import { VSCodeAPI } from '../types';
+
+/**
+ * Props for UsageTab component.
+ */
+interface UsageTabProps {
+    /** Usage data showing Pods using this PVC */
+    data: PVCUsage;
+    /** Namespace of the PVC */
+    namespace: string;
+}
+
+/**
+ * Get VS Code API from window (set by main app component).
+ */
+const getVSCodeAPI = (): VSCodeAPI | undefined => {
+    if (typeof window !== 'undefined' && (window as any).vscodeApi) {
+        return (window as any).vscodeApi;
+    }
+    return undefined;
+};
+
+/**
+ * Usage tab component that displays Pods using this PVC.
+ * Shows Pod name, namespace, phase, mount path, and read-only status.
+ */
+export const UsageTab: React.FC<UsageTabProps> = ({ data, namespace }) => {
+    // Handle navigation to Pod
+    const handleNavigateToPod = useCallback((podName: string, podNamespace: string) => {
+        const vscode = getVSCodeAPI();
+        if (vscode) {
+            vscode.postMessage({
+                command: 'navigateToPod',
+                data: {
+                    name: podName,
+                    namespace: podNamespace
+                }
+            });
+        }
+    }, []);
+
+    // Handle empty state
+    if (data.totalPods === 0) {
+        return (
+            <div className="usage-tab">
+                <div className="empty-state">
+                    <p>No Pods are currently using this PVC</p>
+                    <p className="hint">Pods that mount this PVC will appear here</p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="usage-tab">
+            <div className="section">
+                <h2>Pods Using This PVC</h2>
+                <p className="section-description">
+                    {data.totalPods} Pod{data.totalPods !== 1 ? 's' : ''} {data.totalPods === 1 ? 'is' : 'are'} currently using this PersistentVolumeClaim.
+                </p>
+                <table className="conditions-table">
+                    <thead>
+                        <tr>
+                            <th>Pod Name</th>
+                            <th>Namespace</th>
+                            <th>Phase</th>
+                            <th>Mount Path</th>
+                            <th>Read-Only</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {data.pods.map((pod: PodUsageInfo, index: number) => (
+                            <tr key={`${pod.namespace}/${pod.name}-${index}`}>
+                                <td>{pod.name}</td>
+                                <td>{pod.namespace}</td>
+                                <td>
+                                    <span className={`phase-badge phase-${pod.phase.toLowerCase()}`}>
+                                        {pod.phase}
+                                    </span>
+                                </td>
+                                <td>{pod.mountPath || 'N/A'}</td>
+                                <td>
+                                    {pod.readOnly ? (
+                                        <span className="read-only-badge">Yes</span>
+                                    ) : (
+                                        <span className="read-write-badge">No</span>
+                                    )}
+                                </td>
+                                <td>
+                                    <button
+                                        className="link-button"
+                                        onClick={() => handleNavigateToPod(pod.name, pod.namespace)}
+                                        title={`Navigate to Pod ${pod.name}`}
+                                    >
+                                        View Pod
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+};

--- a/src/webview/pvc-describe/components/VolumeDetailsTab.tsx
+++ b/src/webview/pvc-describe/components/VolumeDetailsTab.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { VolumeDetails } from '../../../providers/PVCDescribeProvider';
+
+/**
+ * Props for VolumeDetailsTab component.
+ */
+interface VolumeDetailsTabProps {
+    /** Volume details data to display */
+    data: VolumeDetails;
+}
+
+/**
+ * Helper function to format a value, showing "N/A" or "Unknown" for empty/null values.
+ */
+function formatValue(value: string | undefined | null, fallback: string = 'N/A'): string {
+    if (!value || value.trim() === '') {
+        return fallback;
+    }
+    return value;
+}
+
+/**
+ * Volume Details tab component that displays PVC volume mode, finalizers, capacity, and access modes.
+ */
+export const VolumeDetailsTab: React.FC<VolumeDetailsTabProps> = ({ data }) => {
+    return (
+        <div className="volume-details-tab">
+            <div className="section">
+                <h2>Volume Details</h2>
+                <div className="info-grid">
+                    {/* Volume Mode */}
+                    <div className="info-item">
+                        <div className="info-label">Volume Mode</div>
+                        <div className="info-value">{formatValue(data.volumeMode)}</div>
+                    </div>
+
+                    {/* Storage Class */}
+                    <div className="info-item">
+                        <div className="info-label">Storage Class</div>
+                        <div className="info-value">{formatValue(data.storageClass)}</div>
+                    </div>
+
+                    {/* Requested Capacity */}
+                    <div className="info-item">
+                        <div className="info-label">Requested Capacity</div>
+                        <div className="info-value">{formatValue(data.requestedCapacity)}</div>
+                    </div>
+
+                    {/* Actual Capacity */}
+                    {data.actualCapacity && (
+                        <div className="info-item">
+                            <div className="info-label">Actual Capacity</div>
+                            <div className="info-value">{formatValue(data.actualCapacity)}</div>
+                        </div>
+                    )}
+
+                    {/* Access Modes */}
+                    <div className="info-item">
+                        <div className="info-label">Access Modes</div>
+                        <div className="info-value">
+                            {data.accessModes.length > 0 ? data.accessModes.join(', ') : 'N/A'}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* Finalizers */}
+            {data.finalizers.length > 0 && (
+                <div className="section">
+                    <h2>Finalizers</h2>
+                    <div className="finalizers-list">
+                        {data.finalizers.map((finalizer, index) => (
+                            <div key={index} className="finalizer-item">
+                                {finalizer}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/webview/pvc-describe/index.tsx
+++ b/src/webview/pvc-describe/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { PVCDescribeApp } from './PVCDescribeApp';
+import '../../../media/describe/podDescribe.css';
+
+// Render React app
+const container = document.getElementById('root');
+if (container) {
+    const root = createRoot(container);
+    root.render(<PVCDescribeApp />);
+} else {
+    console.error('Root element not found');
+}

--- a/src/webview/pvc-describe/types.ts
+++ b/src/webview/pvc-describe/types.ts
@@ -1,0 +1,53 @@
+/**
+ * VS Code Webview API interface.
+ * Matches the API provided by acquireVsCodeApi() in webview contexts.
+ */
+export interface VSCodeAPI {
+    /**
+     * Post a message to the extension host.
+     * @param message The message to send
+     */
+    postMessage(message: WebviewToExtensionMessage): void;
+
+    /**
+     * Get the current state of the webview.
+     * @returns The current state object
+     */
+    getState(): unknown;
+
+    /**
+     * Set the state of the webview.
+     * @param state The state to set
+     */
+    setState(state: unknown): void;
+}
+
+/**
+ * Re-export PVCDescribeData from PVCDescribeProvider for convenience.
+ */
+import type { PVCDescribeData } from '../../providers/PVCDescribeProvider';
+
+/**
+ * Message sent from extension to webview.
+ */
+export interface ExtensionToWebviewMessage {
+    /** Command type */
+    command: 'updatePVCData' | 'showError';
+    /** Message data */
+    data: PVCDescribeData | { message: string };
+}
+
+/**
+ * Message sent from webview to extension.
+ */
+export interface WebviewToExtensionMessage {
+    /** Command type */
+    command: 'refresh' | 'viewYaml' | 'ready' | 'navigateToPod';
+    /** Optional data payload */
+    data?: unknown;
+}
+
+/**
+ * Re-export PVCDescribeData from PVCDescribeProvider for convenience.
+ */
+export type { PVCDescribeData };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "src/webview/event-viewer",
     "src/webview/pod-logs",
     "src/webview/pod-describe",
+    "src/webview/pvc-describe",
     "src/webview/operator-health-report",
     "src/webview/helm-package-manager",
     "src/webview/components"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,10 +28,13 @@ const extensionConfig = {
     rules: [
       {
         test: /\.ts$/,
-        exclude: [/node_modules/, /src\/webview\/argocd-application/, /src\/webview\/event-viewer/, /src\/webview\/pod-logs/, /src\/webview\/pod-describe/, /src\/webview\/operator-health-report/, /src\/webview\/helm-package-manager/],
+        exclude: [/node_modules/, /src\/webview\/argocd-application/, /src\/webview\/event-viewer/, /src\/webview\/pod-logs/, /src\/webview\/pod-describe/, /src\/webview\/pvc-describe/, /src\/webview\/operator-health-report/, /src\/webview\/helm-package-manager/],
         use: [
           {
-            loader: 'ts-loader'
+            loader: 'ts-loader',
+            options: {
+              transpileOnly: true // Skip type checking - done separately via tsc
+            }
           }
         ]
       }
@@ -156,7 +159,46 @@ const namespaceDescribeConfig = {
   }
 };
 
-module.exports = [extensionConfig, webviewConfig, podDescribeConfig, namespaceDescribeConfig];
+/**@type {import('webpack').Configuration}*/
+const pvcDescribeConfig = {
+  target: 'web', // Webview runs in a browser context
+  entry: './src/webview/pvc-describe/index.tsx',
+  output: {
+    path: path.resolve(__dirname, 'dist', 'media', 'pvc-describe'),
+    filename: 'index.js',
+    devtoolModuleFilenameTemplate: '../[resource-path]'
+  },
+  devtool: 'source-map',
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.jsx']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: [
+                ['@babel/preset-env', { targets: 'defaults' }],
+                ['@babel/preset-react', { runtime: 'automatic' }],
+                '@babel/preset-typescript'
+              ]
+            }
+          }
+        ]
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      }
+    ]
+  }
+};
+
+module.exports = [extensionConfig, webviewConfig, podDescribeConfig, namespaceDescribeConfig, pvcDescribeConfig];
 
 
 


### PR DESCRIPTION
## Description

This PR implements a graphical `kubectl describe` functionality for Persistent Volume Claims (PVCs) in the kube9 VS Code extension. When a user left-clicks a PVC in the tree view, a cluster-specific Describe webview opens showing detailed PVC information in a formatted, graphical display.

## Motivation and Context

This change addresses issue #56, which requested the ability to view detailed PVC information in a graphical format similar to the existing Pod and Namespace describe webviews. The implementation follows the same patterns and architecture as the existing describe webviews for consistency.

Fixes #56

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing in Extension Development Host (F5)
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
- [x] Tested with real Kubernetes clusters

## Implementation Details

### Core Components

1. **PVCDescribeProvider** (`src/providers/PVCDescribeProvider.ts`)
   - Fetches PVC, bound PV, and related Pod data from Kubernetes API
   - Formats data into structured display format
   - Handles events fetching with proper error handling

2. **DescribeWebview Integration** (`src/webview/DescribeWebview.ts`)
   - Added `showPVCDescribe` method for routing PVC clicks
   - Integrated PVC data loading and refresh functionality
   - Added navigation support from PVC Usage tab to Pods

3. **React Components** (`src/webview/pvc-describe/`)
   - `PVCDescribeApp.tsx` - Main app component with tab navigation
   - `OverviewTab.tsx` - PVC status, capacity, access modes, storage class
   - `VolumeDetailsTab.tsx` - Volume mode, finalizers, capacity details
   - `UsageTab.tsx` - Pods using the PVC with navigation links
   - `ConditionsTab.tsx` - PVC conditions with status indicators
   - `EventsTab.tsx` - Timeline of PVC-related events
   - `MetadataTab.tsx` - Labels and annotations

4. **Build Configuration**
   - Added webpack entry for PVC describe webview
   - Excluded PVC describe files from TypeScript compilation (handled by webpack/babel)
   - Added `transpileOnly: true` to ts-loader for faster builds

5. **Styling**
   - Extended `podDescribe.css` with PVC-specific styles
   - Added styles for phase badges, read-only badges, link buttons
   - Reused existing table and card styles for consistency

6. **Documentation**
   - Created Forge-compliant feature documentation (`ai/features/webview/pvc-describe-webview.feature.md`)
   - Created technical specification (`ai/specs/webview/pvc-describe-webview-spec.spec.md`)

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
- [x] My changes generate no new warnings (only pre-existing warnings remain)
- [x] I have tested the extension in Extension Development Host
- [x] I have verified the change works with real Kubernetes clusters

## Additional Notes

- The implementation follows the same architecture as Pod and Namespace describe webviews
- All webview files are excluded from TypeScript compilation and handled by webpack/babel
- The webview uses the shared `podDescribe.css` stylesheet for consistency
- Navigation from PVC Usage tab to Pods is supported via the `navigateToPod` command
