### PR TITLE
fix(describe): align context-menu Describe with Pod/Namespace/CronJob/Node detail webviews

### DIFF
--- a/package.json
+++ b/package.json
@@ -530,12 +530,12 @@
         },
         {
           "command": "kube9.describeResource",
-          "when": "view == kube9ClusterView && viewItem =~ /^resource/",
+          "when": "view == kube9ClusterView && (viewItem =~ /^resource/ || viewItem == namespace:active || viewItem == namespace:inactive)",
           "group": "kube9@1"
         },
         {
           "command": "kube9.describeResourceRaw",
-          "when": "view == kube9ClusterView && viewItem =~ /^resource/",
+          "when": "view == kube9ClusterView && (viewItem =~ /^resource/ || viewItem == namespace:active || viewItem == namespace:inactive)",
           "group": "kube9@1.5"
         },
         {

--- a/package.json
+++ b/package.json
@@ -535,7 +535,7 @@
         },
         {
           "command": "kube9.describeResourceRaw",
-          "when": "view == kube9ClusterView && (viewItem =~ /^resource/ || viewItem == namespace:active || viewItem == namespace:inactive)",
+          "when": "view == kube9ClusterView && viewItem =~ /^resource/",
           "group": "kube9@1.5"
         },
         {

--- a/src/test/suite/webview/describeTreeRouting.test.ts
+++ b/src/test/suite/webview/describeTreeRouting.test.ts
@@ -1,0 +1,181 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as k8s from '@kubernetes/client-node';
+import { ClusterTreeItem } from '../../../tree/ClusterTreeItem';
+import { TreeItemData } from '../../../tree/TreeItemTypes';
+import { NamespaceTreeItem } from '../../../tree/items/NamespaceTreeItem';
+import {
+    PodTreeItem,
+    PodInfo,
+    PodStatus
+} from '../../../tree/items/PodTreeItem';
+import { resolveSpecializedDescribeFromTreeItem } from '../../../webview/describeTreeRouting';
+
+const sampleContextName = 'ctx-1';
+
+function baseResourceData(overrides: {
+    namespace?: string;
+    resourceName?: string;
+} = {}): TreeItemData {
+    return {
+        context: { name: sampleContextName, cluster: 'cluster-1' },
+        cluster: { name: 'cluster-1', server: 'https://example.test' },
+        namespace: overrides.namespace,
+        resourceName: overrides.resourceName
+    };
+}
+
+suite('describeTreeRouting (context-menu Describe parity)', () => {
+    test('Pod + PodTreeItem preserves status', () => {
+        const podInfo: PodInfo = {
+            name: 'p1',
+            namespace: 'ns-a',
+            status: 'Running' as PodStatus
+        };
+        const item = new PodTreeItem(podInfo, baseResourceData({ namespace: 'ns-a', resourceName: 'p1' }));
+
+        const r = resolveSpecializedDescribeFromTreeItem(item);
+        assert.strictEqual(r?.kind, 'pod');
+        if (r?.kind === 'pod') {
+            assert.strictEqual(r.podConfig.namespace, 'ns-a');
+            assert.strictEqual(r.podConfig.context, sampleContextName);
+            assert.strictEqual(r.podConfig.status, 'Running');
+        }
+    });
+
+    test('Pod plain ClusterTreeItem uses Unknown status when not PodTreeItem', () => {
+        const item = new ClusterTreeItem(
+            'plain-pod',
+            'pod',
+            vscode.TreeItemCollapsibleState.None,
+            baseResourceData({ namespace: 'ns-b', resourceName: 'plain-pod' })
+        );
+        item.contextValue = 'resource:Pod';
+
+        const r = resolveSpecializedDescribeFromTreeItem(item);
+        assert.strictEqual(r?.kind, 'pod');
+        if (r?.kind === 'pod') {
+            assert.strictEqual(r.podConfig.status, 'Unknown');
+        }
+    });
+
+    test('Pod without namespace is skip', () => {
+        const item = new ClusterTreeItem(
+            'broken',
+            'pod',
+            vscode.TreeItemCollapsibleState.None,
+            baseResourceData({ resourceName: 'broken' })
+        );
+        item.contextValue = 'resource:Pod';
+
+        const r = resolveSpecializedDescribeFromTreeItem(item);
+        assert.deepStrictEqual(r, { kind: 'skip', reason: 'missing-namespace' });
+    });
+
+    test('Namespace from namespace:active contextValue routes by tree type', () => {
+        const item = new ClusterTreeItem(
+            'kube-system',
+            'namespace',
+            vscode.TreeItemCollapsibleState.None,
+            baseResourceData()
+        );
+        item.contextValue = 'namespace:active';
+
+        const r = resolveSpecializedDescribeFromTreeItem(item);
+        assert.strictEqual(r?.kind, 'namespace');
+        if (r?.kind === 'namespace') {
+            assert.strictEqual(r.namespaceConfig.name, 'kube-system');
+            assert.strictEqual(r.namespaceConfig.context, sampleContextName);
+            assert.strictEqual(r.namespaceConfig.metadata.name, 'kube-system');
+        }
+    });
+
+    test('NamespaceTreeItem uses stored status and metadata', () => {
+        const meta: k8s.V1ObjectMeta = {
+            name: 'demo',
+            uid: 'abc',
+            annotations: {}
+        };
+        const statusPh: k8s.V1NamespaceStatus = {
+            phase: 'Terminating'
+        };
+        const nsItem = new NamespaceTreeItem(
+            {
+                name: 'demo',
+                status: statusPh,
+                metadata: meta,
+                context: sampleContextName
+            },
+            baseResourceData({ resourceName: 'demo' })
+        );
+
+        const r = resolveSpecializedDescribeFromTreeItem(nsItem);
+        assert.strictEqual(r?.kind, 'namespace');
+        if (r?.kind === 'namespace') {
+            assert.strictEqual(r.namespaceConfig.status.phase, 'Terminating');
+            assert.strictEqual(r.namespaceConfig.metadata.uid, 'abc');
+        }
+    });
+
+    test('CronJob requires namespace', () => {
+        const item = new ClusterTreeItem(
+            'cj',
+            'cronjob',
+            vscode.TreeItemCollapsibleState.None,
+            baseResourceData({ resourceName: 'cj' })
+        );
+        item.contextValue = 'resource:CronJob';
+
+        assert.deepStrictEqual(resolveSpecializedDescribeFromTreeItem(item), {
+            kind: 'skip',
+            reason: 'missing-namespace'
+        });
+    });
+
+    test('CronJob with namespace routes', () => {
+        const item = new ClusterTreeItem(
+            'cj',
+            'cronjob',
+            vscode.TreeItemCollapsibleState.None,
+            baseResourceData({ namespace: 'ns', resourceName: 'cj' })
+        );
+        item.contextValue = 'resource:CronJob';
+
+        const r = resolveSpecializedDescribeFromTreeItem(item);
+        assert.deepStrictEqual(r, {
+            kind: 'cronjob',
+            name: 'cj',
+            namespace: 'ns',
+            context: sampleContextName
+        });
+    });
+
+    test('Node routes cluster-scoped', () => {
+        const item = new ClusterTreeItem(
+            'node-1',
+            'nodes',
+            vscode.TreeItemCollapsibleState.None,
+            baseResourceData({ resourceName: 'node-1' })
+        );
+        item.contextValue = 'resource:Node';
+
+        const r = resolveSpecializedDescribeFromTreeItem(item);
+        assert.deepStrictEqual(r, {
+            kind: 'node',
+            name: 'node-1',
+            context: sampleContextName
+        });
+    });
+
+    test('Deployment is not specialized here', () => {
+        const item = new ClusterTreeItem(
+            'd1',
+            'deployment',
+            vscode.TreeItemCollapsibleState.None,
+            baseResourceData({ namespace: 'ns', resourceName: 'd1' })
+        );
+        item.contextValue = 'resource:Deployment';
+
+        assert.strictEqual(resolveSpecializedDescribeFromTreeItem(item), undefined);
+    });
+});

--- a/src/webview/DescribeWebview.ts
+++ b/src/webview/DescribeWebview.ts
@@ -19,6 +19,7 @@ import { getHelpController } from '../extension';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 import { NamespaceTreeItemConfig } from '../tree/items/NamespaceTreeItem';
 import { setNamespace } from '../utils/kubectlContext';
+import { resolveSpecializedDescribeFromTreeItem } from './describeTreeRouting';
 
 /**
  * Resource information for the Describe webview.
@@ -407,6 +408,45 @@ export class DescribeWebview {
         if (!treeItem || !treeItem.resourceData) {
             vscode.window.showErrorMessage('Unable to describe: missing resource data');
             return;
+        }
+
+        const specialized = resolveSpecializedDescribeFromTreeItem(treeItem);
+        if (specialized) {
+            if (specialized.kind === 'skip') {
+                vscode.window.showErrorMessage('Unable to describe: namespace is required');
+                return;
+            }
+            if (specialized.kind === 'pod') {
+                await DescribeWebview.showPodDescribe(context, specialized.podConfig);
+                return;
+            }
+            if (specialized.kind === 'namespace') {
+                await DescribeWebview.showNamespaceDescribe(context, specialized.namespaceConfig);
+                return;
+            }
+            if (specialized.kind === 'cronjob') {
+                const kubeconfigPath = KubeconfigParser.getKubeconfigPath();
+                const { CronJobDescribeWebview } = await import('./CronJobDescribeWebview');
+                await CronJobDescribeWebview.show(
+                    context,
+                    specialized.name,
+                    specialized.namespace,
+                    kubeconfigPath,
+                    specialized.context
+                );
+                return;
+            }
+            if (specialized.kind === 'node') {
+                const kubeconfigPath = KubeconfigParser.getKubeconfigPath();
+                const { NodeDescribeWebview } = await import('./NodeDescribeWebview');
+                await NodeDescribeWebview.show(
+                    context,
+                    specialized.name,
+                    kubeconfigPath,
+                    specialized.context
+                );
+                return;
+            }
         }
 
         // Extract kind from contextValue (e.g., "Pod" from "resource:Pod")

--- a/src/webview/DescribeWebview.ts
+++ b/src/webview/DescribeWebview.ts
@@ -426,8 +426,8 @@ export class DescribeWebview {
             }
             if (specialized.kind === 'cronjob') {
                 const kubeconfigPath = KubeconfigParser.getKubeconfigPath();
-                const { CronJobDescribeWebview } = await import('./CronJobDescribeWebview');
-                await CronJobDescribeWebview.show(
+                const cronJobDescribeModule = await import('./CronJobDescribeWebview');
+                await cronJobDescribeModule.CronJobDescribeWebview.show(
                     context,
                     specialized.name,
                     specialized.namespace,
@@ -438,8 +438,8 @@ export class DescribeWebview {
             }
             if (specialized.kind === 'node') {
                 const kubeconfigPath = KubeconfigParser.getKubeconfigPath();
-                const { NodeDescribeWebview } = await import('./NodeDescribeWebview');
-                await NodeDescribeWebview.show(
+                const nodeDescribeModule = await import('./NodeDescribeWebview');
+                await nodeDescribeModule.NodeDescribeWebview.show(
                     context,
                     specialized.name,
                     kubeconfigPath,

--- a/src/webview/describeTreeRouting.ts
+++ b/src/webview/describeTreeRouting.ts
@@ -1,0 +1,124 @@
+import * as k8s from '@kubernetes/client-node';
+import { ClusterTreeItem } from '../tree/ClusterTreeItem';
+import { NamespaceTreeItem } from '../tree/items/NamespaceTreeItem';
+import { PodTreeItem, PodStatus } from '../tree/items/PodTreeItem';
+
+function kindFromTreeContext(contextValue: string | undefined): string {
+    if (!contextValue) {
+        return 'Unknown';
+    }
+    const parts = contextValue.split(':');
+    return parts.length > 1 ? parts[1] : contextValue;
+}
+
+export type SpecializedDescribeResolution =
+    | {
+          kind: 'pod';
+          podConfig: {
+              name: string;
+              namespace: string;
+              status?: PodStatus;
+              metadata: Record<string, unknown>;
+              context: string;
+          };
+      }
+    | {
+          kind: 'namespace';
+          namespaceConfig: {
+              name: string;
+              status: k8s.V1NamespaceStatus;
+              metadata: k8s.V1ObjectMeta;
+              context: string;
+          };
+      }
+    | { kind: 'cronjob'; name: string; namespace: string; context: string }
+    | { kind: 'node'; name: string; context: string }
+    | { kind: 'skip'; reason: 'missing-namespace' };
+
+/**
+ * Maps a cluster tree item to a specialized describe target (Pod / Namespace / CronJob / Node).
+ * Context-menu **Describe** uses `kube9.describeResource` → `DescribeWebview.showFromTreeItem`; this
+ * must align with the default commands on those items (e.g. `kube9.describePod`) so both paths
+ * open the same structured webviews.
+ *
+ * Returns `undefined` when the generic Describe stub should handle the kind.
+ */
+export function resolveSpecializedDescribeFromTreeItem(
+    treeItem: ClusterTreeItem
+): SpecializedDescribeResolution | undefined {
+    if (!treeItem.resourceData) {
+        return undefined;
+    }
+
+    const contextName = treeItem.resourceData.context.name;
+    const name = treeItem.resourceData.resourceName || (treeItem.label as string);
+    const namespace = treeItem.resourceData.namespace;
+    const kind = kindFromTreeContext(treeItem.contextValue);
+
+    const isNamespaceItem = treeItem.type === 'namespace' || kind === 'Namespace';
+
+    if (isNamespaceItem) {
+        if (treeItem instanceof NamespaceTreeItem) {
+            const ni = treeItem.namespaceInfo;
+            return {
+                kind: 'namespace',
+                namespaceConfig: {
+                    name: ni.name,
+                    status: ni.status,
+                    metadata: ni.metadata,
+                    context: contextName
+                }
+            };
+        }
+        return {
+            kind: 'namespace',
+            namespaceConfig: {
+                name,
+                status: { phase: 'Active' } as k8s.V1NamespaceStatus,
+                metadata: { name } as k8s.V1ObjectMeta,
+                context: contextName
+            }
+        };
+    }
+
+    if (kind === 'Pod') {
+        if (!namespace) {
+            return { kind: 'skip', reason: 'missing-namespace' };
+        }
+        if (treeItem instanceof PodTreeItem) {
+            return {
+                kind: 'pod',
+                podConfig: {
+                    name,
+                    namespace,
+                    status: treeItem.podInfo.status,
+                    metadata: {},
+                    context: contextName
+                }
+            };
+        }
+        return {
+            kind: 'pod',
+            podConfig: {
+                name,
+                namespace,
+                status: 'Unknown',
+                metadata: {},
+                context: contextName
+            }
+        };
+    }
+
+    if (kind === 'CronJob') {
+        if (!namespace) {
+            return { kind: 'skip', reason: 'missing-namespace' };
+        }
+        return { kind: 'cronjob', name, namespace, context: contextName };
+    }
+
+    if (kind === 'Node') {
+        return { kind: 'node', name, context: contextName };
+    }
+
+    return undefined;
+}


### PR DESCRIPTION
## Summary

- Route `kube9.describeResource` (tree/context-menu **Describe**) through the same specialized describe flows as primary actions for **Pod**, **Namespace**, **CronJob**, and **Node**, instead of the generic `DescribeWebview.show` stub.
- Add `resolveSpecializedDescribeFromTreeItem` plus unit tests so namespace rows that use `namespace:active` / `namespace:inactive` (not `resource:Namespace`) still resolve correctly.

Fixes #146

## Test plan

- [x] `npm run compile`, `npm run lint`, `npm run test:unit`
- [ ] Extension Development Host: context-menu **Describe** on Pod, Namespace (names category), CronJob, Node opens the structured detail panels; **Describe (Raw)** unchanged.