### PR TITLE
feat(describe): structured CRD describe webview

### DIFF
--- a/src/kubernetes/apiClient.ts
+++ b/src/kubernetes/apiClient.ts
@@ -44,6 +44,7 @@ export class KubernetesApiClient {
     private storageApi: k8s.StorageV1Api;
     private authorizationApi: k8s.AuthorizationV1Api;
     private apiextensionsApi: k8s.ApiextensionsV1Api;
+    private customObjectsApi: k8s.CustomObjectsApi;
     private versionApi: k8s.VersionApi;
     private rbacApi: k8s.RbacAuthorizationV1Api;
 
@@ -64,6 +65,7 @@ export class KubernetesApiClient {
         this.storageApi = this.kubeConfig.makeApiClient(k8s.StorageV1Api);
         this.authorizationApi = this.kubeConfig.makeApiClient(k8s.AuthorizationV1Api);
         this.apiextensionsApi = this.kubeConfig.makeApiClient(k8s.ApiextensionsV1Api);
+        this.customObjectsApi = this.kubeConfig.makeApiClient(k8s.CustomObjectsApi);
         this.versionApi = this.kubeConfig.makeApiClient(k8s.VersionApi);
         this.rbacApi = this.kubeConfig.makeApiClient(k8s.RbacAuthorizationV1Api);
     }
@@ -84,6 +86,7 @@ export class KubernetesApiClient {
         this.storageApi = this.kubeConfig.makeApiClient(k8s.StorageV1Api);
         this.authorizationApi = this.kubeConfig.makeApiClient(k8s.AuthorizationV1Api);
         this.apiextensionsApi = this.kubeConfig.makeApiClient(k8s.ApiextensionsV1Api);
+        this.customObjectsApi = this.kubeConfig.makeApiClient(k8s.CustomObjectsApi);
         this.versionApi = this.kubeConfig.makeApiClient(k8s.VersionApi);
         this.rbacApi = this.kubeConfig.makeApiClient(k8s.RbacAuthorizationV1Api);
     }
@@ -174,6 +177,13 @@ export class KubernetesApiClient {
      */
     public get apiextensions(): k8s.ApiextensionsV1Api {
         return this.apiextensionsApi;
+    }
+
+    /**
+     * Gets the CustomObjects API client for arbitrary custom resources.
+     */
+    public get customObjects(): k8s.CustomObjectsApi {
+        return this.customObjectsApi;
     }
 
     /**

--- a/src/providers/CRDDescribeProvider.ts
+++ b/src/providers/CRDDescribeProvider.ts
@@ -1,0 +1,269 @@
+/**
+ * CRD Describe Provider — types and implementation for CustomResourceDefinition detail views.
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import * as yaml from 'js-yaml';
+import { KubernetesApiClient } from '../kubernetes/apiClient';
+import { KubectlError } from '../kubernetes/KubectlError';
+
+const INSTANCE_LIST_LIMIT = 200;
+
+/** One row in the CRD version table. */
+export interface CRDVersionRow {
+    name: string;
+    served: boolean;
+    storage: boolean;
+    deprecated: boolean;
+}
+
+/** OpenAPI structural schema text for a served version. */
+export interface CRDSchemaSection {
+    versionName: string;
+    schemaText: string;
+}
+
+/** Condition from CRD `.status.conditions`. */
+export interface CRDConditionRow {
+    type: string;
+    status: string;
+    reason?: string;
+    message?: string;
+}
+
+/** One custom resource instance (summary). */
+export interface CRDInstanceRow {
+    name: string;
+    namespace?: string;
+}
+
+/** Listing custom resource instances (exists / placement). */
+export interface CRDInstancesSummary {
+    scope: 'Namespaced' | 'Cluster' | 'Unknown';
+    totalReturned: number;
+    truncated: boolean;
+    sample: CRDInstanceRow[];
+    /** Present when list/discovery failed (e.g. RBAC). */
+    fetchError?: string;
+}
+
+/** Payload for the CRD describe webview. */
+export interface CRDDescribeData {
+    overview: {
+        metadataName: string;
+        kind: string;
+        plural: string;
+        group: string;
+        scope: string;
+        categories: string[];
+        servedVersions: string[];
+        storageVersion: string;
+        age: string;
+        creationTimestamp: string;
+    };
+    versions: CRDVersionRow[];
+    schemas: CRDSchemaSection[];
+    instances: CRDInstancesSummary;
+    conditions: CRDConditionRow[];
+    yaml: string;
+}
+
+/**
+ * Fetches and formats CustomResourceDefinition detail for the Describe webview.
+ */
+export class CRDDescribeProvider {
+    constructor(private k8sClient: KubernetesApiClient) {}
+
+    async getCRDDetails(crdMetadataName: string, context: string): Promise<CRDDescribeData> {
+        this.k8sClient.setContext(context);
+
+        let crd: k8s.V1CustomResourceDefinition;
+        try {
+            crd = await this.k8sClient.apiextensions.readCustomResourceDefinition({
+                name: crdMetadataName
+            });
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+            throw new Error(`Failed to fetch CustomResourceDefinition ${crdMetadataName}: ${message}`);
+        }
+
+        const group = crd.spec?.group || '';
+        const plural = crd.spec?.names?.plural || '';
+        const kind = crd.spec?.names?.kind || 'Unknown';
+        const scopeRaw = crd.spec?.scope || '';
+        const scope: 'Namespaced' | 'Cluster' | 'Unknown' =
+            scopeRaw === 'Namespaced' ? 'Namespaced' :
+            scopeRaw === 'Cluster' ? 'Cluster' : 'Unknown';
+
+        const versions = crd.spec?.versions || [];
+        const storageVersion = versions.find(v => v.storage === true)?.name || versions[0]?.name || '';
+
+        const versionRows: CRDVersionRow[] = versions.map(v => ({
+            name: v.name || 'Unknown',
+            served: v.served === true,
+            storage: v.storage === true,
+            deprecated: v.deprecated === true || Boolean(v.deprecationWarning)
+        }));
+
+        const schemas: CRDSchemaSection[] = versions
+            .filter(v => v.served !== false && v.schema?.openAPIV3Schema !== undefined && v.schema.openAPIV3Schema !== null)
+            .map(v => ({
+                versionName: v.name || 'Unknown',
+                schemaText: this.stringifySchema(v.schema!.openAPIV3Schema as Record<string, unknown>)
+            }));
+
+        const servedLabels = versions.filter(v => v.served !== false).map(v => v.name || '').filter(Boolean);
+
+        const conditions: CRDConditionRow[] = (crd.status?.conditions || []).map(c => ({
+            type: c.type || 'Unknown',
+            status: c.status || 'Unknown',
+            reason: c.reason,
+            message: c.message
+        }));
+
+        const instances = await this.listInstances(
+            group,
+            plural,
+            storageVersion,
+            scope,
+            context
+        );
+
+        const yamlBody = yaml.dump(crd as unknown as Record<string, unknown>, {
+            lineWidth: 120,
+            noRefs: true
+        });
+
+        return {
+            overview: {
+                metadataName: crd.metadata?.name || crdMetadataName,
+                kind,
+                plural,
+                group,
+                scope: scopeRaw || 'Unknown',
+                categories: crd.spec?.names?.categories || [],
+                servedVersions: servedLabels,
+                storageVersion,
+                age: this.calculateAge(crd.metadata?.creationTimestamp),
+                creationTimestamp: this.formatTimestamp(crd.metadata?.creationTimestamp)
+            },
+            versions: versionRows,
+            schemas,
+            instances,
+            conditions,
+            yaml: yamlBody
+        };
+    }
+
+    private stringifySchema(openApi: Record<string, unknown>): string {
+        try {
+            return JSON.stringify(openApi, null, 2);
+        } catch {
+            return '[Unable to render schema JSON]';
+        }
+    }
+
+    private async listInstances(
+        group: string,
+        plural: string,
+        version: string,
+        scope: 'Namespaced' | 'Cluster' | 'Unknown',
+        contextName: string
+    ): Promise<CRDInstancesSummary> {
+        if (!group || !plural || !version || scope === 'Unknown') {
+            return {
+                scope,
+                totalReturned: 0,
+                truncated: false,
+                sample: [],
+                fetchError: !group ? 'Missing API group on CRD.' : !plural ? 'Missing plural name on CRD.' : undefined
+            };
+        }
+
+        try {
+            let body: Record<string, unknown>;
+            if (scope === 'Namespaced') {
+                body = await this.k8sClient.customObjects.listCustomObjectForAllNamespaces({
+                    group,
+                    version,
+                    plural,
+                    limit: INSTANCE_LIST_LIMIT,
+                    timeoutSeconds: 15
+                }) as Record<string, unknown>;
+            } else {
+                body = await this.k8sClient.customObjects.listClusterCustomObject({
+                    group,
+                    version,
+                    plural,
+                    limit: INSTANCE_LIST_LIMIT,
+                    timeoutSeconds: 15
+                }) as Record<string, unknown>;
+            }
+
+            const items = (body.items as Array<Record<string, unknown>>) || [];
+            const sample: CRDInstanceRow[] = items.map(item => {
+                const meta = item.metadata as { name?: string; namespace?: string } | undefined;
+                return {
+                    name: meta?.name || 'Unknown',
+                    namespace: scope === 'Namespaced' ? meta?.namespace : undefined
+                };
+            });
+
+            return {
+                scope,
+                totalReturned: sample.length,
+                truncated: sample.length >= INSTANCE_LIST_LIMIT,
+                sample
+            };
+        } catch (error: unknown) {
+            const kerr = KubectlError.fromExecError(error, contextName);
+            return {
+                scope,
+                totalReturned: 0,
+                truncated: false,
+                sample: [],
+                fetchError: kerr.getDetails() || kerr.message
+            };
+        }
+    }
+
+    private formatTimestamp(timestamp?: string | Date): string {
+        if (!timestamp) {
+            return 'Unknown';
+        }
+        if (timestamp instanceof Date) {
+            return timestamp.toISOString();
+        }
+        return timestamp;
+    }
+
+    private calculateAge(timestamp?: string | Date): string {
+        if (!timestamp) {
+            return 'Unknown';
+        }
+        try {
+            const now = new Date();
+            const then = timestamp instanceof Date ? timestamp : new Date(timestamp);
+            const diffMs = now.getTime() - then.getTime();
+            if (isNaN(diffMs) || diffMs < 0) {
+                return 'Unknown';
+            }
+            const seconds = Math.floor(diffMs / 1000);
+            const minutes = Math.floor(seconds / 60);
+            const hours = Math.floor(minutes / 60);
+            const days = Math.floor(hours / 24);
+            if (days > 0) {
+                return `${days}d`;
+            }
+            if (hours > 0) {
+                return `${hours}h`;
+            }
+            if (minutes > 0) {
+                return `${minutes}m`;
+            }
+            return `${seconds}s`;
+        } catch {
+            return 'Unknown';
+        }
+    }
+}

--- a/src/test/suite/providers/CRDDescribeProvider.test.ts
+++ b/src/test/suite/providers/CRDDescribeProvider.test.ts
@@ -1,0 +1,129 @@
+import * as assert from 'assert';
+import * as k8s from '@kubernetes/client-node';
+import { CRDDescribeProvider } from '../../../providers/CRDDescribeProvider';
+import type { KubernetesApiClient } from '../../../kubernetes/apiClient';
+
+function minimalNamespacedCRD(metadataName: string): k8s.V1CustomResourceDefinition {
+    return {
+        apiVersion: 'apiextensions.k8s.io/v1',
+        kind: 'CustomResourceDefinition',
+        metadata: {
+            name: metadataName,
+            creationTimestamp: new Date('2020-01-01T00:00:00.000Z')
+        },
+        spec: {
+            group: 'example.com',
+            scope: 'Namespaced',
+            names: {
+                plural: 'widgets',
+                singular: 'widget',
+                kind: 'Widget',
+                categories: ['all']
+            },
+            versions: [
+                {
+                    name: 'v1',
+                    served: true,
+                    storage: true,
+                    schema: {
+                        openAPIV3Schema: {
+                            type: 'object',
+                            properties: {
+                                spec: { type: 'object' }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        status: {
+            conditions: [
+                {
+                    type: 'Established',
+                    status: 'True',
+                    reason: 'Initial',
+                    message: 'ok'
+                }
+            ]
+        }
+    };
+}
+
+suite('CRDDescribeProvider', () => {
+    test('returns overview and instances for namespaced CRD', async () => {
+        const crd = minimalNamespacedCRD('widgets.example.com');
+
+        let listCalls = 0;
+        const mockClient = {
+            setContext: (): void => {
+                /**/
+            },
+            apiextensions: {
+                readCustomResourceDefinition: async (opts: { name: string }): Promise<k8s.V1CustomResourceDefinition> => {
+                    assert.strictEqual(opts.name, 'widgets.example.com');
+                    return crd;
+                }
+            },
+            customObjects: {
+                listCustomObjectForAllNamespaces: async (req: {
+                    group: string;
+                    version: string;
+                    plural: string;
+                }): Promise<{ items: unknown[] }> => {
+                    listCalls += 1;
+                    assert.strictEqual(req.group, 'example.com');
+                    assert.strictEqual(req.version, 'v1');
+                    assert.strictEqual(req.plural, 'widgets');
+                    return {
+                        items: [{ metadata: { name: 'w1', namespace: 'demo' } }]
+                    };
+                },
+                listClusterCustomObject: async (): Promise<{ items: unknown[] }> => {
+                    assert.fail('unexpected cluster-wide list');
+                }
+            }
+        } as unknown as KubernetesApiClient;
+
+        const provider = new CRDDescribeProvider(mockClient);
+        const data = await provider.getCRDDetails('widgets.example.com', 'test-context');
+
+        assert.strictEqual(data.overview.kind, 'Widget');
+        assert.strictEqual(data.overview.scope, 'Namespaced');
+        assert.strictEqual(listCalls, 1);
+        assert.strictEqual(data.instances.sample.length, 1);
+        assert.strictEqual(data.instances.sample[0].namespace, 'demo');
+        assert.strictEqual(data.conditions.length, 1);
+        assert.ok(data.yaml.includes('CustomResourceDefinition'));
+        assert.strictEqual(data.schemas.length, 1);
+        assert.ok(data.schemas[0].schemaText.includes('"type": "object"'));
+    });
+
+    test('lists cluster-scoped instances', async () => {
+        const crd = minimalNamespacedCRD('clusterwidgets.example.com');
+        crd.spec!.scope = 'Cluster';
+
+        const mockClient = {
+            setContext: (): void => {
+                /**/
+            },
+            apiextensions: {
+                readCustomResourceDefinition: async (): Promise<k8s.V1CustomResourceDefinition> => crd
+            },
+            customObjects: {
+                listCustomObjectForAllNamespaces: async (): Promise<{ items: unknown[] }> => {
+                    assert.fail('unexpected namespaced-wide list');
+                },
+                listClusterCustomObject: async (): Promise<{ items: unknown[] }> => ({
+                    items: [{ metadata: { name: 'cw1' } }]
+                })
+            }
+        } as unknown as KubernetesApiClient;
+
+        const provider = new CRDDescribeProvider(mockClient);
+        const data = await provider.getCRDDetails('clusterwidgets.example.com', 'ctx');
+
+        assert.strictEqual(data.instances.scope, 'Cluster');
+        assert.strictEqual(data.instances.sample[0].name, 'cw1');
+        assert.strictEqual(data.instances.sample[0].namespace, undefined);
+    });
+});

--- a/src/test/suite/webview/describeWebviewCRDConfigMutex.test.ts
+++ b/src/test/suite/webview/describeWebviewCRDConfigMutex.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'assert';
+import { DescribeWebview } from '../../../webview/DescribeWebview';
+
+/**
+ * Regression: shared Describe panel message handlers branch on static *Config fields.
+ * Opening CRD describe after PV/Pod/etc. must clear stale configs so refresh/viewYaml
+ * target the CRD (PR review: stale currentPVConfig shadowed currentCRDConfig).
+ */
+type DescribeWebviewInternals = {
+    clearAllDescribeResourceConfigs(): void;
+    currentPodConfig: unknown;
+    currentNamespaceConfig: unknown;
+    currentPVCConfig: unknown;
+    currentPVConfig: unknown;
+    currentSecretConfig: unknown;
+    currentServiceConfig: unknown;
+    currentConfigMapConfig: unknown;
+    currentStorageClassConfig: unknown;
+    currentCRDConfig: { name: string; kindLabel: string; context: string } | undefined;
+};
+
+suite('DescribeWebview CRD config mutex', () => {
+    teardown(() => {
+        const w = DescribeWebview as unknown as DescribeWebviewInternals;
+        w.clearAllDescribeResourceConfigs();
+    });
+
+    test('clearAllDescribeResourceConfigs removes stale PV before CRD is active', () => {
+        const w = DescribeWebview as unknown as DescribeWebviewInternals;
+        w.currentPVConfig = { name: 'pv-stale', context: 'ctx' };
+        w.clearAllDescribeResourceConfigs();
+        w.currentCRDConfig = { name: 'widgets.example.com', kindLabel: 'Widget', context: 'ctx' };
+        assert.strictEqual(w.currentPVConfig, undefined);
+        assert.strictEqual(w.currentCRDConfig.name, 'widgets.example.com');
+    });
+
+    test('clearAllDescribeResourceConfigs clears every describe binding slot', () => {
+        const w = DescribeWebview as unknown as DescribeWebviewInternals;
+        w.currentPodConfig = { name: 'p', namespace: 'ns', context: 'c' };
+        w.currentNamespaceConfig = { stub: true };
+        w.currentPVCConfig = { name: 'pvc', namespace: 'ns', context: 'c' };
+        w.currentPVConfig = { name: 'pv', context: 'c' };
+        w.currentSecretConfig = { name: 's', namespace: 'ns', context: 'c' };
+        w.currentServiceConfig = { name: 'svc', namespace: 'ns', context: 'c' };
+        w.currentConfigMapConfig = { name: 'cm', namespace: 'ns', context: 'c' };
+        w.currentStorageClassConfig = { name: 'sc', context: 'c' };
+        w.currentCRDConfig = { name: 'x.example.com', kindLabel: 'X', context: 'c' };
+        w.clearAllDescribeResourceConfigs();
+        assert.strictEqual(w.currentPodConfig, undefined);
+        assert.strictEqual(w.currentNamespaceConfig, undefined);
+        assert.strictEqual(w.currentPVCConfig, undefined);
+        assert.strictEqual(w.currentPVConfig, undefined);
+        assert.strictEqual(w.currentSecretConfig, undefined);
+        assert.strictEqual(w.currentServiceConfig, undefined);
+        assert.strictEqual(w.currentConfigMapConfig, undefined);
+        assert.strictEqual(w.currentStorageClassConfig, undefined);
+        assert.strictEqual(w.currentCRDConfig, undefined);
+    });
+});

--- a/src/tree/categories/CustomResourcesCategory.ts
+++ b/src/tree/categories/CustomResourcesCategory.ts
@@ -52,12 +52,18 @@ export class CustomResourcesCategory {
         const crdItems = result.crds.map(crdInfo => {
             // Label is the kind name (e.g., "MyCustomResource")
             const label = crdInfo.kind;
+
+            const itemResourceData: TreeItemData = {
+                ...resourceData,
+                /** metadata.name / kubectl resource id (group-suffixed plural) */
+                resourceName: crdInfo.name
+            };
             
             const item = new ClusterTreeItem(
                 label,
                 'crd',
                 vscode.TreeItemCollapsibleState.None,
-                resourceData
+                itemResourceData
             );
 
             // Set description to show group and version (e.g., "apps.example.com/v1")

--- a/src/webview/DescribeWebview.ts
+++ b/src/webview/DescribeWebview.ts
@@ -225,6 +225,23 @@ export class DescribeWebview {
     private static currentCRDConfig: CRDTreeItemConfig | undefined;
 
     /**
+     * Clears which resource the shared Describe panel is bound to.
+     * Call before assigning a new active config when switching kinds so
+     * refresh/viewYaml handlers do not match a stale type first.
+     */
+    private static clearAllDescribeResourceConfigs(): void {
+        DescribeWebview.currentPodConfig = undefined;
+        DescribeWebview.currentNamespaceConfig = undefined;
+        DescribeWebview.currentPVCConfig = undefined;
+        DescribeWebview.currentPVConfig = undefined;
+        DescribeWebview.currentSecretConfig = undefined;
+        DescribeWebview.currentServiceConfig = undefined;
+        DescribeWebview.currentConfigMapConfig = undefined;
+        DescribeWebview.currentStorageClassConfig = undefined;
+        DescribeWebview.currentCRDConfig = undefined;
+    }
+
+    /**
      * Show the Describe webview for a resource.
      * Creates a new panel if none exists, or reuses and updates the existing panel.
      * 
@@ -2040,6 +2057,7 @@ export class DescribeWebview {
         crdConfig: CRDTreeItemConfig
     ): Promise<void> {
         DescribeWebview.extensionContext = context;
+        DescribeWebview.clearAllDescribeResourceConfigs();
         DescribeWebview.currentCRDConfig = crdConfig;
 
         if (!DescribeWebview.crdProvider) {
@@ -2087,8 +2105,9 @@ export class DescribeWebview {
         if (!DescribeWebview.currentPanel) {
             return;
         }
-        DescribeWebview.currentPanel.title = `CRD / ${crdConfig.kindLabel}`;
+        DescribeWebview.clearAllDescribeResourceConfigs();
         DescribeWebview.currentCRDConfig = crdConfig;
+        DescribeWebview.currentPanel.title = `CRD / ${crdConfig.kindLabel}`;
         DescribeWebview.currentPanel.webview.html = DescribeWebview.getCRDWebviewContent(
             DescribeWebview.currentPanel.webview,
             crdConfig

--- a/src/webview/DescribeWebview.ts
+++ b/src/webview/DescribeWebview.ts
@@ -11,6 +11,7 @@ import { SecretDescribeProvider } from '../providers/SecretDescribeProvider';
 import { ServiceDescribeProvider } from '../providers/ServiceDescribeProvider';
 import { ConfigMapDescribeProvider } from '../providers/ConfigMapDescribeProvider';
 import { StorageClassDescribeProvider } from '../providers/StorageClassDescribeProvider';
+import { CRDDescribeProvider } from '../providers/CRDDescribeProvider';
 import { getKubernetesApiClient } from '../kubernetes/apiClient';
 import { DeploymentDescribeWebview } from './DeploymentDescribeWebview';
 import { KubeconfigParser } from '../kubernetes/KubeconfigParser';
@@ -93,12 +94,20 @@ export interface ConfigMapTreeItemConfig {
     context: string;
 }
 
-/**
- * StorageClass configuration passed from tree item to describe webview.
- */
 interface StorageClassTreeItemConfig {
     name: string;
     metadata?: Record<string, unknown>;
+    context: string;
+}
+
+/**
+ * CustomResourceDefinition tree item → describe webview.
+ */
+interface CRDTreeItemConfig {
+    /** `metadata.name` (e.g. applications.argoproj.io) */
+    name: string;
+    /** Tree label (CRD `.spec.names.kind`) */
+    kindLabel: string;
     context: string;
 }
 
@@ -210,6 +219,10 @@ export class DescribeWebview {
      * Used for refresh operations.
      */
     private static currentStorageClassConfig: StorageClassTreeItemConfig | undefined;
+
+    private static crdProvider: CRDDescribeProvider | undefined;
+
+    private static currentCRDConfig: CRDTreeItemConfig | undefined;
 
     /**
      * Show the Describe webview for a resource.
@@ -527,6 +540,23 @@ export class DescribeWebview {
             return;
         }
 
+        if (kind === 'crd') {
+            const crdApiName = treeItem.resourceData?.resourceName;
+            if (!crdApiName) {
+                vscode.window.showErrorMessage(
+                    'Unable to describe CRD: missing API resource name. Refresh the Custom Resources list and try again.'
+                );
+                return;
+            }
+            const kindLabel = typeof treeItem.label === 'string' ? treeItem.label : 'CustomResourceDefinition';
+            await DescribeWebview.showCRDDescribe(context, {
+                name: crdApiName,
+                kindLabel,
+                context: contextName
+            });
+            return;
+        }
+
         // Show the Describe webview for other resource types
         DescribeWebview.show(context, {
             kind,
@@ -718,6 +748,11 @@ export class DescribeWebview {
                                 DescribeWebview.currentStorageClassConfig,
                                 panel
                             );
+                        } else if (DescribeWebview.currentCRDConfig) {
+                            await DescribeWebview.loadCRDData(
+                                DescribeWebview.currentCRDConfig,
+                                panel
+                            );
                         }
                         break;
 
@@ -739,6 +774,8 @@ export class DescribeWebview {
                             await DescribeWebview.openConfigMapYamlEditor();
                         } else if (DescribeWebview.currentStorageClassConfig) {
                             await DescribeWebview.openStorageClassYamlEditor();
+                        } else if (DescribeWebview.currentCRDConfig) {
+                            await DescribeWebview.openCRDYamlEditor();
                         }
                         break;
 
@@ -969,6 +1006,8 @@ export class DescribeWebview {
             contextName = DescribeWebview.currentPVConfig.context;
         } else if (DescribeWebview.currentStorageClassConfig) {
             contextName = DescribeWebview.currentStorageClassConfig.context;
+        } else if (DescribeWebview.currentCRDConfig) {
+            contextName = DescribeWebview.currentCRDConfig.context;
         } else if (DescribeWebview.currentPVCConfig) {
             contextName = DescribeWebview.currentPVCConfig.context;
         } else if (DescribeWebview.currentPodConfig) {
@@ -1991,6 +2030,189 @@ export class DescribeWebview {
             null,
             context.subscriptions
         );
+    }
+
+    /**
+     * Describe view for a cluster CustomResourceDefinition (CRD metadata name).
+     */
+    public static async showCRDDescribe(
+        context: vscode.ExtensionContext,
+        crdConfig: CRDTreeItemConfig
+    ): Promise<void> {
+        DescribeWebview.extensionContext = context;
+        DescribeWebview.currentCRDConfig = crdConfig;
+
+        if (!DescribeWebview.crdProvider) {
+            DescribeWebview.crdProvider = new CRDDescribeProvider(getKubernetesApiClient());
+        }
+
+        if (DescribeWebview.currentPanel) {
+            await DescribeWebview.updateCRDPanel(crdConfig);
+            DescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
+            return;
+        }
+
+        const title = `CRD / ${crdConfig.kindLabel}`;
+        notifyMajorWebviewOpened('resource_describe');
+        const panel = vscode.window.createWebviewPanel(
+            'kube9Describe',
+            title,
+            vscode.ViewColumn.One,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true
+            }
+        );
+
+        DescribeWebview.currentPanel = panel;
+        panel.webview.html = DescribeWebview.getCRDWebviewContent(panel.webview, crdConfig);
+        DescribeWebview.setupMessageHandling(panel, context);
+
+        const helpHandler = new WebviewHelpHandler(getHelpController());
+        helpHandler.setupHelpMessageHandler(panel.webview);
+
+        await DescribeWebview.loadCRDData(crdConfig, panel);
+
+        panel.onDidDispose(
+            () => {
+                DescribeWebview.currentPanel = undefined;
+                DescribeWebview.currentCRDConfig = undefined;
+            },
+            null,
+            context.subscriptions
+        );
+    }
+
+    private static async updateCRDPanel(crdConfig: CRDTreeItemConfig): Promise<void> {
+        if (!DescribeWebview.currentPanel) {
+            return;
+        }
+        DescribeWebview.currentPanel.title = `CRD / ${crdConfig.kindLabel}`;
+        DescribeWebview.currentCRDConfig = crdConfig;
+        DescribeWebview.currentPanel.webview.html = DescribeWebview.getCRDWebviewContent(
+            DescribeWebview.currentPanel.webview,
+            crdConfig
+        );
+        await DescribeWebview.loadCRDData(crdConfig, DescribeWebview.currentPanel);
+    }
+
+    private static async loadCRDData(
+        crdConfig: CRDTreeItemConfig,
+        panel: vscode.WebviewPanel
+    ): Promise<void> {
+        if (!DescribeWebview.crdProvider) {
+            return;
+        }
+
+        try {
+            const data = await DescribeWebview.crdProvider.getCRDDetails(
+                crdConfig.name,
+                crdConfig.context
+            );
+            panel.webview.postMessage({
+                command: 'updateCRDDescribeData',
+                data
+            });
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            panel.webview.postMessage({
+                command: 'showError',
+                data: {
+                    message: errorMessage
+                }
+            });
+        }
+    }
+
+    private static getCRDWebviewContent(webview: vscode.Webview, crdConfig: CRDTreeItemConfig): string {
+        if (!DescribeWebview.extensionContext) {
+            return DescribeWebview.getCRDFallbackHtml(crdConfig);
+        }
+
+        const scriptUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(DescribeWebview.extensionContext.extensionUri, 'dist', 'media', 'crd-describe', 'index.js')
+        );
+
+        let headerCss = '';
+        try {
+            const headerCssPath = path.join(
+                DescribeWebview.extensionContext.extensionPath,
+                'src',
+                'webview',
+                'styles',
+                'webview-header.css'
+            );
+            headerCss = fs.readFileSync(headerCssPath, 'utf8');
+        } catch (err) {
+            console.error('Failed to load header CSS:', err);
+        }
+
+        const nonce = getNonce();
+        const escaped = DescribeWebview.escapeHtml(crdConfig.kindLabel);
+        const cspSource = webview.cspSource;
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
+    <title>CRD / ${escaped}</title>
+    <style>
+        ${headerCss}
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+    }
+
+    private static getCRDFallbackHtml(crdConfig: CRDTreeItemConfig): string {
+        const escaped = DescribeWebview.escapeHtml(crdConfig.kindLabel);
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CRD / ${escaped}</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
+    <style>
+        body {
+            font-family: var(--vscode-font-family);
+            color: var(--vscode-foreground);
+            background-color: var(--vscode-editor-background);
+            padding: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="error">Failed to load webview bundle. Ensure <code>dist/media/crd-describe/index.js</code> exists (run webpack production build).</div>
+</body>
+</html>`;
+    }
+
+    private static async openCRDYamlEditor(): Promise<void> {
+        if (!DescribeWebview.currentCRDConfig) {
+            vscode.window.showErrorMessage('No CustomResourceDefinition is currently being displayed');
+            return;
+        }
+        try {
+            const cfg = DescribeWebview.currentCRDConfig;
+            const resource = {
+                kind: 'CustomResourceDefinition',
+                name: cfg.name,
+                namespace: undefined,
+                apiVersion: 'apiextensions.k8s.io/v1',
+                cluster: cfg.context
+            };
+            const yamlEditorManager = getYAMLEditorManager();
+            await yamlEditorManager.openYAMLEditor(resource);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.error('Failed to open YAML editor for CRD:', errorMessage);
+            vscode.window.showErrorMessage(`Failed to open YAML editor: ${errorMessage}`);
+        }
     }
 
     /**

--- a/src/webview/crd-describe/CRDDescribeApp.tsx
+++ b/src/webview/crd-describe/CRDDescribeApp.tsx
@@ -1,0 +1,388 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import type { CRDDescribeData } from '../../providers/CRDDescribeProvider';
+import { WebviewHeader, WebviewHeaderAction } from '../components/WebviewHeader';
+import type { ExtensionToWebviewMessage, WebviewToExtensionMessage, VSCodeAPI } from './types';
+
+const vscodeApi: VSCodeAPI | undefined =
+    typeof acquireVsCodeApi !== 'undefined' ? acquireVsCodeApi() : undefined;
+if (vscodeApi && typeof window !== 'undefined') {
+    (window as Window & { vscodeApi?: VSCodeAPI }).vscodeApi = vscodeApi;
+}
+
+type CRDDescribeTab =
+    | 'overview'
+    | 'versions'
+    | 'schemas'
+    | 'instances'
+    | 'conditions'
+    | 'yaml';
+
+export const CRDDescribeApp: React.FC = () => {
+    const [data, setData] = useState<CRDDescribeData | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [activeTab, setActiveTab] = useState<CRDDescribeTab>('overview');
+    const loading = data === null && error === null;
+
+    const sendMessage = useCallback((message: WebviewToExtensionMessage) => {
+        vscodeApi?.postMessage(message);
+    }, []);
+
+    useEffect(() => {
+        if (!vscodeApi) {
+            return;
+        }
+        const handler = (event: MessageEvent) => {
+            const message = event.data as ExtensionToWebviewMessage;
+            switch (message.command) {
+                case 'updateCRDDescribeData':
+                    setData(message.data as CRDDescribeData);
+                    setError(null);
+                    break;
+                case 'showError':
+                    setError((message.data as { message: string }).message);
+                    setData(null);
+                    break;
+                default:
+                    break;
+            }
+        };
+        window.addEventListener('message', handler);
+        sendMessage({ command: 'ready' });
+        return () => window.removeEventListener('message', handler);
+    }, [sendMessage]);
+
+    const handleRefresh = useCallback(() => sendMessage({ command: 'refresh' }), [sendMessage]);
+    const handleViewYaml = useCallback(() => sendMessage({ command: 'viewYaml' }), [sendMessage]);
+
+    if (loading) {
+        return (
+            <div className="pod-describe-container">
+                <div className="loading-state">
+                    <div className="loading-spinner" />
+                    <div className="loading-message">Loading CRD details...</div>
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="pod-describe-container">
+                <div className="error-state">
+                    <div className="error-icon">⚠️</div>
+                    <div className="error-message">{error}</div>
+                </div>
+            </div>
+        );
+    }
+
+    if (!data) {
+        return null;
+    }
+
+    const headerActions: WebviewHeaderAction[] = [
+        { label: 'Refresh', icon: 'codicon-refresh', onClick: handleRefresh },
+        { label: 'View YAML', icon: 'codicon-file-code', onClick: handleViewYaml }
+    ];
+
+    const instanceCountLabel = data.instances.fetchError
+        ? 'Instances'
+        : `Instances (${data.instances.totalReturned}${data.instances.truncated ? '+' : ''})`;
+
+    return (
+        <div className="pod-describe-container">
+            <div className="container">
+                <WebviewHeader
+                    title={`CRD / ${data.overview.kind}`}
+                    actions={headerActions}
+                    helpContext="describe-webview"
+                />
+                <div className="resource-info" style={{ marginBottom: 12, opacity: 0.85, fontSize: '0.9em' }}>
+                    Definition: {data.overview.metadataName}
+                </div>
+
+                <nav className="tab-navigation">
+                    <button
+                        type="button"
+                        className={`tab-btn ${activeTab === 'overview' ? 'active' : ''}`}
+                        onClick={() => setActiveTab('overview')}
+                    >
+                        Overview
+                    </button>
+                    <button
+                        type="button"
+                        className={`tab-btn ${activeTab === 'versions' ? 'active' : ''}`}
+                        onClick={() => setActiveTab('versions')}
+                    >
+                        Versions ({data.versions.length})
+                    </button>
+                    <button
+                        type="button"
+                        className={`tab-btn ${activeTab === 'schemas' ? 'active' : ''}`}
+                        onClick={() => setActiveTab('schemas')}
+                    >
+                        Schema ({data.schemas.length})
+                    </button>
+                    <button
+                        type="button"
+                        className={`tab-btn ${activeTab === 'instances' ? 'active' : ''}`}
+                        onClick={() => setActiveTab('instances')}
+                    >
+                        {instanceCountLabel}
+                    </button>
+                    <button
+                        type="button"
+                        className={`tab-btn ${activeTab === 'conditions' ? 'active' : ''}`}
+                        onClick={() => setActiveTab('conditions')}
+                    >
+                        Conditions ({data.conditions.length})
+                    </button>
+                    <button
+                        type="button"
+                        className={`tab-btn ${activeTab === 'yaml' ? 'active' : ''}`}
+                        onClick={() => setActiveTab('yaml')}
+                    >
+                        YAML
+                    </button>
+                </nav>
+
+                <main className="tab-content">
+                    {activeTab === 'overview' && <OverviewPanel d={data} />}
+                    {activeTab === 'versions' && <VersionsPanel versions={data.versions} />}
+                    {activeTab === 'schemas' && <SchemasPanel schemas={data.schemas} />}
+                    {activeTab === 'instances' && <InstancesPanel instances={data.instances} />}
+                    {activeTab === 'conditions' && <ConditionsPanel conditions={data.conditions} />}
+                    {activeTab === 'yaml' && <YamlPanel yamlText={data.yaml} />}
+                </main>
+            </div>
+        </div>
+    );
+};
+
+const OverviewPanel: React.FC<{ d: CRDDescribeData }> = ({ d }) => {
+    const o = d.overview;
+    return (
+        <div className="section overview-tab">
+            <div className="section">
+                <h2>Definition</h2>
+                <div className="info-grid">
+                    <div className="info-item">
+                        <div className="info-label">Kind</div>
+                        <div className="info-value">{o.kind}</div>
+                    </div>
+                    <div className="info-item">
+                        <div className="info-label">Plural</div>
+                        <div className="info-value">{o.plural}</div>
+                    </div>
+                    <div className="info-item">
+                        <div className="info-label">Group</div>
+                        <div className="info-value">{o.group || '—'}</div>
+                    </div>
+                    <div className="info-item">
+                        <div className="info-label">Scope</div>
+                        <div className="info-value">{o.scope}</div>
+                    </div>
+                    <div className="info-item">
+                        <div className="info-label">Storage version</div>
+                        <div className="info-value">{o.storageVersion || '—'}</div>
+                    </div>
+                    <div className="info-item">
+                        <div className="info-label">Served versions</div>
+                        <div className="info-value">{o.servedVersions.length ? o.servedVersions.join(', ') : '—'}</div>
+                    </div>
+                    <div className="info-item">
+                        <div className="info-label">Categories</div>
+                        <div className="info-value">{o.categories.length ? o.categories.join(', ') : '—'}</div>
+                    </div>
+                    <div className="info-item">
+                        <div className="info-label">Age</div>
+                        <div className="info-value">{o.age}</div>
+                    </div>
+                    <div className="info-item">
+                        <div className="info-label">Created</div>
+                        <div className="info-value">{o.creationTimestamp}</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const VersionsPanel: React.FC<{ versions: CRDDescribeData['versions'] }> = ({ versions }) => {
+    if (versions.length === 0) {
+        return <p className="empty-hint">No versions defined on this CRD.</p>;
+    }
+    return (
+        <div className="section">
+            <table className="conditions-table">
+                <thead>
+                    <tr>
+                        <th>Version</th>
+                        <th>Served</th>
+                        <th>Storage</th>
+                        <th>Deprecated</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {versions.map(v => (
+                        <tr key={v.name}>
+                            <td>{v.name}</td>
+                            <td>{v.served ? 'Yes' : 'No'}</td>
+                            <td>{v.storage ? 'Yes' : 'No'}</td>
+                            <td>{v.deprecated ? 'Yes' : 'No'}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+const SchemasPanel: React.FC<{ schemas: CRDDescribeData['schemas'] }> = ({ schemas }) => {
+    if (schemas.length === 0) {
+        return (
+            <p className="empty-hint">
+                No per-version structural schema (OpenAPI v3) is published for served versions of this CRD.
+            </p>
+        );
+    }
+    return (
+        <div className="section">
+            {schemas.map(s => (
+                <details key={s.versionName} open={schemas.length === 1} style={{ marginBottom: 12 }}>
+                    <summary style={{ cursor: 'pointer', fontWeight: 600 }}>Version {s.versionName}</summary>
+                    <pre
+                        className="code-block schema-block"
+                        style={{
+                            overflow: 'auto',
+                            maxHeight: 480,
+                            fontSize: 12,
+                            marginTop: 8,
+                            padding: 8,
+                            background: 'var(--vscode-editor-inactiveSelectionBackground)',
+                            borderRadius: 4
+                        }}
+                    >
+                        {s.schemaText}
+                    </pre>
+                </details>
+            ))}
+        </div>
+    );
+};
+
+const InstancesPanel: React.FC<{ instances: CRDDescribeData['instances'] }> = ({ instances }) => {
+    if (instances.fetchError) {
+        return (
+            <div className="section">
+                <div
+                    style={{
+                        padding: 12,
+                        borderRadius: 4,
+                        border: '1px solid var(--vscode-inputValidation-errorBorder)',
+                        backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
+                        marginBottom: 12
+                    }}
+                >
+                    <strong>Unable to list custom resources:</strong>
+                    <div style={{ marginTop: 8, whiteSpace: 'pre-wrap' }}>{instances.fetchError}</div>
+                </div>
+                <p className="empty-hint">
+                    This is usually RBAC or API discovery related—metadata about the CRD above is still valid.
+                </p>
+            </div>
+        );
+    }
+    if (instances.sample.length === 0) {
+        return (
+            <p className="empty-hint">
+                No {instances.scope === 'Namespaced' ? 'namespaced' : 'cluster-scoped'} instances found (or none
+                returned in this sample).
+            </p>
+        );
+    }
+    return (
+        <div className="section">
+            {instances.scope === 'Namespaced' ? (
+                <p style={{ opacity: 0.85, marginBottom: 8 }}>
+                    Namespaced CRD — instances show with namespace. Showing up to{' '}
+                    {instances.sample.length}
+                    {instances.truncated ? ' (truncated)' : ''}.
+                </p>
+            ) : (
+                <p style={{ opacity: 0.85, marginBottom: 8 }}>
+                    Cluster-scoped CRD — instances listed without namespace. Showing up to{' '}
+                    {instances.sample.length}
+                    {instances.truncated ? ' (truncated)' : ''}.
+                </p>
+            )}
+            <table className="conditions-table">
+                <thead>
+                    <tr>
+                        {instances.scope === 'Namespaced' && <th>Namespace</th>}
+                        <th>Name</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {instances.sample.map(row => (
+                        <tr key={`${row.namespace || ''}:${row.name}`}>
+                            {instances.scope === 'Namespaced' && <td>{row.namespace}</td>}
+                            <td>{row.name}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+const ConditionsPanel: React.FC<{ conditions: CRDDescribeData['conditions'] }> = ({ conditions }) => {
+    if (conditions.length === 0) {
+        return <p className="empty-hint">No status conditions reported on this CRD.</p>;
+    }
+    return (
+        <div className="section">
+            <table className="conditions-table">
+                <thead>
+                    <tr>
+                        <th>Type</th>
+                        <th>Status</th>
+                        <th>Reason</th>
+                        <th>Message</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {conditions.map(c => (
+                        <tr key={`${c.type}-${c.status}`}>
+                            <td>{c.type}</td>
+                            <td>{c.status}</td>
+                            <td>{c.reason || '—'}</td>
+                            <td>{c.message || '—'}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+const YamlPanel: React.FC<{ yamlText: string }> = ({ yamlText }) => (
+    <div className="section">
+        <pre
+            className="code-block yaml-block"
+            style={{
+                overflow: 'auto',
+                maxHeight: '70vh',
+                fontSize: 12,
+                padding: 8,
+                background: 'var(--vscode-editor-inactiveSelectionBackground)',
+                borderRadius: 4
+            }}
+        >
+            {yamlText}
+        </pre>
+        <p className="empty-hint" style={{ marginTop: 8 }}>
+            Use <strong>View YAML</strong> in the header to open this CustomResourceDefinition in the YAML editor.
+        </p>
+    </div>
+);

--- a/src/webview/crd-describe/index.tsx
+++ b/src/webview/crd-describe/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { CRDDescribeApp } from './CRDDescribeApp';
+import '../../../media/describe/podDescribe.css';
+
+const container = document.getElementById('root');
+if (container) {
+    createRoot(container).render(
+        <React.StrictMode>
+            <CRDDescribeApp />
+        </React.StrictMode>
+    );
+}

--- a/src/webview/crd-describe/types.ts
+++ b/src/webview/crd-describe/types.ts
@@ -1,0 +1,19 @@
+import type { CRDDescribeData } from '../../providers/CRDDescribeProvider';
+
+/** VS Code webview messaging API surface used by Describe webviews. */
+export interface VSCodeAPI {
+    postMessage(message: WebviewToExtensionMessage): void;
+    getState(): unknown;
+    setState(state: unknown): void;
+}
+
+export interface ExtensionToWebviewMessage {
+    command: 'updateCRDDescribeData' | 'showError';
+    data: CRDDescribeData | { message: string };
+}
+
+export interface WebviewToExtensionMessage {
+    command: 'refresh' | 'viewYaml' | 'ready';
+}
+
+export type { CRDDescribeData };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
     "src/webview/service-describe",
     "src/webview/configmap-describe",
     "src/webview/storageclass-describe",
+    "src/webview/crd-describe",
     "src/webview/operator-health-report",
     "src/webview/well-architected-assessment-report",
     "src/webview/helm-package-manager",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ const extensionConfig = {
     rules: [
       {
         test: /\.ts$/,
-        exclude: [/node_modules/, /src\/webview\/argocd-application/, /src\/webview\/event-viewer/, /src\/webview\/pod-logs/, /src\/webview\/pod-describe/, /src\/webview\/pvc-describe/, /src\/webview\/pv-describe/, /src\/webview\/secret-describe/, /src\/webview\/service-describe/, /src\/webview\/configmap-describe/, /src\/webview\/storageclass-describe/, /src\/webview\/operator-health-report/, /src\/webview\/helm-package-manager/],
+        exclude: [/node_modules/, /src\/webview\/argocd-application/, /src\/webview\/event-viewer/, /src\/webview\/pod-logs/, /src\/webview\/pod-describe/, /src\/webview\/pvc-describe/, /src\/webview\/pv-describe/, /src\/webview\/secret-describe/, /src\/webview\/service-describe/, /src\/webview\/configmap-describe/, /src\/webview\/storageclass-describe/, /src\/webview\/crd-describe/, /src\/webview\/operator-health-report/, /src\/webview\/helm-package-manager/],
         use: [
           {
             loader: 'ts-loader',
@@ -394,7 +394,46 @@ const storageClassDescribeConfig = {
   }
 };
 
-module.exports = [extensionConfig, webviewConfig, podDescribeConfig, namespaceDescribeConfig, pvcDescribeConfig, pvDescribeConfig, secretDescribeConfig, serviceDescribeConfig, configMapDescribeConfig, storageClassDescribeConfig];
+/**@type {import('webpack').Configuration}*/
+const crdDescribeConfig = {
+  target: 'web',
+  entry: './src/webview/crd-describe/index.tsx',
+  output: {
+    path: path.resolve(__dirname, 'dist', 'media', 'crd-describe'),
+    filename: 'index.js',
+    devtoolModuleFilenameTemplate: '../[resource-path]'
+  },
+  devtool: 'source-map',
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.jsx']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: [
+                ['@babel/preset-env', { targets: 'defaults' }],
+                ['@babel/preset-react', { runtime: 'automatic' }],
+                '@babel/preset-typescript'
+              ]
+            }
+          }
+        ]
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      }
+    ]
+  }
+};
+
+module.exports = [extensionConfig, webviewConfig, podDescribeConfig, namespaceDescribeConfig, pvcDescribeConfig, pvDescribeConfig, secretDescribeConfig, serviceDescribeConfig, configMapDescribeConfig, storageClassDescribeConfig, crdDescribeConfig];
 
 
 


### PR DESCRIPTION
## Summary

- Route **Describe** for Custom Resources tree items (`kind` `crd`) to a dedicated CRD flow instead of the generic `Coming soon` stub.
- Add `CRDDescribeProvider`: load `CustomResourceDefinition` via apiextensions API, optional instance listing via CustomObjects (`listCustomObjectForAllNamespaces` vs `listClusterCustomObject`), conditions, per-version structural schema preview, YAML dump (`js-yaml`).
- Add React webview bundle `dist/media/crd-describe/index.js` with tabs (Overview, Versions, Schema, Instances, Conditions, YAML), **Refresh**, **View YAML** (reuse existing YAML editor path).
- Tree items now carry `resourceName` (`metadata.name` for the CRD) so Describe can fetch the correct object (`CustomResourcesCategory`).
- Extend `KubernetesApiClient` with `customObjects`; register webpack entry + exclude `src/webview/crd-describe` from root `tsc` like other describe bundles.

Coordinates with broader describe routing (#146) as discussed on the ticket; CRD/custom-instance routing for other tree nodes remains future work unless they already use this path.

Fixes alto9/kube9-vscode#95.

## Test plan

- [x] `npm run build`
- [x] `npm run lint` (warnings baseline only; no new errors)
- [x] `npm run test:unit` (includes new `CRDDescribeProvider.test.ts`)
- [ ] Manual: Extension Development Host → **Kube9 → Clusters → Custom Resources** → Describe on a CRD; confirm tabs, RBAC denial shows explicit Instances error panel, View YAML opens CRD (`apiextensions.k8s.io/v1`).