### PR TITLE
docs(telemetry): M1.4 product telemetry QA checklist and forbid-list tests (#135)

### DIFF
--- a/docs/product-telemetry-qa.md
+++ b/docs/product-telemetry-qa.md
@@ -1,0 +1,58 @@
+# Product telemetry QA (M1.4)
+
+Maintainer QA sign-off for **forbid-list verification** and **telemetry-disabled smoke**, per milestone intent. **Authoritative contracts** remain in [.forge/operations/observability.md](../.forge/operations/observability.md) and [.forge/operations/security.md](../.forge/operations/security.md); this document is the **executable checklist** only.
+
+| Reference | Purpose |
+|-----------|---------|
+| [telemetry-event-catalog.md](./telemetry-event-catalog.md) | Shipped event keys and payload fields |
+| [telemetry-lint-guardrails.md](./telemetry-lint-guardrails.md) | ESLint rule scope and limitations |
+| [CONTRIBUTING.md](../CONTRIBUTING.md#product-telemetry-and-event-catalog-prs) | PR and review expectations |
+
+## 1. Never-send themes → verification
+
+Map each **Never send** theme from the observability contract to how we verify it in repo CI or manually.
+
+| Theme (from contract) | Automated / CI | Manual or follow-up |
+|----------------------|----------------|---------------------|
+| Kubeconfig-like paths | `kube9-telemetry-payload-guard` blocks interpolated templates in `src/telemetry/**/*.ts` (see [telemetry-lint-guardrails.md](./telemetry-lint-guardrails.md)). Unit tests in `src/test/suite/telemetry/payloadForbidListVerification.test.ts` scan serialized allowlisted payloads for path/manifest heuristics. | On a throwaway branch, add a template literal with a fake home path into a telemetry call under `src/telemetry/`; confirm `npm run lint` fails; discard branch. |
+| Cluster / context / namespace / resource identifiers | Façade types (`ProductTelemetryProperties`) are closed keys; no cluster fields in catalog rows. Same lint + payload scan tests. | With instrumentation enabled, exercise catalog commands/webviews; confirm mock sink / debug output has no context name, namespace, workload name, or UID values in payload values. |
+| Manifest / YAML / spec content | Payload scan tests reject `apiVersion`-style manifest markers and multiline blob values in JSON payloads. | Spot-check outbound or mock events during YAML-heavy workflows; values must remain enumerations only. |
+| Cluster log lines / API bodies | No API on façade for log lines or response bodies; lint blocks raw `Error` objects as call arguments in `src/telemetry/`. | N/A beyond code review + negative lint experiment. |
+| Forbidden free-form strings where enumeration is required | `telemetryPropertiesToPayload` only emits enumerated keys; `errorBucket` is `ErrorType`; `webviewSurface` is a closed union; `commandKey` is allowlisted from `package.json`. Tests cover golden combinations. | Review any new catalog row before merge. |
+
+## 2. Guardrail proof (#138)
+
+1. **CI:** `npm run lint` must pass on `main` (rule `kube9-telemetry-payload-guard` on `src/telemetry/**/*.ts`).
+2. **Regression test:** `src/test/suite/telemetry/eslintTelemetryGuardProof.test.ts` runs ESLint on synthetic snippets and expects violations for representative forbidden patterns.
+3. **Optional maintainer spot-check:** Introduce a deliberate violation on a throwaway branch (template interpolation or `error` identifier in a telemetry call); confirm ESLint reports `kube9-telemetry-payload-guard`.
+
+## 3. Payload inspection (#134 / #137)
+
+- **Structured evidence:** `npm run test:unit` includes `payloadForbidListVerification.test.ts`, which serializes golden `ProductTelemetryProperties` objects (all shipped `commandKey` values from `package.json`, all `ErrorType` buckets, all webview surfaces) and asserts the JSON matches forbid-list heuristics.
+- **Manual:** When using a real or mock sink, compare captured events to [telemetry-event-catalog.md](./telemetry-event-catalog.md); each property value must match the allowed shape for that row.
+
+## 4. Telemetry disabled (smoke)
+
+Baseline (extension must remain usable):
+
+1. Disable VS Code telemetry (`telemetry.telemetryLevel` → **off** or equivalent for your build). Optionally disable any extension-specific telemetry toggles if present.
+2. Ensure `telemetryInstrumentationConnectionString` is unset or empty in packaged `package.json` for local dev if you are not testing real egress.
+3. Smoke core flows aligned with catalog coverage, for example: activate extension, refresh cluster tree, open one shipped webview from the catalog, run one allowlisted command.
+4. **Pass:** No crashes or missing commands attributable to telemetry being off; no telemetry constructor side effects when disabled (see `registerExtensionProductTelemetry` in `src/telemetry/vscodeExtensionTelemetry.ts`).
+
+## 5. CI parity
+
+Sign-off revision MUST pass the same checks as [.github/workflows/ci.yml](../.github/workflows/ci.yml):
+
+```bash
+npm ci
+npm run lint
+npm run build
+npm run test:unit
+```
+
+Node **≥ 22**. Use `NODE_OPTIONS=--experimental-require-module` when running mocha manually if your environment mirrors CI.
+
+## 6. Maintainer sign-off (issue closure)
+
+Post a short comment on [#135](https://github.com/alto9/kube9-vscode/issues/135) with: date, git revision (or PR), who ran QA, checklist sections completed, and any accepted gaps or follow-up issues.

--- a/docs/telemetry-event-catalog.md
+++ b/docs/telemetry-event-catalog.md
@@ -4,6 +4,7 @@
 
 - **Governance contracts:** [.forge/operations/observability.md](../.forge/operations/observability.md), [.forge/operations/security.md](../.forge/operations/security.md)
 - **Lint / forbid-list guardrails:** [telemetry-lint-guardrails.md](./telemetry-lint-guardrails.md) (runs via `npm run lint`)
+- **M1.4 QA checklist:** [product-telemetry-qa.md](./product-telemetry-qa.md) (forbid-list verification + telemetry-off smoke)
 - **Implementation:** [`src/telemetry/productTelemetry.ts`](../src/telemetry/productTelemetry.ts) (event names + bounded payload types), [`src/telemetry/vscodeExtensionTelemetry.ts`](../src/telemetry/vscodeExtensionTelemetry.ts) (transport when `telemetryInstrumentationConnectionString` is set and consent is on)
 
 ## Version

--- a/src/test/suite/telemetry/eslintTelemetryGuardProof.test.ts
+++ b/src/test/suite/telemetry/eslintTelemetryGuardProof.test.ts
@@ -1,0 +1,75 @@
+import * as assert from 'assert';
+import { ESLint } from 'eslint';
+import * as path from 'path';
+import { resolveRepoRootFromTestFile } from './repoRoot';
+
+suite('telemetry ESLint guardrail proof (#135, #138)', () => {
+    test('kube9-telemetry-payload-guard flags template interpolation, error arg, and new Error()', async function () {
+        this.timeout(30_000);
+        const root = resolveRepoRootFromTestFile(__dirname);
+        const eslint = new ESLint({
+            cwd: root,
+            // rulePaths maps to --rulesdir; supported at runtime, omitted from some ESLint @types revisions
+            ...( { rulePaths: [path.join(root, 'eslint-rules')] } as { rulePaths: string[] } ),
+        });
+        const telemetryFixturePath = path.join(root, 'src', 'telemetry', '_fixture_guard.ts');
+
+        const cases: Array<{ name: string; code: string; expectViolation: boolean }> = [
+            {
+                name: 'template literal interpolation in call argument',
+                code: `declare const sink: { send: (s: string) => void };
+function bad(arg: string): void {
+  sink.send(\`evt_\${arg}\`);
+}
+`,
+                expectViolation: true,
+            },
+            {
+                name: 'passing identifier named error',
+                code: `declare const sink: { send: (e: unknown) => void };
+function bad(error: Error): void {
+  sink.send(error);
+}
+`,
+                expectViolation: true,
+            },
+            {
+                name: 'new Error() as argument',
+                code: `declare const sink: { send: (e: unknown) => void };
+function bad(): void {
+  sink.send(new Error('x'));
+}
+`,
+                expectViolation: true,
+            },
+            {
+                name: 'clean static literal',
+                code: `declare const sink: { send: (s: string) => void };
+function ok(): void {
+  sink.send('kube9.product.safe');
+}
+`,
+                expectViolation: false,
+            },
+        ];
+
+        for (const c of cases) {
+            const [result] = await eslint.lintText(c.code, { filePath: telemetryFixturePath });
+            const guardMessages = result.messages.filter((m) => m.ruleId === 'kube9-telemetry-payload-guard');
+            if (c.expectViolation) {
+                assert.ok(
+                    guardMessages.length > 0,
+                    `${c.name}: expected kube9-telemetry-payload-guard violation; messages=${JSON.stringify(
+                        result.messages
+                    )}`
+                );
+            } else {
+                assert.deepStrictEqual(
+                    guardMessages,
+                    [],
+                    `${c.name}: expected no guard violations; got ${JSON.stringify(guardMessages)}`
+                );
+            }
+        }
+    });
+});

--- a/src/test/suite/telemetry/forbidListPayloadPatterns.ts
+++ b/src/test/suite/telemetry/forbidListPayloadPatterns.ts
@@ -1,0 +1,66 @@
+/**
+ * Heuristic checks that serialized telemetry JSON does not echo observability.md
+ * "Never send" categories (paths, manifest snippets, multiline blobs).
+ * Used by payloadForbidListVerification.test.ts — not production code.
+ */
+
+export interface ForbidListRule {
+    readonly id: string;
+    readonly test: (json: string, parsed: Record<string, unknown>) => string | null;
+}
+
+function anyValueTooLongOrMultiline(parsed: Record<string, unknown>, maxLen: number): string | null {
+    for (const [k, v] of Object.entries(parsed)) {
+        if (typeof v !== 'string') {
+            return `non-string value for ${k}`;
+        }
+        if (v.includes('\n') || v.includes('\r')) {
+            return `multiline value for ${k}`;
+        }
+        if (v.length > maxLen) {
+            return `value for ${k} exceeds ${maxLen} characters`;
+        }
+    }
+    return null;
+}
+
+/** Rules applied to JSON.stringify output of allowlisted telemetry payloads. */
+export const FORBID_LIST_PAYLOAD_RULES: ForbidListRule[] = [
+    {
+        id: 'kubeconfig_path_marker',
+        test: (json) => (/\.kube(\/|\\|'|"|$|\s)/i.test(json) ? 'matches .kube path marker' : null),
+    },
+    {
+        id: 'unix_home_path',
+        test: (json) => (/[/\\](Users|home)[/\\]/i.test(json) ? 'matches Unix/macOS home path segment' : null),
+    },
+    {
+        id: 'windows_drive_path',
+        test: (json) => (/[A-Za-z]:\\/.test(json) ? 'matches Windows drive path' : null),
+    },
+    {
+        id: 'k8s_manifest_apiversion',
+        test: (json) => (/apiVersion\s*:/i.test(json) ? 'matches Kubernetes manifest apiVersion marker' : null),
+    },
+    {
+        id: 'bounded_scalar_strings',
+        test: (_json, parsed) => anyValueTooLongOrMultiline(parsed, 256),
+    },
+];
+
+export function violationsForTelemetryPayloadJson(json: string): string[] {
+    let parsed: Record<string, unknown>;
+    try {
+        parsed = JSON.parse(json) as Record<string, unknown>;
+    } catch {
+        return ['invalid JSON'];
+    }
+    const out: string[] = [];
+    for (const rule of FORBID_LIST_PAYLOAD_RULES) {
+        const hit = rule.test(json, parsed);
+        if (hit !== null) {
+            out.push(`${rule.id}: ${hit}`);
+        }
+    }
+    return out;
+}

--- a/src/test/suite/telemetry/payloadForbidListVerification.test.ts
+++ b/src/test/suite/telemetry/payloadForbidListVerification.test.ts
@@ -1,0 +1,95 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ErrorType } from '../../../errors/types';
+import { buildKube9TelemetryCommandAllowlistFromPackageJson } from '../../../telemetry/commandAllowlist';
+import {
+    ProductTelemetryEventName,
+    SHIPPED_WEBVIEW_TELEMETRY_SURFACES_CONST,
+} from '../../../telemetry/productTelemetry';
+import { telemetryPropertiesToPayload } from '../../../telemetry/vscodeExtensionTelemetry';
+import { violationsForTelemetryPayloadJson } from './forbidListPayloadPatterns';
+import { resolveRepoRootFromTestFile } from './repoRoot';
+
+suite('telemetry payload forbid-list verification (#135)', () => {
+    test('golden catalog payloads serialize with no heuristic violations', () => {
+        const root = resolveRepoRootFromTestFile(__dirname);
+        const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')) as Record<
+            string,
+            unknown
+        >;
+        const commandKeys = [...buildKube9TelemetryCommandAllowlistFromPackageJson(pkg)];
+
+        const bodies: Array<{ label: string; payload: Record<string, string> }> = [];
+
+        for (const commandKey of commandKeys) {
+            bodies.push({
+                label: `command success ${commandKey}`,
+                payload: telemetryPropertiesToPayload({
+                    outcome: 'success',
+                    commandKey,
+                }),
+            });
+            for (const errorBucket of Object.values(ErrorType)) {
+                bodies.push({
+                    label: `command failure ${commandKey} / ${errorBucket}`,
+                    payload: telemetryPropertiesToPayload({
+                        outcome: 'failure',
+                        errorBucket,
+                        commandKey,
+                    }),
+                });
+            }
+            bodies.push({
+                label: `feature usage ${commandKey}`,
+                payload: telemetryPropertiesToPayload({ commandKey }),
+            });
+        }
+
+        for (const surf of SHIPPED_WEBVIEW_TELEMETRY_SURFACES_CONST) {
+            bodies.push({
+                label: `webview ${surf}`,
+                payload: telemetryPropertiesToPayload({ webviewSurface: surf }),
+            });
+        }
+
+        for (const outcome of ['success', 'failure'] as const) {
+            if (outcome === 'success') {
+                bodies.push({
+                    label: 'extension activated success',
+                    payload: telemetryPropertiesToPayload({ outcome }),
+                });
+            } else {
+                for (const errorBucket of Object.values(ErrorType)) {
+                    bodies.push({
+                        label: `extension activated failure / ${errorBucket}`,
+                        payload: telemetryPropertiesToPayload({ outcome, errorBucket }),
+                    });
+                }
+            }
+        }
+
+        for (const { label, payload } of bodies) {
+            const json = JSON.stringify(payload);
+            const bad = violationsForTelemetryPayloadJson(json);
+            assert.deepStrictEqual(
+                bad,
+                [],
+                `${label}: expected no forbid-list heuristic violations; json=${json}; got: ${bad.join('; ')}`
+            );
+        }
+    });
+
+    test('event name strings are stable catalog keys (no accidental cluster-ish tokens)', () => {
+        for (const ev of Object.values(ProductTelemetryEventName)) {
+            const eventKey = String(ev);
+            assert.match(eventKey, /^kube9\.product(\.[a-z0-9_]+)+$/, `event key shape: ${ev}`);
+            const bad = violationsForTelemetryPayloadJson(JSON.stringify({ eventKey }));
+            assert.deepStrictEqual(
+                bad,
+                [],
+                `event key should not trip forbid-list heuristics: ${ev}`
+            );
+        }
+    });
+});

--- a/src/test/suite/telemetry/repoRoot.ts
+++ b/src/test/suite/telemetry/repoRoot.ts
@@ -1,0 +1,21 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Resolve repository root from a test file living under out/src/test/...
+ */
+export function resolveRepoRootFromTestFile(startDir: string): string {
+    let dir = startDir;
+    for (;;) {
+        const pkg = path.join(dir, 'package.json');
+        const rules = path.join(dir, 'eslint-rules');
+        if (fs.existsSync(pkg) && fs.existsSync(rules)) {
+            return dir;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            throw new Error('Could not resolve repository root from test file');
+        }
+        dir = parent;
+    }
+}


### PR DESCRIPTION
## Description

Adds [docs/product-telemetry-qa.md](docs/product-telemetry-qa.md): executable checklist mapping observability **Never send** themes to CI, guard lint, golden payload tests, and manual/mock-sink steps. Links the doc from [docs/telemetry-event-catalog.md](docs/telemetry-event-catalog.md).

Adds unit coverage:
- `payloadForbidListVerification.test.ts` — serializes all golden `telemetryPropertiesToPayload` shapes (package-derived command keys, `ErrorType`, webview surfaces) and applies heuristic forbid-list scans.
- `eslintTelemetryGuardProof.test.ts` — ESLint `kube9-telemetry-payload-guard` reports on representative synthetic violations.

## Motivation and Context

Implements repository-side artifacts for **M1.4 Product telemetry QA** ([#135](https://github.com/alto9/kube9-vscode/issues/135)): AC1–5 tooling and documentation. **AC6** (maintainer closure comment on the issue) remains for humans after review.

## Type of Change

- [x] Documentation update
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated

`npm run lint`, `npm run build`, `npm run test:unit` (1032 passing, full run outside sandbox).

## Checklist

- [x] Telemetry: QA doc cross-links catalog and lint guardrails; no new catalog events
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm run test:unit`)
- [x] I have run the linter (`npm run lint`)
