### PR TITLE
fix: persist tutorial dismissal preference on checkbox change

### DIFF
--- a/src/webview/TutorialWebview.ts
+++ b/src/webview/TutorialWebview.ts
@@ -115,11 +115,8 @@ export class TutorialWebview {
                             'kube9.tutorialCompleted',
                             true
                         );
-                        // Save dismissal preference if checkbox was checked
-                        if (message.doNotShowAgain) {
-                            const globalState = GlobalState.getInstance();
-                            await globalState.setWelcomeScreenDismissed(true);
-                        }
+                        // Persist dismissal preference as an idempotent write
+                        await GlobalState.getInstance().setWelcomeScreenDismissed(Boolean(message.doNotShowAgain));
                         vscode.window.showInformationMessage(
                             'Tutorial completed! You can replay it anytime from the Command Palette.'
                         );
@@ -129,8 +126,15 @@ export class TutorialWebview {
                     case 'dismiss': {
                         // Handle dismissal with checkbox state
                         const globalState = GlobalState.getInstance();
-                        await globalState.setWelcomeScreenDismissed(message.doNotShowAgain);
+                        await globalState.setWelcomeScreenDismissed(Boolean(message.doNotShowAgain));
                         panel.dispose();
+                        break;
+                    }
+
+                    case 'setDoNotShowAgain': {
+                        // Persist checkbox changes immediately so close flows cannot lose preference
+                        const globalState = GlobalState.getInstance();
+                        await globalState.setWelcomeScreenDismissed(Boolean(message.value));
                         break;
                     }
 
@@ -632,7 +636,10 @@ export class TutorialWebview {
             const checkbox = document.getElementById('doNotShowAgain');
             if (checkbox) {
                 checkbox.addEventListener('change', () => {
-                    // Optionally save immediately on change, or wait for close/complete
+                    vscode.postMessage({
+                        command: 'setDoNotShowAgain',
+                        value: checkbox.checked
+                    });
                 });
             }
         });


### PR DESCRIPTION
## Description

Persist the tutorial dismissal preference immediately when the user toggles the **Don't show this tutorial again** checkbox.

## Motivation and Context

The preference could be lost when the panel was closed without hitting the existing `completeTutorial` / `dismiss` paths, causing the tutorial to reappear across workspaces.

Fixes #125

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## How Has This Been Tested?

- [ ] Manual testing in Extension Development Host (F5)
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Tested with multiple Kubernetes clusters
- [ ] Tested on multiple OS (macOS, Windows, Linux)
- [ ] Tested with different VS Code versions

- `npm run lint`
- `npm run test:unit`

## Checklist

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [ ] I have updated the CHANGELOG.md (if applicable)
- [ ] I have tested the extension in Extension Development Host
- [ ] I have verified the change works with real Kubernetes clusters

## How to Test this Work

1. Start with a profile where the tutorial has not been dismissed.
2. Open the tutorial and check **Don't show this tutorial again**.
3. Close the tutorial panel without pressing completion/dismiss actions.
4. Restart VS Code/Cursor and open another workspace.
5. Verify the tutorial does not auto-open.
6. Re-open the tutorial manually, uncheck/re-check the checkbox, and verify the persisted behavior updates accordingly.

## How to Validate this Work

1. As a user, check **Don't show this tutorial again** once.
2. Relaunch the editor and switch projects.
3. Confirm the tutorial no longer auto-opens until preference is reset.

## Additional Notes

- Added a new webview message command: `setDoNotShowAgain`.
- `completeTutorial` and `dismiss` now perform idempotent boolean writes to global state.