### PR TITLE
feat(describe): StatefulSet structured detail page

### DIFF
--- a/src/kubectl/WorkloadCommands.ts
+++ b/src/kubectl/WorkloadCommands.ts
@@ -143,6 +143,38 @@ export interface DeploymentEventsResult {
 }
 
 /**
+ * Result of a StatefulSet details query.
+ */
+export interface StatefulSetDetailsResult {
+    statefulSet?: k8s.V1StatefulSet;
+    error?: KubectlError;
+}
+
+/**
+ * Result of listing events for a StatefulSet.
+ */
+export interface StatefulSetEventsResult {
+    events: k8s.CoreV1Event[];
+    error?: KubectlError;
+}
+
+/**
+ * Full Pod objects returned for a label selector (describe views).
+ */
+export interface V1PodsResult {
+    pods: k8s.V1Pod[];
+    error?: KubectlError;
+}
+
+/**
+ * PVC list for a namespace.
+ */
+export interface PersistentVolumeClaimsResult {
+    items: k8s.V1PersistentVolumeClaim[];
+    error?: KubectlError;
+}
+
+/**
  * Result of a ReplicaSets query operation.
  */
 export interface ReplicaSetsResult {
@@ -595,6 +627,157 @@ export class WorkloadCommands {
             
             return {
                 events: [],
+                error: kubectlError
+            };
+        }
+    }
+
+    /**
+     * Fetches a single StatefulSet by name.
+     */
+    public static async getStatefulSetDetails(
+        statefulSetName: string,
+        namespace: string,
+        kubeconfigPath: string,
+        contextName: string
+    ): Promise<StatefulSetDetailsResult> {
+        try {
+            const apiClient = getKubernetesApiClient();
+            apiClient.setContext(contextName);
+
+            const resource = await apiClient.apps.readNamespacedStatefulSet({
+                name: statefulSetName,
+                namespace
+            });
+
+            return {
+                statefulSet: resource,
+                error: undefined
+            };
+        } catch (error: unknown) {
+            const kubectlError = KubectlError.fromExecError(error, contextName);
+            console.log(
+                `StatefulSet details query failed for ${statefulSetName} in namespace ${namespace} in context ${contextName}: ${kubectlError.getDetails()}`
+            );
+            return {
+                statefulSet: undefined,
+                error: kubectlError
+            };
+        }
+    }
+
+    /**
+     * Lists namespace events involving this StatefulSet.
+     */
+    public static async getStatefulSetEvents(
+        statefulSetName: string,
+        namespace: string,
+        kubeconfigPath: string,
+        contextName: string
+    ): Promise<StatefulSetEventsResult> {
+        try {
+            const apiClient = getKubernetesApiClient();
+            apiClient.setContext(contextName);
+
+            const response = await apiClient.core.listNamespacedEvent({
+                namespace,
+                timeoutSeconds: 10
+            });
+
+            const allEvents = response.items || [];
+            const filteredEvents = allEvents.filter(
+                event =>
+                    event.involvedObject?.kind === 'StatefulSet' &&
+                    event.involvedObject?.name === statefulSetName
+            );
+
+            const sortedEvents = filteredEvents.sort((a, b) => {
+                const aTimestamp = a.lastTimestamp || a.firstTimestamp || '';
+                const bTimestamp = b.lastTimestamp || b.firstTimestamp || '';
+                if (aTimestamp > bTimestamp) {
+                    return -1;
+                }
+                if (aTimestamp < bTimestamp) {
+                    return 1;
+                }
+                return 0;
+            });
+
+            return {
+                events: sortedEvents,
+                error: undefined
+            };
+        } catch (error: unknown) {
+            const kubectlError = KubectlError.fromExecError(error, contextName);
+            console.log(
+                `StatefulSet events query failed for ${statefulSetName} in namespace ${namespace} in context ${contextName}: ${kubectlError.getDetails()}`
+            );
+            return {
+                events: [],
+                error: kubectlError
+            };
+        }
+    }
+
+    /**
+     * Returns full Pod objects for a namespaced label selector (used by StatefulSet describe).
+     */
+    public static async getV1PodsForLabelSelector(
+        namespace: string,
+        labelSelector: string,
+        _kubeconfigPath: string,
+        contextName: string
+    ): Promise<V1PodsResult> {
+        try {
+            if (!labelSelector) {
+                return { pods: [] };
+            }
+            const apiClient = getKubernetesApiClient();
+            apiClient.setContext(contextName);
+
+            const v1Pods = await fetchPods({
+                namespace,
+                labelSelector,
+                timeout: 10
+            });
+
+            return { pods: v1Pods };
+        } catch (error: unknown) {
+            const kubectlError = KubectlError.fromExecError(error, contextName);
+            console.log(`Pod query failed for labelSelector in ${namespace}: ${kubectlError.getDetails()}`);
+            return {
+                pods: [],
+                error: kubectlError
+            };
+        }
+    }
+
+    /**
+     * Lists PVCs in a namespace (filtered client-side for StatefulSetordinal claims).
+     */
+    public static async listNamespacedPersistentVolumeClaims(
+        namespace: string,
+        _kubeconfigPath: string,
+        contextName: string
+    ): Promise<PersistentVolumeClaimsResult> {
+        try {
+            const apiClient = getKubernetesApiClient();
+            apiClient.setContext(contextName);
+
+            const response = await apiClient.core.listNamespacedPersistentVolumeClaim({
+                namespace,
+                timeoutSeconds: 10
+            });
+
+            return {
+                items: response.items || [],
+                error: undefined
+            };
+        } catch (error: unknown) {
+            const kubectlError = KubectlError.fromExecError(error, contextName);
+            console.log(`PVC list failed for ${namespace}: ${kubectlError.getDetails()}`);
+            return {
+                items: [],
                 error: kubectlError
             };
         }

--- a/src/test/suite/webview/statefulSetDataTransformer.test.ts
+++ b/src/test/suite/webview/statefulSetDataTransformer.test.ts
@@ -98,4 +98,71 @@ suite('statefulSetDataTransformer', () => {
         assert.ok(p1);
         assert.strictEqual(p1!.found, false);
     });
+
+    test('honors spec.ordinals.start for pod and PVC rows', () => {
+        const sts: k8s.V1StatefulSet = {
+            metadata: {
+                name: 'web',
+                namespace: 'ns1',
+                creationTimestamp: new Date('2020-01-01T00:00:00.000Z')
+            },
+            spec: {
+                replicas: 2,
+                ordinals: { start: 3 },
+                serviceName: 'web',
+                selector: { matchLabels: { app: 'web' } },
+                template: { spec: { containers: [{ name: 'nginx', image: 'nginx' }] } },
+                volumeClaimTemplates: [
+                    {
+                        metadata: { name: 'data' },
+                        spec: {
+                            accessModes: ['ReadWriteOnce'],
+                            resources: { requests: { storage: '1Gi' } }
+                        }
+                    }
+                ]
+            },
+            status: { replicas: 2, readyReplicas: 2, currentReplicas: 2, updatedReplicas: 2 }
+        };
+
+        const pods: k8s.V1Pod[] = [
+            {
+                metadata: { name: 'web-3', namespace: 'ns1' },
+                spec: { nodeName: 'node-a', containers: [] },
+                status: { phase: 'Running', conditions: [{ type: 'Ready', status: 'True' }] }
+            },
+            {
+                metadata: { name: 'web-4', namespace: 'ns1' },
+                spec: { nodeName: 'node-b', containers: [] },
+                status: { phase: 'Running', conditions: [{ type: 'Ready', status: 'True' }] }
+            }
+        ];
+
+        const pvcs: k8s.V1PersistentVolumeClaim[] = [
+            {
+                metadata: { name: 'data-web-3', namespace: 'ns1' },
+                status: { phase: 'Bound', capacity: { storage: '1Gi' } }
+            },
+            {
+                metadata: { name: 'data-web-4', namespace: 'ns1' },
+                status: { phase: 'Bound', capacity: { storage: '1Gi' } }
+            }
+        ];
+
+        const data = transformStatefulSetData(sts, pods, pvcs, []);
+
+        assert.deepStrictEqual(
+            data.ordinalPods.map(r => r.ordinal),
+            [3, 4]
+        );
+        assert.strictEqual(data.ordinalPods[0].expectedPodName, 'web-3');
+        assert.strictEqual(data.ordinalPods[1].expectedPodName, 'web-4');
+        assert.deepStrictEqual(
+            data.ordinalPvcs.map(r => ({ ordinal: r.ordinal, pvcName: r.pvcName, found: r.found })),
+            [
+                { ordinal: 3, pvcName: 'data-web-3', found: true },
+                { ordinal: 4, pvcName: 'data-web-4', found: true }
+            ]
+        );
+    });
 });

--- a/src/test/suite/webview/statefulSetDataTransformer.test.ts
+++ b/src/test/suite/webview/statefulSetDataTransformer.test.ts
@@ -1,0 +1,101 @@
+import * as assert from 'assert';
+import * as k8s from '@kubernetes/client-node';
+import { transformStatefulSetData } from '../../../webview/statefulSetDataTransformer';
+
+suite('statefulSetDataTransformer', () => {
+    test('shapes overview, ordinal pods, and PVC naming', () => {
+        const sts: k8s.V1StatefulSet = {
+            metadata: {
+                name: 'web',
+                namespace: 'ns1',
+                creationTimestamp: new Date('2020-01-01T00:00:00.000Z'),
+                generation: 2,
+                labels: { app: 'web' }
+            },
+            spec: {
+                replicas: 2,
+                serviceName: 'web',
+                selector: { matchLabels: { app: 'web' } },
+                template: {
+                    spec: {
+                        containers: [{ name: 'nginx', image: 'nginx:1.25' }]
+                    }
+                },
+                volumeClaimTemplates: [
+                    {
+                        metadata: { name: 'data' },
+                        spec: {
+                            accessModes: ['ReadWriteOnce'],
+                            resources: { requests: { storage: '1Gi' } }
+                        }
+                    }
+                ],
+                updateStrategy: { type: 'RollingUpdate', rollingUpdate: { partition: 0 } },
+                podManagementPolicy: 'OrderedReady'
+            },
+            status: {
+                replicas: 2,
+                readyReplicas: 1,
+                currentReplicas: 2,
+                updatedReplicas: 2,
+                observedGeneration: 2,
+                currentRevision: 'web-abc',
+                updateRevision: 'web-def',
+                collisionCount: 0
+            }
+        };
+
+        const pods: k8s.V1Pod[] = [
+            {
+                metadata: {
+                    name: 'web-0',
+                    namespace: 'ns1',
+                    creationTimestamp: new Date('2020-01-02T00:00:00.000Z')
+                },
+                spec: { nodeName: 'node-a', containers: [] },
+                status: {
+                    phase: 'Running',
+                    conditions: [{ type: 'Ready', status: 'True' }],
+                    containerStatuses: [
+                        {
+                            name: 'nginx',
+                            restartCount: 0,
+                            image: 'nginx:1.25',
+                            imageID: 'docker.io/library/nginx@sha256:abc',
+                            ready: true
+                        }
+                    ]
+                }
+            }
+        ];
+
+        const pvcs: k8s.V1PersistentVolumeClaim[] = [
+            {
+                metadata: { name: 'data-web-0', namespace: 'ns1' },
+                spec: { storageClassName: 'standard' },
+                status: { phase: 'Bound', capacity: { storage: '1Gi' } }
+            }
+        ];
+
+        const data = transformStatefulSetData(sts, pods, pvcs, []);
+
+        assert.strictEqual(data.overview.replicas, 2);
+        assert.strictEqual(data.overview.serviceName, 'web');
+        assert.strictEqual(data.overview.selectorDisplay, 'app=web');
+        assert.strictEqual(data.replicaStatus.ready, 1);
+        assert.strictEqual(data.ordinalPods.length, 2);
+        assert.strictEqual(data.ordinalPods[0].podPresent, true);
+        assert.strictEqual(data.ordinalPods[0].phase, 'Running');
+        assert.strictEqual(data.ordinalPods[1].podPresent, false);
+
+        assert.strictEqual(data.ordinalPvcs.length, 2);
+        const p0 = data.ordinalPvcs.find(r => r.ordinal === 0 && r.templateName === 'data');
+        assert.ok(p0);
+        assert.strictEqual(p0!.found, true);
+        assert.strictEqual(p0!.phase, 'Bound');
+
+        const p1 = data.ordinalPvcs.find(r => r.ordinal === 1 && r.templateName === 'data');
+        assert.ok(p1);
+        assert.strictEqual(p1!.found, false);
+    });
+});

--- a/src/test/suite/webview/statefulSetDescribeWebviewBindings.test.ts
+++ b/src/test/suite/webview/statefulSetDescribeWebviewBindings.test.ts
@@ -1,0 +1,222 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as k8s from '@kubernetes/client-node';
+import { getResourceCache } from '../../../kubernetes/cache';
+import { KubectlError, KubectlErrorType } from '../../../kubernetes/KubectlError';
+import { WorkloadCommands } from '../../../kubectl/WorkloadCommands';
+import { DescribeWebview } from '../../../webview/DescribeWebview';
+import { StatefulSetDescribeWebview } from '../../../webview/StatefulSetDescribeWebview';
+
+type MockWebviewWithFire = vscode.Webview & { _fireMessage(message: unknown): void };
+
+async function flushAsyncWork(): Promise<void> {
+    await new Promise<void>(resolve => setImmediate(resolve));
+}
+
+function stsPanel(): vscode.WebviewPanel | undefined {
+    return (
+        StatefulSetDescribeWebview as unknown as {
+            currentPanel?: vscode.WebviewPanel;
+        }
+    ).currentPanel;
+}
+
+const MIN_STS_TEMPLATE: () => k8s.V1StatefulSet = () => ({
+    metadata: {
+        name: 'web',
+        namespace: 'ns1',
+        creationTimestamp: new Date('2020-01-01T00:00:00.000Z'),
+        generation: 1,
+        labels: { app: 'web' }
+    },
+    spec: {
+        replicas: 1,
+        serviceName: 'web',
+        selector: { matchLabels: { app: 'web' } },
+        template: {
+            spec: {
+                containers: [{ name: 'nginx', image: 'nginx' }]
+            }
+        },
+        updateStrategy: { type: 'RollingUpdate' },
+        podManagementPolicy: 'OrderedReady'
+    },
+    status: {
+        replicas: 1,
+        readyReplicas: 0,
+        currentReplicas: 1,
+        updatedReplicas: 1,
+        observedGeneration: 1
+    }
+});
+
+suite('StatefulSetDescribeWebview panel bindings', () => {
+    let mockContext: vscode.ExtensionContext;
+
+    let origGetDetails: typeof WorkloadCommands.getStatefulSetDetails;
+    let origGetPods: typeof WorkloadCommands.getV1PodsForLabelSelector;
+    let origPvcs: typeof WorkloadCommands.listNamespacedPersistentVolumeClaims;
+    let origEvents: typeof WorkloadCommands.getStatefulSetEvents;
+
+    setup(() => {
+        mockContext = {
+            subscriptions: [],
+            extensionUri: vscode.Uri.file('/mock/extension/path'),
+            extensionPath: '/mock/extension/path'
+        } as unknown as vscode.ExtensionContext;
+
+        origGetDetails = WorkloadCommands.getStatefulSetDetails;
+        origGetPods = WorkloadCommands.getV1PodsForLabelSelector;
+        origPvcs = WorkloadCommands.listNamespacedPersistentVolumeClaims;
+        origEvents = WorkloadCommands.getStatefulSetEvents;
+
+        WorkloadCommands.getStatefulSetDetails = async () =>
+            ({
+                statefulSet: MIN_STS_TEMPLATE(),
+                error: undefined
+            }) as Awaited<ReturnType<typeof WorkloadCommands.getStatefulSetDetails>>;
+
+        WorkloadCommands.getV1PodsForLabelSelector = async () => ({ pods: [] });
+
+        WorkloadCommands.listNamespacedPersistentVolumeClaims = async () =>
+            ({
+                items: []
+            }) as Awaited<ReturnType<typeof WorkloadCommands.listNamespacedPersistentVolumeClaims>>;
+
+        WorkloadCommands.getStatefulSetEvents = async () => ({ events: [] });
+
+        getResourceCache().clear();
+        (vscode.window as unknown as { _clearMessages(): void })._clearMessages();
+        DescribeWebview.setSharedPanel(undefined);
+    });
+
+    teardown(async () => {
+        WorkloadCommands.getStatefulSetDetails = origGetDetails;
+        WorkloadCommands.getV1PodsForLabelSelector = origGetPods;
+        WorkloadCommands.listNamespacedPersistentVolumeClaims = origPvcs;
+        WorkloadCommands.getStatefulSetEvents = origEvents;
+
+        const panel = stsPanel();
+        DescribeWebview.setSharedPanel(undefined);
+        panel?.dispose();
+        await flushAsyncWork();
+
+        getResourceCache().clear();
+        (vscode.commands as unknown as { _unregisterCommand(name: string): void })._unregisterCommand('kube9.revealPod');
+
+        if (mockContext?.subscriptions?.length) {
+            for (const sub of mockContext.subscriptions) {
+                sub?.dispose?.();
+            }
+            mockContext.subscriptions.length = 0;
+        }
+    });
+
+    test('shared Describe panel path wires message handlers (navigateToPod)', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        const revealArgs: unknown[] = [];
+        (vscode.commands as unknown as { _registerCommand(c: string, h: (...args: unknown[]) => Thenable<unknown>): void })._registerCommand(
+            'kube9.revealPod',
+            async (...args: unknown[]) => {
+                revealArgs.push(args);
+            }
+        );
+
+        await StatefulSetDescribeWebview.show(mockContext, 'web', 'ns1', '/kc', 'ctx-a');
+
+        const panel = stsPanel();
+        assert.ok(panel);
+        assert.strictEqual(panel, prePanel);
+
+        const wv = panel!.webview as unknown as MockWebviewWithFire;
+        wv._fireMessage({ command: 'navigateToPod', podName: 'web-0' });
+        await flushAsyncWork();
+
+        assert.strictEqual(revealArgs.length, 1);
+        assert.deepStrictEqual(revealArgs[0], ['web-0', 'ns1']);
+    });
+
+    test('re-show on shared panel replaces handlers so refresh does not stack duplicate API calls', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        let detailHits = 0;
+        WorkloadCommands.getStatefulSetDetails = async () => {
+            detailHits += 1;
+            return {
+                statefulSet: MIN_STS_TEMPLATE(),
+                error: undefined
+            } as Awaited<ReturnType<typeof WorkloadCommands.getStatefulSetDetails>>;
+        };
+
+        await StatefulSetDescribeWebview.show(mockContext, 'sts-a', 'ns1', '/kc', 'ctx-a');
+        assert.strictEqual(detailHits, 1);
+
+        const panel = stsPanel()!;
+        const wv = panel.webview as unknown as MockWebviewWithFire;
+        wv._fireMessage({ command: 'refresh' });
+        await flushAsyncWork();
+        assert.strictEqual(detailHits, 2);
+
+        await StatefulSetDescribeWebview.show(mockContext, 'sts-b', 'ns1', '/kc', 'ctx-a');
+        assert.strictEqual(detailHits, 3);
+
+        wv._fireMessage({ command: 'refresh' });
+        await flushAsyncWork();
+        assert.strictEqual(detailHits, 4, 'Duplicate message listeners would issue extra getStatefulSetDetails calls');
+    });
+
+    test('shared panel path surfaces API failures via webview error message', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        WorkloadCommands.getStatefulSetDetails = async () =>
+            ({
+                statefulSet: undefined,
+                error: new KubectlError(
+                    KubectlErrorType.PermissionDenied,
+                    'Forbidden',
+                    'forbidden',
+                    'ctx-a'
+                )
+            }) as Awaited<ReturnType<typeof WorkloadCommands.getStatefulSetDetails>>;
+
+        const posted: unknown[] = [];
+        const bindPm = prePanel.webview.postMessage.bind(prePanel.webview);
+        prePanel.webview.postMessage = (msg: unknown) => {
+            posted.push(msg);
+            return bindPm(msg);
+        };
+
+        await StatefulSetDescribeWebview.show(mockContext, 'web', 'ns1', '/kc', 'ctx-a');
+        await flushAsyncWork();
+
+        assert.ok(posted.some(m => typeof m === 'object' && m !== null && (m as { command?: string }).command === 'error'));
+    });
+
+    test('disposing the panel clears StatefulSet Describe static panel pointer', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        await StatefulSetDescribeWebview.show(mockContext, 'web', 'ns1', '/kc', 'ctx-a');
+        assert.strictEqual(stsPanel(), prePanel);
+
+        prePanel.dispose();
+        await flushAsyncWork();
+        assert.strictEqual(stsPanel(), undefined);
+    });
+});

--- a/src/test/suite/webview/statefulSetDescribeWebviewBindings.test.ts
+++ b/src/test/suite/webview/statefulSetDescribeWebviewBindings.test.ts
@@ -4,6 +4,7 @@ import * as k8s from '@kubernetes/client-node';
 import { getResourceCache } from '../../../kubernetes/cache';
 import { KubectlError, KubectlErrorType } from '../../../kubernetes/KubectlError';
 import { WorkloadCommands } from '../../../kubectl/WorkloadCommands';
+import { DeploymentDescribeWebview } from '../../../webview/DeploymentDescribeWebview';
 import { DescribeWebview } from '../../../webview/DescribeWebview';
 import { StatefulSetDescribeWebview } from '../../../webview/StatefulSetDescribeWebview';
 
@@ -290,6 +291,79 @@ suite('StatefulSetDescribeWebview panel bindings', () => {
             assert.ok(stsDetailHits > stsLoadsBeforeRefresh, 'Refresh should reload StatefulSet data');
         } finally {
             origLoadPod.loadPodData = realLoadPod;
+        }
+    });
+
+    test('reusing panel after Deployment describe clears Deployment refresh handlers', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        let deploymentDetailHits = 0;
+        const origGetDeployment = WorkloadCommands.getDeploymentDetails;
+        const origGetRs = WorkloadCommands.getRelatedReplicaSets;
+        const origGetEvents = WorkloadCommands.getDeploymentEvents;
+
+        WorkloadCommands.getDeploymentDetails = async () => {
+            deploymentDetailHits += 1;
+            return {
+                deployment: {
+                    metadata: { name: 'nginx', namespace: 'ns1', uid: 'dep-uid' },
+                    spec: {
+                        replicas: 1,
+                        selector: { matchLabels: { app: 'nginx' } },
+                        template: { spec: { containers: [{ name: 'nginx', image: 'nginx' }] } }
+                    },
+                    status: {}
+                },
+                error: undefined
+            } as Awaited<ReturnType<typeof WorkloadCommands.getDeploymentDetails>>;
+        };
+        WorkloadCommands.getRelatedReplicaSets = async () => ({ replicaSets: [] });
+        WorkloadCommands.getDeploymentEvents = async () => ({ events: [] });
+
+        try {
+            await DeploymentDescribeWebview.show(mockContext, 'nginx', 'ns1', '/kc', 'ctx-a');
+            assert.strictEqual(deploymentDetailHits, 1);
+
+            await StatefulSetDescribeWebview.show(mockContext, 'web', 'ns1', '/kc', 'ctx-a');
+
+            const dw = DeploymentDescribeWebview as unknown as {
+                messageSubscription?: vscode.Disposable;
+            };
+            assert.strictEqual(
+                dw.messageSubscription,
+                undefined,
+                'Deployment subscription must be released when StatefulSet takes the shared panel'
+            );
+
+            let stsDetailHits = 0;
+            WorkloadCommands.getStatefulSetDetails = async () => {
+                stsDetailHits += 1;
+                return {
+                    statefulSet: MIN_STS_TEMPLATE(),
+                    error: undefined
+                } as Awaited<ReturnType<typeof WorkloadCommands.getStatefulSetDetails>>;
+            };
+
+            const wv = prePanel.webview as unknown as MockWebviewWithFire;
+            const deploymentHitsBeforeRefresh = deploymentDetailHits;
+            const stsHitsBeforeRefresh = stsDetailHits;
+            wv._fireMessage({ command: 'refresh' });
+            await flushUntil(() => stsDetailHits > stsHitsBeforeRefresh);
+
+            assert.strictEqual(
+                deploymentDetailHits,
+                deploymentHitsBeforeRefresh,
+                'Leaked Deployment refresh must not fetch deployment data after StatefulSet takeover'
+            );
+            assert.ok(stsDetailHits > stsHitsBeforeRefresh, 'Refresh should reload StatefulSet data');
+        } finally {
+            WorkloadCommands.getDeploymentDetails = origGetDeployment;
+            WorkloadCommands.getRelatedReplicaSets = origGetRs;
+            WorkloadCommands.getDeploymentEvents = origGetEvents;
         }
     });
 });

--- a/src/test/suite/webview/statefulSetDescribeWebviewBindings.test.ts
+++ b/src/test/suite/webview/statefulSetDescribeWebviewBindings.test.ts
@@ -13,6 +13,15 @@ async function flushAsyncWork(): Promise<void> {
     await new Promise<void>(resolve => setImmediate(resolve));
 }
 
+async function flushUntil(predicate: () => boolean, maxTicks = 80): Promise<void> {
+    for (let i = 0; i < maxTicks; i++) {
+        if (predicate()) {
+            return;
+        }
+        await flushAsyncWork();
+    }
+}
+
 function stsPanel(): vscode.WebviewPanel | undefined {
     return (
         StatefulSetDescribeWebview as unknown as {
@@ -218,5 +227,69 @@ suite('StatefulSetDescribeWebview panel bindings', () => {
         prePanel.dispose();
         await flushAsyncWork();
         assert.strictEqual(stsPanel(), undefined);
+    });
+
+    test('reusing a real Describe panel clears Describe bindings before StatefulSet handlers run', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        const dw = DescribeWebview as unknown as {
+            setupMessageHandling(p: vscode.WebviewPanel, c: vscode.ExtensionContext): void;
+            currentPodConfig?: { name: string; namespace: string; context: string };
+            describeMessageSubscription?: vscode.Disposable;
+        };
+        dw.currentPodConfig = { name: 'nginx-fake', namespace: 'ns1', context: 'ctx-a' };
+        dw.setupMessageHandling(prePanel, mockContext);
+        assert.ok(dw.describeMessageSubscription, 'Describe should register a message subscription');
+
+        let podRefreshHits = 0;
+        const origLoadPod = DescribeWebview as unknown as {
+            loadPodData(
+                podConfig: { name: string; namespace: string; context: string },
+                panel: vscode.WebviewPanel
+            ): Promise<void>;
+        };
+        const realLoadPod = origLoadPod.loadPodData.bind(DescribeWebview);
+        origLoadPod.loadPodData = async (podConfig, panel) => {
+            podRefreshHits += 1;
+            return realLoadPod(podConfig, panel);
+        };
+
+        let stsDetailHits = 0;
+        WorkloadCommands.getStatefulSetDetails = async () => {
+            stsDetailHits += 1;
+            return {
+                statefulSet: MIN_STS_TEMPLATE(),
+                error: undefined
+            } as Awaited<ReturnType<typeof WorkloadCommands.getStatefulSetDetails>>;
+        };
+
+        try {
+            await StatefulSetDescribeWebview.show(mockContext, 'web', 'ns1', '/kc', 'ctx-a');
+
+            assert.strictEqual(
+                dw.describeMessageSubscription,
+                undefined,
+                'Describe subscription must be released when StatefulSet takes the shared panel'
+            );
+            assert.strictEqual(
+                dw.currentPodConfig,
+                undefined,
+                'Stale Describe resource config must be cleared for StatefulSet'
+            );
+
+            const wv = prePanel.webview as unknown as MockWebviewWithFire;
+            const stsLoadsBeforeRefresh = stsDetailHits;
+            wv._fireMessage({ command: 'refresh' });
+            await flushUntil(() => stsDetailHits > stsLoadsBeforeRefresh);
+
+            assert.strictEqual(podRefreshHits, 0, 'Leaked Describe refresh must not load Pod data');
+            assert.ok(stsDetailHits > stsLoadsBeforeRefresh, 'Refresh should reload StatefulSet data');
+        } finally {
+            origLoadPod.loadPodData = realLoadPod;
+        }
     });
 });

--- a/src/utils/webviewManager.ts
+++ b/src/utils/webviewManager.ts
@@ -7,6 +7,7 @@ import { HealthReportPanel } from '../webview/HealthReportPanel';
 import { HelmPackageManagerPanel } from '../webview/HelmPackageManagerPanel';
 import { NodeDescribeWebview } from '../webview/NodeDescribeWebview';
 import { DeploymentDescribeWebview } from '../webview/DeploymentDescribeWebview';
+import { StatefulSetDescribeWebview } from '../webview/StatefulSetDescribeWebview';
 import { TutorialWebview } from '../webview/TutorialWebview';
 import { ClusterManagerWebview } from '../webview/ClusterManagerWebview';
 import { ArgoCDApplicationWebviewProvider } from '../webview/ArgoCDApplicationWebviewProvider';
@@ -49,6 +50,7 @@ export async function closeWebviewsForContext(contextName: string): Promise<void
             { name: 'NamespaceWebview', getPanel: () => (NamespaceWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel },
             { name: 'TutorialWebview', getPanel: () => (TutorialWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel },
             { name: 'DeploymentDescribeWebview', getPanel: () => (DeploymentDescribeWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel },
+            { name: 'StatefulSetDescribeWebview', getPanel: () => (StatefulSetDescribeWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel },
             { name: 'NodeDescribeWebview', getPanel: () => (NodeDescribeWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel }
         ];
 

--- a/src/webview/CronJobDescribeWebview.ts
+++ b/src/webview/CronJobDescribeWebview.ts
@@ -4,6 +4,7 @@ import { transformCronJobData } from './cronJobDataTransformer';
 import { CronJobDescribeData } from '../providers/CronJobDescribeProvider';
 import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
 import { DescribeWebview } from './DescribeWebview';
+import { releaseExclusiveDescribePanelBindings } from './describeSharedPanelBindings';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 
 /**
@@ -54,6 +55,17 @@ export class CronJobDescribeWebview {
      */
     private static contextName: string | undefined;
 
+    private static messageSubscription: vscode.Disposable | undefined;
+    private static panelDisposeSubscription: vscode.Disposable | undefined;
+
+    /** Drops CronJob message handlers when another describe view takes the shared panel. */
+    public static releaseMessageBindings(): void {
+        CronJobDescribeWebview.messageSubscription?.dispose();
+        CronJobDescribeWebview.messageSubscription = undefined;
+        CronJobDescribeWebview.panelDisposeSubscription?.dispose();
+        CronJobDescribeWebview.panelDisposeSubscription = undefined;
+    }
+
     /**
      * Show the CronJob Describe webview for a cronjob.
      * Creates a new panel if none exists, or reuses and updates the existing panel.
@@ -72,6 +84,8 @@ export class CronJobDescribeWebview {
         kubeconfigPath: string,
         contextName: string
     ): Promise<void> {
+        releaseExclusiveDescribePanelBindings();
+
         // Store the extension context for later use
         CronJobDescribeWebview.extensionContext = context;
         CronJobDescribeWebview.currentCronJobName = cronjobName;
@@ -90,6 +104,7 @@ export class CronJobDescribeWebview {
             CronJobDescribeWebview.currentPanel.webview.html = CronJobDescribeWebview.getWebviewContent(
                 CronJobDescribeWebview.currentPanel.webview
             );
+            CronJobDescribeWebview.attachPanelBindings(CronJobDescribeWebview.currentPanel);
             await CronJobDescribeWebview.refreshCronJobData();
             CronJobDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
             return;
@@ -106,6 +121,7 @@ export class CronJobDescribeWebview {
             CronJobDescribeWebview.currentPanel.webview.html = CronJobDescribeWebview.getWebviewContent(
                 CronJobDescribeWebview.currentPanel.webview
             );
+            CronJobDescribeWebview.attachPanelBindings(CronJobDescribeWebview.currentPanel);
             await CronJobDescribeWebview.refreshCronJobData();
             CronJobDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
             // Register our panel as the shared panel
@@ -137,26 +153,29 @@ export class CronJobDescribeWebview {
             panel.webview
         );
 
-        // Set up message handlers
-        CronJobDescribeWebview.setupMessageHandlers(panel, context);
+        CronJobDescribeWebview.attachPanelBindings(panel);
 
         // Fetch and display initial data
         await CronJobDescribeWebview.refreshCronJobData();
+    }
 
-        // Handle panel disposal
-        panel.onDidDispose(
-            () => {
+    private static attachPanelBindings(panel: vscode.WebviewPanel): void {
+        CronJobDescribeWebview.releaseMessageBindings();
+        CronJobDescribeWebview.setupMessageHandlers(panel);
+
+        CronJobDescribeWebview.panelDisposeSubscription = panel.onDidDispose(() => {
+            if (CronJobDescribeWebview.currentPanel === panel) {
                 CronJobDescribeWebview.currentPanel = undefined;
                 CronJobDescribeWebview.currentCronJobName = undefined;
                 CronJobDescribeWebview.currentNamespace = undefined;
                 CronJobDescribeWebview.kubeconfigPath = undefined;
                 CronJobDescribeWebview.contextName = undefined;
-                // Clear the shared panel reference
-                DescribeWebview.setSharedPanel(undefined);
-            },
-            null,
-            context.subscriptions
-        );
+                if (DescribeWebview.getSharedPanel() === panel) {
+                    DescribeWebview.setSharedPanel(undefined);
+                }
+            }
+            CronJobDescribeWebview.releaseMessageBindings();
+        });
     }
 
     /**
@@ -272,11 +291,8 @@ export class CronJobDescribeWebview {
      * @param panel The webview panel
      * @param context The VS Code extension context
      */
-    private static setupMessageHandlers(
-        panel: vscode.WebviewPanel,
-        context: vscode.ExtensionContext
-    ): void {
-        panel.webview.onDidReceiveMessage(
+    private static setupMessageHandlers(panel: vscode.WebviewPanel): void {
+        CronJobDescribeWebview.messageSubscription = panel.webview.onDidReceiveMessage(
             async (message: WebviewMessage) => {
                 switch (message.command) {
                     case 'refresh': {
@@ -319,9 +335,7 @@ export class CronJobDescribeWebview {
                         console.log('Unknown message command:', message.command);
                     }
                 }
-            },
-            null,
-            context.subscriptions
+            }
         );
     }
 

--- a/src/webview/DeploymentDescribeWebview.ts
+++ b/src/webview/DeploymentDescribeWebview.ts
@@ -3,6 +3,7 @@ import { WorkloadCommands } from '../kubectl/WorkloadCommands';
 import { transformDeploymentData, DeploymentDescribeData } from './deploymentDataTransformer';
 import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
 import { DescribeWebview } from './DescribeWebview';
+import { releaseExclusiveDescribePanelBindings } from './describeSharedPanelBindings';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 
 /**
@@ -53,6 +54,17 @@ export class DeploymentDescribeWebview {
      */
     private static contextName: string | undefined;
 
+    private static messageSubscription: vscode.Disposable | undefined;
+    private static panelDisposeSubscription: vscode.Disposable | undefined;
+
+    /** Drops Deployment message handlers when another describe view takes the shared panel. */
+    public static releaseMessageBindings(): void {
+        DeploymentDescribeWebview.messageSubscription?.dispose();
+        DeploymentDescribeWebview.messageSubscription = undefined;
+        DeploymentDescribeWebview.panelDisposeSubscription?.dispose();
+        DeploymentDescribeWebview.panelDisposeSubscription = undefined;
+    }
+
     /**
      * Show the Deployment Describe webview for a deployment.
      * Creates a new panel if none exists, or reuses and updates the existing panel.
@@ -70,6 +82,8 @@ export class DeploymentDescribeWebview {
         kubeconfigPath: string,
         contextName: string
     ): Promise<void> {
+        releaseExclusiveDescribePanelBindings();
+
         // Store the extension context for later use
         DeploymentDescribeWebview.extensionContext = context;
         DeploymentDescribeWebview.currentDeploymentName = deploymentName;
@@ -92,6 +106,7 @@ export class DeploymentDescribeWebview {
             DeploymentDescribeWebview.currentPanel.webview.html = DeploymentDescribeWebview.getWebviewContent(
                 DeploymentDescribeWebview.currentPanel.webview
             );
+            DeploymentDescribeWebview.attachPanelBindings(DeploymentDescribeWebview.currentPanel);
             await DeploymentDescribeWebview.refreshDeploymentData();
             DeploymentDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
             return;
@@ -108,6 +123,7 @@ export class DeploymentDescribeWebview {
             DeploymentDescribeWebview.currentPanel.webview.html = DeploymentDescribeWebview.getWebviewContent(
                 DeploymentDescribeWebview.currentPanel.webview
             );
+            DeploymentDescribeWebview.attachPanelBindings(DeploymentDescribeWebview.currentPanel);
             await DeploymentDescribeWebview.refreshDeploymentData();
             DeploymentDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
             // Register our panel as the shared panel
@@ -139,26 +155,29 @@ export class DeploymentDescribeWebview {
             panel.webview
         );
 
-        // Set up message handlers
-        DeploymentDescribeWebview.setupMessageHandlers(panel, context);
+        DeploymentDescribeWebview.attachPanelBindings(panel);
 
         // Fetch and display initial data
         await DeploymentDescribeWebview.refreshDeploymentData();
+    }
 
-        // Handle panel disposal
-        panel.onDidDispose(
-            () => {
+    private static attachPanelBindings(panel: vscode.WebviewPanel): void {
+        DeploymentDescribeWebview.releaseMessageBindings();
+        DeploymentDescribeWebview.setupMessageHandlers(panel);
+
+        DeploymentDescribeWebview.panelDisposeSubscription = panel.onDidDispose(() => {
+            if (DeploymentDescribeWebview.currentPanel === panel) {
                 DeploymentDescribeWebview.currentPanel = undefined;
                 DeploymentDescribeWebview.currentDeploymentName = undefined;
                 DeploymentDescribeWebview.currentNamespace = undefined;
                 DeploymentDescribeWebview.kubeconfigPath = undefined;
                 DeploymentDescribeWebview.contextName = undefined;
-                // Clear the shared panel reference
-                DescribeWebview.setSharedPanel(undefined);
-            },
-            null,
-            context.subscriptions
-        );
+                if (DescribeWebview.getSharedPanel() === panel) {
+                    DescribeWebview.setSharedPanel(undefined);
+                }
+            }
+            DeploymentDescribeWebview.releaseMessageBindings();
+        });
     }
 
     /**
@@ -303,11 +322,8 @@ export class DeploymentDescribeWebview {
      * @param panel The webview panel
      * @param context The VS Code extension context
      */
-    private static setupMessageHandlers(
-        panel: vscode.WebviewPanel,
-        context: vscode.ExtensionContext
-    ): void {
-        panel.webview.onDidReceiveMessage(
+    private static setupMessageHandlers(panel: vscode.WebviewPanel): void {
+        DeploymentDescribeWebview.messageSubscription = panel.webview.onDidReceiveMessage(
             async (message: WebviewMessage) => {
                 switch (message.command) {
                     case 'refresh': {
@@ -370,9 +386,7 @@ export class DeploymentDescribeWebview {
                         console.log('Unknown message command:', message.command);
                     }
                 }
-            },
-            null,
-            context.subscriptions
+            }
         );
     }
 

--- a/src/webview/DescribeWebview.ts
+++ b/src/webview/DescribeWebview.ts
@@ -226,6 +226,13 @@ export class DescribeWebview {
     private static currentCRDConfig: CRDTreeItemConfig | undefined;
 
     /**
+     * Active {@link vscode.Webview.onDidReceiveMessage} subscription for the shared Describe panel.
+     * Replaced on each {@link DescribeWebview.setupMessageHandling} and released when the panel is
+     * yielded to a structured detail webview or disposed.
+     */
+    private static describeMessageSubscription: vscode.Disposable | undefined;
+
+    /**
      * Clears which resource the shared Describe panel is bound to.
      * Call before assigning a new active config when switching kinds so
      * refresh/viewYaml handlers do not match a stale type first.
@@ -240,6 +247,16 @@ export class DescribeWebview {
         DescribeWebview.currentConfigMapConfig = undefined;
         DescribeWebview.currentStorageClassConfig = undefined;
         DescribeWebview.currentCRDConfig = undefined;
+    }
+
+    /**
+     * Drops Describe-side message handlers and resource bindings when the shared Describe webview
+     * is taken over by a structured detail view (StatefulSet, Deployment, etc.).
+     */
+    public static releaseSharedDescribeMessageBindings(): void {
+        DescribeWebview.describeMessageSubscription?.dispose();
+        DescribeWebview.describeMessageSubscription = undefined;
+        DescribeWebview.clearAllDescribeResourceConfigs();
     }
 
     /**
@@ -286,6 +303,7 @@ export class DescribeWebview {
         // Handle panel disposal - clear shared state
         panel.onDidDispose(
             () => {
+                DescribeWebview.releaseSharedDescribeMessageBindings();
                 DescribeWebview.currentPanel = undefined;
             },
             null,
@@ -655,8 +673,8 @@ export class DescribeWebview {
         // Handle panel disposal - clear all describe webview state
         panel.onDidDispose(
             () => {
+                DescribeWebview.releaseSharedDescribeMessageBindings();
                 DescribeWebview.currentPanel = undefined;
-                DescribeWebview.currentPodConfig = undefined;
             },
             null,
             context.subscriptions
@@ -729,9 +747,13 @@ export class DescribeWebview {
      */
     private static setupMessageHandling(
         panel: vscode.WebviewPanel,
-        context: vscode.ExtensionContext
+        _context: vscode.ExtensionContext
     ): void {
-        panel.webview.onDidReceiveMessage(
+        void _context;
+        DescribeWebview.describeMessageSubscription?.dispose();
+        DescribeWebview.describeMessageSubscription = undefined;
+
+        DescribeWebview.describeMessageSubscription = panel.webview.onDidReceiveMessage(
             async (message) => {
                 switch (message.command) {
                     case 'refresh':
@@ -882,9 +904,7 @@ export class DescribeWebview {
                     default:
                         console.warn('Unknown message command:', message.command);
                 }
-            },
-            null,
-            context.subscriptions
+            }
         );
     }
 
@@ -1222,8 +1242,8 @@ export class DescribeWebview {
         // Handle panel disposal - clear all describe webview state
         panel.onDidDispose(
             () => {
+                DescribeWebview.releaseSharedDescribeMessageBindings();
                 DescribeWebview.currentPanel = undefined;
-                DescribeWebview.currentNamespaceConfig = undefined;
             },
             null,
             context.subscriptions
@@ -1429,8 +1449,8 @@ export class DescribeWebview {
         // Handle panel disposal - clear all describe webview state
         panel.onDidDispose(
             () => {
+                DescribeWebview.releaseSharedDescribeMessageBindings();
                 DescribeWebview.currentPanel = undefined;
-                DescribeWebview.currentPVCConfig = undefined;
             },
             null,
             context.subscriptions
@@ -1655,8 +1675,8 @@ export class DescribeWebview {
         // Handle panel disposal - clear all describe webview state
         panel.onDidDispose(
             () => {
+                DescribeWebview.releaseSharedDescribeMessageBindings();
                 DescribeWebview.currentPanel = undefined;
-                DescribeWebview.currentPVConfig = undefined;
             },
             null,
             context.subscriptions
@@ -1983,8 +2003,8 @@ export class DescribeWebview {
         // Handle panel disposal - clear all describe webview state
         panel.onDidDispose(
             () => {
+                DescribeWebview.releaseSharedDescribeMessageBindings();
                 DescribeWebview.currentPanel = undefined;
-                DescribeWebview.currentSecretConfig = undefined;
             },
             null,
             context.subscriptions
@@ -2052,8 +2072,8 @@ export class DescribeWebview {
         // Handle panel disposal - clear all describe webview state
         panel.onDidDispose(
             () => {
+                DescribeWebview.releaseSharedDescribeMessageBindings();
                 DescribeWebview.currentPanel = undefined;
-                DescribeWebview.currentStorageClassConfig = undefined;
             },
             null,
             context.subscriptions
@@ -2104,8 +2124,8 @@ export class DescribeWebview {
 
         panel.onDidDispose(
             () => {
+                DescribeWebview.releaseSharedDescribeMessageBindings();
                 DescribeWebview.currentPanel = undefined;
-                DescribeWebview.currentCRDConfig = undefined;
             },
             null,
             context.subscriptions
@@ -2688,8 +2708,8 @@ export class DescribeWebview {
         // Handle panel disposal - clear all describe webview state
         panel.onDidDispose(
             () => {
+                DescribeWebview.releaseSharedDescribeMessageBindings();
                 DescribeWebview.currentPanel = undefined;
-                DescribeWebview.currentServiceConfig = undefined;
             },
             null,
             context.subscriptions
@@ -2973,8 +2993,8 @@ export class DescribeWebview {
         // Handle panel disposal - clear all describe webview state
         panel.onDidDispose(
             () => {
+                DescribeWebview.releaseSharedDescribeMessageBindings();
                 DescribeWebview.currentPanel = undefined;
-                DescribeWebview.currentConfigMapConfig = undefined;
             },
             null,
             context.subscriptions

--- a/src/webview/DescribeWebview.ts
+++ b/src/webview/DescribeWebview.ts
@@ -14,6 +14,7 @@ import { StorageClassDescribeProvider } from '../providers/StorageClassDescribeP
 import { CRDDescribeProvider } from '../providers/CRDDescribeProvider';
 import { getKubernetesApiClient } from '../kubernetes/apiClient';
 import { DeploymentDescribeWebview } from './DeploymentDescribeWebview';
+import { StatefulSetDescribeWebview } from './StatefulSetDescribeWebview';
 import { KubeconfigParser } from '../kubernetes/KubeconfigParser';
 import { WebviewHelpHandler } from './WebviewHelpHandler';
 import { getHelpController } from '../extension';
@@ -470,6 +471,16 @@ export class DescribeWebview {
                 kubeconfigPath,
                 contextName
             );
+            return;
+        }
+
+        if (kind === 'StatefulSet') {
+            if (!namespace) {
+                vscode.window.showErrorMessage('Unable to describe StatefulSet: namespace is required');
+                return;
+            }
+            const kubeconfigPath = KubeconfigParser.getKubeconfigPath();
+            await StatefulSetDescribeWebview.show(context, name, namespace, kubeconfigPath, contextName);
             return;
         }
 

--- a/src/webview/NodeDescribeWebview.ts
+++ b/src/webview/NodeDescribeWebview.ts
@@ -4,6 +4,7 @@ import { PodCommands } from '../kubectl/PodCommands';
 import { transformNodeData, NodeDescribeData } from './nodeDescribeTransformer';
 import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
 import { DescribeWebview } from './DescribeWebview';
+import { releaseExclusiveDescribePanelBindings } from './describeSharedPanelBindings';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 
 /**
@@ -49,6 +50,17 @@ export class NodeDescribeWebview {
      */
     private static contextName: string | undefined;
 
+    private static messageSubscription: vscode.Disposable | undefined;
+    private static panelDisposeSubscription: vscode.Disposable | undefined;
+
+    /** Drops Node message handlers when another describe view takes the shared panel. */
+    public static releaseMessageBindings(): void {
+        NodeDescribeWebview.messageSubscription?.dispose();
+        NodeDescribeWebview.messageSubscription = undefined;
+        NodeDescribeWebview.panelDisposeSubscription?.dispose();
+        NodeDescribeWebview.panelDisposeSubscription = undefined;
+    }
+
     /**
      * Show the Node Describe webview for a node.
      * Creates a new panel if none exists, or reuses and updates the existing panel.
@@ -65,6 +77,8 @@ export class NodeDescribeWebview {
         kubeconfigPath: string,
         contextName: string
     ): Promise<void> {
+        releaseExclusiveDescribePanelBindings();
+
         // Store the extension context for later use
         NodeDescribeWebview.extensionContext = context;
         NodeDescribeWebview.currentNodeName = nodeName;
@@ -82,6 +96,7 @@ export class NodeDescribeWebview {
             NodeDescribeWebview.currentPanel.webview.html = NodeDescribeWebview.getWebviewContent(
                 NodeDescribeWebview.currentPanel.webview
             );
+            NodeDescribeWebview.attachPanelBindings(NodeDescribeWebview.currentPanel);
             await NodeDescribeWebview.refreshNodeData();
             NodeDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
             return;
@@ -97,6 +112,7 @@ export class NodeDescribeWebview {
             NodeDescribeWebview.currentPanel.webview.html = NodeDescribeWebview.getWebviewContent(
                 NodeDescribeWebview.currentPanel.webview
             );
+            NodeDescribeWebview.attachPanelBindings(NodeDescribeWebview.currentPanel);
             await NodeDescribeWebview.refreshNodeData();
             NodeDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
             // Register our panel as the shared panel
@@ -128,25 +144,28 @@ export class NodeDescribeWebview {
             panel.webview
         );
 
-        // Set up message handlers
-        NodeDescribeWebview.setupMessageHandlers(panel, context);
+        NodeDescribeWebview.attachPanelBindings(panel);
 
         // Fetch and display initial data
         await NodeDescribeWebview.refreshNodeData();
+    }
 
-        // Handle panel disposal
-        panel.onDidDispose(
-            () => {
+    private static attachPanelBindings(panel: vscode.WebviewPanel): void {
+        NodeDescribeWebview.releaseMessageBindings();
+        NodeDescribeWebview.setupMessageHandlers(panel);
+
+        NodeDescribeWebview.panelDisposeSubscription = panel.onDidDispose(() => {
+            if (NodeDescribeWebview.currentPanel === panel) {
                 NodeDescribeWebview.currentPanel = undefined;
                 NodeDescribeWebview.currentNodeName = undefined;
                 NodeDescribeWebview.kubeconfigPath = undefined;
                 NodeDescribeWebview.contextName = undefined;
-                // Clear the shared panel reference
-                DescribeWebview.setSharedPanel(undefined);
-            },
-            null,
-            context.subscriptions
-        );
+                if (DescribeWebview.getSharedPanel() === panel) {
+                    DescribeWebview.setSharedPanel(undefined);
+                }
+            }
+            NodeDescribeWebview.releaseMessageBindings();
+        });
     }
 
     /**
@@ -251,11 +270,8 @@ export class NodeDescribeWebview {
      * @param panel The webview panel
      * @param context The VS Code extension context
      */
-    private static setupMessageHandlers(
-        panel: vscode.WebviewPanel,
-        context: vscode.ExtensionContext
-    ): void {
-        panel.webview.onDidReceiveMessage(
+    private static setupMessageHandlers(panel: vscode.WebviewPanel): void {
+        NodeDescribeWebview.messageSubscription = panel.webview.onDidReceiveMessage(
             async (message: WebviewMessage) => {
                 switch (message.command) {
                     case 'refresh': {
@@ -301,9 +317,7 @@ export class NodeDescribeWebview {
                         console.log('Unknown message command:', message.command);
                     }
                 }
-            },
-            null,
-            context.subscriptions
+            }
         );
     }
 

--- a/src/webview/StatefulSetDescribeWebview.ts
+++ b/src/webview/StatefulSetDescribeWebview.ts
@@ -3,6 +3,7 @@ import { WorkloadCommands } from '../kubectl/WorkloadCommands';
 import { transformStatefulSetData, StatefulSetDescribeData } from './statefulSetDataTransformer';
 import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
 import { DescribeWebview } from './DescribeWebview';
+import { releaseExclusiveDescribePanelBindings } from './describeSharedPanelBindings';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 
 interface WebviewMessage {
@@ -35,7 +36,7 @@ export class StatefulSetDescribeWebview {
         kubeconfigPath: string,
         contextName: string
     ): Promise<void> {
-        DescribeWebview.releaseSharedDescribeMessageBindings();
+        releaseExclusiveDescribePanelBindings();
         StatefulSetDescribeWebview.currentName = statefulSetName;
         StatefulSetDescribeWebview.currentNamespace = namespace;
         StatefulSetDescribeWebview.kubeconfigPath = kubeconfigPath;
@@ -112,6 +113,11 @@ export class StatefulSetDescribeWebview {
             StatefulSetDescribeWebview.messageSubscription?.dispose();
             StatefulSetDescribeWebview.messageSubscription = undefined;
         });
+    }
+
+    /** Drops StatefulSet message handlers when another describe view takes the shared panel. */
+    public static releaseMessageBindings(): void {
+        StatefulSetDescribeWebview.detachPanelSubscriptions();
     }
 
     private static detachPanelSubscriptions(): void {

--- a/src/webview/StatefulSetDescribeWebview.ts
+++ b/src/webview/StatefulSetDescribeWebview.ts
@@ -1,0 +1,556 @@
+import * as vscode from 'vscode';
+import { WorkloadCommands } from '../kubectl/WorkloadCommands';
+import { transformStatefulSetData, StatefulSetDescribeData } from './statefulSetDataTransformer';
+import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
+import { DescribeWebview } from './DescribeWebview';
+import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
+
+interface WebviewMessage {
+    command: 'refresh' | 'copyValue' | 'viewYaml' | 'navigateToPod';
+    value?: string;
+    content?: string;
+    podName?: string;
+    namespace?: string;
+}
+
+/**
+ * Webview for StatefulSet describe (structured detail page).
+ * Mirrors {@link DeploymentDescribeWebview} patterns (shared panel, cache, messages).
+ */
+export class StatefulSetDescribeWebview {
+    private static currentPanel: vscode.WebviewPanel | undefined;
+    private static extensionContext: vscode.ExtensionContext | undefined;
+    private static currentName: string | undefined;
+    private static currentNamespace: string | undefined;
+    private static kubeconfigPath: string | undefined;
+    private static contextName: string | undefined;
+
+    public static async show(
+        context: vscode.ExtensionContext,
+        statefulSetName: string,
+        namespace: string,
+        kubeconfigPath: string,
+        contextName: string
+    ): Promise<void> {
+        StatefulSetDescribeWebview.extensionContext = context;
+        StatefulSetDescribeWebview.currentName = statefulSetName;
+        StatefulSetDescribeWebview.currentNamespace = namespace;
+        StatefulSetDescribeWebview.kubeconfigPath = kubeconfigPath;
+        StatefulSetDescribeWebview.contextName = contextName;
+
+        const sharedPanel = DescribeWebview.getSharedPanel();
+
+        if (sharedPanel) {
+            StatefulSetDescribeWebview.currentPanel = sharedPanel;
+            StatefulSetDescribeWebview.currentPanel.title = `StatefulSet / ${statefulSetName}`;
+            StatefulSetDescribeWebview.currentName = statefulSetName;
+            StatefulSetDescribeWebview.currentNamespace = namespace;
+            StatefulSetDescribeWebview.kubeconfigPath = kubeconfigPath;
+            StatefulSetDescribeWebview.contextName = contextName;
+            StatefulSetDescribeWebview.currentPanel.webview.html = StatefulSetDescribeWebview.getWebviewContent(
+                StatefulSetDescribeWebview.currentPanel.webview
+            );
+            await StatefulSetDescribeWebview.refreshData();
+            StatefulSetDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
+            return;
+        }
+
+        if (StatefulSetDescribeWebview.currentPanel) {
+            StatefulSetDescribeWebview.currentPanel.title = `StatefulSet / ${statefulSetName}`;
+            StatefulSetDescribeWebview.currentName = statefulSetName;
+            StatefulSetDescribeWebview.currentNamespace = namespace;
+            StatefulSetDescribeWebview.kubeconfigPath = kubeconfigPath;
+            StatefulSetDescribeWebview.contextName = contextName;
+            StatefulSetDescribeWebview.currentPanel.webview.html = StatefulSetDescribeWebview.getWebviewContent(
+                StatefulSetDescribeWebview.currentPanel.webview
+            );
+            await StatefulSetDescribeWebview.refreshData();
+            StatefulSetDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
+            DescribeWebview.setSharedPanel(StatefulSetDescribeWebview.currentPanel);
+            return;
+        }
+
+        const title = `StatefulSet / ${statefulSetName}`;
+        notifyMajorWebviewOpened('resource_describe');
+        const panel = vscode.window.createWebviewPanel('kube9Describe', title, vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+
+        StatefulSetDescribeWebview.currentPanel = panel;
+        DescribeWebview.setSharedPanel(panel);
+
+        panel.webview.html = StatefulSetDescribeWebview.getWebviewContent(panel.webview);
+        StatefulSetDescribeWebview.setupMessageHandlers(panel, context);
+        await StatefulSetDescribeWebview.refreshData();
+
+        panel.onDidDispose(
+            () => {
+                StatefulSetDescribeWebview.currentPanel = undefined;
+                StatefulSetDescribeWebview.currentName = undefined;
+                StatefulSetDescribeWebview.currentNamespace = undefined;
+                StatefulSetDescribeWebview.kubeconfigPath = undefined;
+                StatefulSetDescribeWebview.contextName = undefined;
+                DescribeWebview.setSharedPanel(undefined);
+            },
+            null,
+            context.subscriptions
+        );
+    }
+
+    private static clearCache(contextName: string, namespace: string, name: string): void {
+        const cache = getResourceCache();
+        cache.invalidate(`statefulset-describe:${contextName}:${namespace}:${name}`);
+    }
+
+    private static async refreshData(): Promise<void> {
+        if (!StatefulSetDescribeWebview.currentPanel) {
+            return;
+        }
+        const panel = StatefulSetDescribeWebview.currentPanel;
+        const name = StatefulSetDescribeWebview.currentName;
+        const namespace = StatefulSetDescribeWebview.currentNamespace;
+        const kubeconfigPath = StatefulSetDescribeWebview.kubeconfigPath;
+        const contextName = StatefulSetDescribeWebview.contextName;
+        if (!name || !namespace || !kubeconfigPath || !contextName) {
+            panel.webview.postMessage({
+                command: 'error',
+                message: 'Missing required parameters for StatefulSet describe'
+            });
+            return;
+        }
+
+        const cache = getResourceCache();
+        const cacheKey = `statefulset-describe:${contextName}:${namespace}:${name}`;
+        const cached = cache.get<StatefulSetDescribeData>(cacheKey);
+        if (cached) {
+            panel.webview.postMessage({ command: 'updateStatefulSetData', data: cached });
+            return;
+        }
+
+        try {
+            const detail = await WorkloadCommands.getStatefulSetDetails(
+                name,
+                namespace,
+                kubeconfigPath,
+                contextName
+            );
+            if (detail.error) {
+                panel.webview.postMessage({
+                    command: 'error',
+                    message: detail.error.getUserMessage()
+                });
+                return;
+            }
+            if (!detail.statefulSet) {
+                panel.webview.postMessage({
+                    command: 'error',
+                    message: 'StatefulSet not found or unavailable'
+                });
+                return;
+            }
+
+            const sts = detail.statefulSet;
+            const selector = Object.entries(sts.spec?.selector?.matchLabels || {})
+                .map(([k, v]) => `${k}=${v}`)
+                .join(',');
+
+            const [podsRes, pvcRes, eventsRes] = await Promise.all([
+                WorkloadCommands.getV1PodsForLabelSelector(
+                    namespace,
+                    selector,
+                    kubeconfigPath,
+                    contextName
+                ),
+                WorkloadCommands.listNamespacedPersistentVolumeClaims(
+                    namespace,
+                    kubeconfigPath,
+                    contextName
+                ),
+                WorkloadCommands.getStatefulSetEvents(name, namespace, kubeconfigPath, contextName)
+            ]);
+
+            const dataLoadErrors: StatefulSetDescribeData['dataLoadErrors'] = {};
+            if (podsRes.error) {
+                dataLoadErrors.pods = podsRes.error.getUserMessage();
+            }
+            if (pvcRes.error) {
+                dataLoadErrors.pvcs = pvcRes.error.getUserMessage();
+            }
+            if (eventsRes.error) {
+                dataLoadErrors.events = eventsRes.error.getUserMessage();
+            }
+
+            const transformed = transformStatefulSetData(
+                sts,
+                podsRes.pods,
+                pvcRes.items,
+                eventsRes.events
+            );
+            if (Object.keys(dataLoadErrors).length > 0) {
+                transformed.dataLoadErrors = dataLoadErrors;
+            }
+
+            cache.set(cacheKey, transformed, CACHE_TTL.DEPLOYMENTS);
+            panel.webview.postMessage({ command: 'updateStatefulSetData', data: transformed });
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.error('Error refreshing StatefulSet describe:', errorMessage);
+            panel.webview.postMessage({
+                command: 'error',
+                message: `Failed to refresh StatefulSet: ${errorMessage}`
+            });
+        }
+    }
+
+    private static setupMessageHandlers(panel: vscode.WebviewPanel, context: vscode.ExtensionContext): void {
+        panel.webview.onDidReceiveMessage(
+            async (message: WebviewMessage) => {
+                switch (message.command) {
+                    case 'refresh': {
+                        const ctx = StatefulSetDescribeWebview.contextName;
+                        const ns = StatefulSetDescribeWebview.currentNamespace;
+                        const n = StatefulSetDescribeWebview.currentName;
+                        if (ctx && ns && n) {
+                            StatefulSetDescribeWebview.clearCache(ctx, ns, n);
+                        }
+                        await StatefulSetDescribeWebview.refreshData();
+                        break;
+                    }
+                    case 'viewYaml': {
+                        const n = StatefulSetDescribeWebview.currentName;
+                        const ns = StatefulSetDescribeWebview.currentNamespace;
+                        const cluster = StatefulSetDescribeWebview.contextName;
+                        if (!n || !ns || !cluster) {
+                            vscode.window.showErrorMessage('StatefulSet context not available');
+                            break;
+                        }
+                        try {
+                            const { getYAMLEditorManager } = await import('../extension');
+                            const yamlEditorManager = getYAMLEditorManager();
+                            await yamlEditorManager.openYAMLEditor({
+                                kind: 'StatefulSet',
+                                name: n,
+                                namespace: ns,
+                                apiVersion: 'apps/v1',
+                                cluster
+                            });
+                        } catch (e) {
+                            const msg = e instanceof Error ? e.message : String(e);
+                            vscode.window.showErrorMessage(`Failed to open YAML: ${msg}`);
+                        }
+                        break;
+                    }
+                    case 'navigateToPod': {
+                        const podName = message.podName;
+                        const ns = message.namespace || StatefulSetDescribeWebview.currentNamespace;
+                        if (!podName) {
+                            vscode.window.showErrorMessage('Pod name is required');
+                            break;
+                        }
+                        try {
+                            await vscode.commands.executeCommand('kube9.revealPod', podName, ns || 'default');
+                        } catch (e) {
+                            const msg = e instanceof Error ? e.message : String(e);
+                            vscode.window.showErrorMessage(`Failed to reveal pod: ${msg}`);
+                        }
+                        break;
+                    }
+                    case 'copyValue': {
+                        const value = message.value || message.content;
+                        if (value) {
+                            try {
+                                await vscode.env.clipboard.writeText(value);
+                                vscode.window.showInformationMessage('Copied to clipboard');
+                            } catch (e) {
+                                const msg = e instanceof Error ? e.message : String(e);
+                                vscode.window.showErrorMessage(`Failed to copy: ${msg}`);
+                            }
+                        }
+                        break;
+                    }
+                    default:
+                        console.log('Unknown StatefulSet describe message:', message.command);
+                }
+            },
+            null,
+            context.subscriptions
+        );
+    }
+
+    private static getWebviewContent(webview: vscode.Webview): string {
+        const cspSource = webview.cspSource;
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src ${cspSource} 'unsafe-inline';">
+    <title>StatefulSet Describe</title>
+    <style>
+        body { font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); color: var(--vscode-foreground);
+            background-color: var(--vscode-editor-background); padding: 0; margin: 0; }
+        .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
+        .resource-header { display: flex; justify-content: space-between; align-items: center;
+            border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 15px; margin-bottom: 20px; flex-wrap: wrap; gap: 10px; }
+        .resource-title { margin: 0; font-size: 24px; font-weight: 600; }
+        .header-actions { display: flex; gap: 10px; flex-wrap: wrap; }
+        .action-btn { display: flex; align-items: center; gap: 6px; padding: 6px 12px;
+            background-color: var(--vscode-button-background); color: var(--vscode-button-foreground);
+            border: none; border-radius: 2px; cursor: pointer; font-family: inherit; }
+        .action-btn:hover { background-color: var(--vscode-button-hoverBackground); }
+        .section { margin-bottom: 28px; }
+        .section h2 { margin: 0 0 12px 0; font-size: 18px; font-weight: 600;
+            border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 8px; }
+        .info-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+        .info-item { display: flex; flex-direction: column; gap: 4px; }
+        .info-label { font-size: 12px; color: var(--vscode-descriptionForeground); text-transform: uppercase; letter-spacing: 0.5px; }
+        .info-value { word-break: break-word; }
+        .warn-banner, .error-banner { padding: 12px 14px; border-radius: 4px; margin-bottom: 16px; }
+        .warn-banner { background: rgba(255,170,0,0.12); border: 1px solid #ffaa00; color: var(--vscode-foreground); }
+        .error-banner { background: rgba(255,0,0,0.1); border: 1px solid var(--vscode-errorForeground); color: var(--vscode-errorForeground); }
+        .replica-status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
+        .replica-status-value { font-size: 20px; font-weight: 600; }
+        .replica-status-value.warn { color: var(--vscode-errorForeground); }
+        table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+        th, td { text-align: left; padding: 10px; border-bottom: 1px solid var(--vscode-panel-border); }
+        th { font-size: 12px; text-transform: uppercase; color: var(--vscode-descriptionForeground); }
+        tr.warning { background: rgba(255,170,0,0.08); }
+        .pod-link { color: var(--vscode-textLink-foreground); cursor: pointer; text-decoration: underline; background: none; border: none;
+            font: inherit; padding: 0; }
+        .empty-state { padding: 16px; color: var(--vscode-descriptionForeground); font-style: italic; text-align: center; }
+        .copy-btn { background: none; border: none; color: var(--vscode-textLink-foreground); cursor: pointer; padding: 2px 6px; }
+        .loading { text-align: center; padding: 40px; color: var(--vscode-descriptionForeground); }
+        .hidden { display: none; }
+        .label-list { list-style: none; padding: 0; margin: 0; }
+        .label-item { display: flex; align-items: center; gap: 10px; padding: 6px 0; border-bottom: 1px solid var(--vscode-panel-border); }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="resource-header">
+            <h1 class="resource-title">StatefulSet / <span id="sts-name">Loading…</span></h1>
+            <div class="header-actions">
+                <button id="yaml-btn" class="action-btn">View YAML</button>
+                <button id="refresh-btn" class="action-btn">Refresh</button>
+            </div>
+        </div>
+        <div id="loading" class="loading">Loading StatefulSet…</div>
+        <div id="page-error" class="error-banner hidden"></div>
+        <div id="warnings" class="hidden"></div>
+        <div id="content" class="hidden">
+            <div class="section" id="overview-section"><h2>Overview</h2><div class="info-grid" id="overview-grid"></div></div>
+            <div class="section" id="replica-section"><h2>Replica status</h2><div class="replica-status-grid" id="replica-grid"></div></div>
+            <div class="section" id="rollout-section"><h2>Rollout</h2><div class="info-grid" id="rollout-grid"></div></div>
+            <div class="section" id="ordinal-section"><h2>Ordinal pods</h2><table><thead><tr>
+                <th>Ordinal</th><th>Pod</th><th>Phase</th><th>Ready</th><th>Restarts</th><th>Node</th><th>Age</th><th>Notes</th>
+            </tr></thead><tbody id="ordinal-body"></tbody></table></div>
+            <div class="section" id="vct-section"><h2>Volume claim templates</h2><div id="vct-body"></div></div>
+            <div class="section" id="pvc-section"><h2>PersistentVolumeClaims</h2><table><thead><tr>
+                <th>Ordinal</th><th>Template</th><th>PVC</th><th>Found</th><th>Phase</th><th>Capacity</th><th>Storage class</th>
+            </tr></thead><tbody id="pvc-body"></tbody></table></div>
+            <div class="section" id="conditions-section"><h2>Conditions</h2><table><thead><tr>
+                <th>Type</th><th>Status</th><th>Reason</th><th>Message</th><th>Since</th>
+            </tr></thead><tbody id="conditions-body"></tbody></table></div>
+            <div class="section" id="podtemplate-section"><h2>Pod template</h2><div id="podtemplate-body"></div></div>
+            <div class="section" id="labels-section"><h2>Labels & selectors</h2><div id="labels-body"></div></div>
+            <div class="section" id="events-section"><h2>Recent events</h2><table><thead><tr>
+                <th>Type</th><th>Reason</th><th>Message</th><th>Age</th><th>From</th><th>Count</th>
+            </tr></thead><tbody id="events-body"></tbody></table></div>
+        </div>
+    </div>
+    <script>
+    (function() {
+        var vscode = acquireVsCodeApi();
+        window.addEventListener('message', function(event) {
+            var message = event.data;
+            if (message.command === 'updateStatefulSetData') {
+                hideError();
+                render(message.data);
+                document.getElementById('loading').classList.add('hidden');
+                document.getElementById('content').classList.remove('hidden');
+            } else if (message.command === 'error') {
+                document.getElementById('loading').classList.add('hidden');
+                showError(message.message);
+            }
+        });
+        function showError(msg) {
+            var el = document.getElementById('page-error');
+            el.textContent = msg;
+            el.classList.remove('hidden');
+            document.getElementById('content').classList.add('hidden');
+        }
+        function hideError() {
+            var el = document.getElementById('page-error');
+            el.classList.add('hidden');
+            el.textContent = '';
+        }
+        function escapeHtml(u) {
+            if (u == null) return '';
+            return String(u).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+                .replace(/"/g,'&quot;').replace(/'/g,'&#039;');
+        }
+        function render(data) {
+            document.getElementById('sts-name').textContent = data.name || '';
+            var warnEl = document.getElementById('warnings');
+            var parts = [];
+            var errs = data.dataLoadErrors || {};
+            if (errs.pods) parts.push('Pods: ' + errs.pods);
+            if (errs.pvcs) parts.push('PVCs: ' + errs.pvcs);
+            if (errs.events) parts.push('Events: ' + errs.events);
+            if (parts.length) {
+                warnEl.innerHTML = '<div class="warn-banner">' + parts.map(escapeHtml).join('<br/>') + '</div>';
+                warnEl.classList.remove('hidden');
+            } else {
+                warnEl.innerHTML = '';
+                warnEl.classList.add('hidden');
+            }
+            var o = data.overview;
+            document.getElementById('overview-grid').innerHTML = [
+                ['Replicas (desired)', String(o.replicas)],
+                ['Current / Ready / Updated', (o.currentReplicas + ' / ' + o.readyReplicas + ' / ' + o.updatedReplicas)],
+                ['Service name', o.serviceName || '—'],
+                ['Update strategy', o.updateStrategyType],
+                ['Pod management', o.podManagementPolicy],
+                ['Selector', o.selectorDisplay || '—'],
+                ['Namespace', o.namespace],
+                ['Age', o.age || '—'],
+                ['Generation / Observed', o.generation + ' / ' + o.observedGeneration],
+                ['Rollout summary', o.rolloutSummary]
+            ].map(function(row) {
+                return '<div class="info-item"><div class="info-label">' + escapeHtml(row[0]) + '</div><div class="info-value">' + escapeHtml(row[1]) + '</div></div>';
+            }).join('');
+            var rs = data.replicaStatus;
+            var repClass = rs.isHealthy ? '' : ' warn';
+            document.getElementById('replica-grid').innerHTML = [
+                ['Desired', String(rs.desired)],
+                ['Current', String(rs.current), repClass],
+                ['Ready', String(rs.ready), repClass],
+                ['Updated', String(rs.updated)]
+            ].map(function(item) {
+                var cls = item[2] ? ' class="replica-status-value' + item[2] + '"' : ' class="replica-status-value"';
+                return '<div class="info-item"><div class="info-label">' + escapeHtml(item[0]) + '</div><div' + cls + '>' + escapeHtml(item[1]) + '</div></div>';
+            }).join('');
+            var r = data.rollout;
+            document.getElementById('rollout-grid').innerHTML = [
+                ['Current revision', r.currentRevision || '—'],
+                ['Update revision', r.updateRevision || '—'],
+                ['Collision count', String(r.collisionCount)],
+                ['Partition', r.partition == null ? '—' : String(r.partition)]
+            ].map(function(row) {
+                return '<div class="info-item"><div class="info-label">' + escapeHtml(row[0]) + '</div><div class="info-value">' + escapeHtml(row[1]) + '</div></div>';
+            }).join('');
+            var ob = document.getElementById('ordinal-body');
+            if (!data.ordinalPods || !data.ordinalPods.length) {
+                ob.innerHTML = '<tr><td colspan="8" class="empty-state">No replicas configured or unable to list pods</td></tr>';
+            } else {
+                ob.innerHTML = data.ordinalPods.map(function(row) {
+                    var rowClass = !row.podPresent || row.phase === 'Failed' || (row.readyDisplay && row.readyDisplay.indexOf('NotReady') >= 0) ? ' class="warning"' : '';
+                    var podCell = row.podPresent
+                        ? '<button type="button" class="pod-link" data-pod="' + escapeHtml(row.expectedPodName) + '">' + escapeHtml(row.expectedPodName) + '</button>'
+                        : '<em>missing</em>';
+                    return '<tr' + rowClass + '><td>' + row.ordinal + '</td><td>' + podCell + '</td><td>' + escapeHtml(row.phase) +
+                        '</td><td>' + escapeHtml(row.readyDisplay) + '</td><td>' + row.restartCount + '</td><td>' + escapeHtml(row.nodeName) +
+                        '</td><td>' + escapeHtml(row.age) + '</td><td>' + escapeHtml(row.statusDetail) + '</td></tr>';
+                }).join('');
+            }
+            var vct = data.volumeClaimTemplates || [];
+            document.getElementById('vct-body').innerHTML = vct.length === 0
+                ? '<div class="empty-state">No volumeClaimTemplates</div>'
+                : '<table><thead><tr><th>Name</th><th>Access modes</th><th>Storage request</th><th>Storage class</th></tr></thead><tbody>' +
+                vct.map(function(t) {
+                    return '<tr><td>' + escapeHtml(t.name) + '</td><td>' + escapeHtml((t.accessModes || []).join(', ')) +
+                        '</td><td>' + escapeHtml(t.storageRequest) + '</td><td>' + escapeHtml(t.storageClassName) + '</td></tr>';
+                }).join('') + '</tbody></table>';
+            var pvcB = document.getElementById('pvc-body');
+            if (!data.ordinalPvcs || !data.ordinalPvcs.length) {
+                pvcB.innerHTML = '<tr><td colspan="7" class="empty-state">No PVC rows (no templates or zero replicas)</td></tr>';
+            } else {
+                pvcB.innerHTML = data.ordinalPvcs.map(function(p) {
+                    var rowClass = !p.found ? ' class="warning"' : '';
+                    return '<tr' + rowClass + '><td>' + p.ordinal + '</td><td>' + escapeHtml(p.templateName) + '</td><td>' + escapeHtml(p.pvcName) +
+                        '</td><td>' + (p.found ? 'Yes' : 'No') + '</td><td>' + escapeHtml(p.phase) + '</td><td>' + escapeHtml(p.capacity) +
+                        '</td><td>' + escapeHtml(p.storageClassName) + '</td></tr>';
+                }).join('');
+            }
+            var condBody = document.getElementById('conditions-body');
+            if (!data.conditions || !data.conditions.length) {
+                condBody.innerHTML = '<tr><td colspan="5" class="empty-state">No conditions reported</td></tr>';
+            } else {
+                condBody.innerHTML = data.conditions.map(function(c) {
+                    return '<tr><td>' + escapeHtml(c.type) + '</td><td>' + escapeHtml(c.status) + '</td><td>' + escapeHtml(c.reason) +
+                        '</td><td>' + escapeHtml(c.message) + '</td><td>' + escapeHtml(c.relativeTime) + '</td></tr>';
+                }).join('');
+            }
+            var pt = data.podTemplate || {};
+            var pth = '';
+            if (pt.containers && pt.containers.length) {
+                pth += '<h3>Containers</h3><ul class="label-list">';
+                pt.containers.forEach(function(c) {
+                    pth += '<li class="label-item">' + escapeHtml(c.name) + ' — ' + escapeHtml(c.image || '') + '</li>';
+                });
+                pth += '</ul>';
+            }
+            if (pt.volumes && pt.volumes.length) {
+                pth += '<h3>Volumes</h3><div class="info-value">' + String(pt.volumes.length) + ' volume(s)</div>';
+            }
+            document.getElementById('podtemplate-body').innerHTML = pth || '<div class="empty-state">No pod template</div>';
+            var sel = data.selectors || {};
+            var lab = data.labels || {};
+            var lh = '<h3>Selectors</h3>';
+            if (Object.keys(sel).length === 0) lh += '<div class="empty-state">None</div>';
+            else lh += '<ul class="label-list">' + Object.keys(sel).map(function(k) {
+                var pair = k + '=' + sel[k];
+                return '<li class="label-item"><span>' + escapeHtml(pair) + '</span><button class="copy-btn" data-copy="' + escapeHtml(pair) + '">Copy</button></li>';
+            }).join('') + '</ul>';
+            lh += '<h3>Labels</h3>';
+            if (Object.keys(lab).length === 0) lh += '<div class="empty-state">None</div>';
+            else lh += '<ul class="label-list">' + Object.keys(lab).map(function(k) {
+                var pair = k + '=' + lab[k];
+                return '<li class="label-item"><span>' + escapeHtml(pair) + '</span><button class="copy-btn" data-copy="' + escapeHtml(pair) + '">Copy</button></li>';
+            }).join('') + '</ul>';
+            document.getElementById('labels-body').innerHTML = lh;
+            var evb = document.getElementById('events-body');
+            if (!data.events || !data.events.length) {
+                evb.innerHTML = '<tr><td colspan="6" class="empty-state">No recent events</td></tr>';
+            } else {
+                evb.innerHTML = data.events.map(function(ev) {
+                    var rc = ev.type === 'Warning' ? ' class="warning"' : '';
+                    return '<tr' + rc + '><td>' + escapeHtml(ev.type) + '</td><td>' + escapeHtml(ev.reason) + '</td><td>' + escapeHtml(ev.message) +
+                        '</td><td>' + escapeHtml(ev.relativeTime) + '</td><td>' + escapeHtml(ev.source) + '</td><td>' + String(ev.count) + '</td></tr>';
+                }).join('');
+            }
+            wireCopy();
+            wirePods();
+        }
+        function wireCopy() {
+            document.querySelectorAll('.copy-btn').forEach(function(btn) {
+                btn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    var v = btn.getAttribute('data-copy');
+                    if (v) vscode.postMessage({ command: 'copyValue', value: v });
+                });
+            });
+        }
+        function wirePods() {
+            document.querySelectorAll('.pod-link').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    var name = btn.getAttribute('data-pod');
+                    if (name) vscode.postMessage({ command: 'navigateToPod', podName: name });
+                });
+            });
+        }
+        document.getElementById('refresh-btn').addEventListener('click', function() {
+            document.getElementById('loading').classList.remove('hidden');
+            document.getElementById('content').classList.add('hidden');
+            vscode.postMessage({ command: 'refresh' });
+        });
+        document.getElementById('yaml-btn').addEventListener('click', function() {
+            vscode.postMessage({ command: 'viewYaml' });
+        });
+    })();
+    </script>
+</body>
+</html>`;
+    }
+}

--- a/src/webview/StatefulSetDescribeWebview.ts
+++ b/src/webview/StatefulSetDescribeWebview.ts
@@ -19,11 +19,14 @@ interface WebviewMessage {
  */
 export class StatefulSetDescribeWebview {
     private static currentPanel: vscode.WebviewPanel | undefined;
-    private static extensionContext: vscode.ExtensionContext | undefined;
     private static currentName: string | undefined;
     private static currentNamespace: string | undefined;
     private static kubeconfigPath: string | undefined;
     private static contextName: string | undefined;
+    /** Owned subscription for STS messages; swapped whenever HTML/handlers refresh on a reused panel. */
+    private static messageSubscription: vscode.Disposable | undefined;
+    /** Owned subscription clearing STS bindings when this panel closes (including shared Describe reuse). */
+    private static panelDisposeSubscription: vscode.Disposable | undefined;
 
     public static async show(
         context: vscode.ExtensionContext,
@@ -32,7 +35,6 @@ export class StatefulSetDescribeWebview {
         kubeconfigPath: string,
         contextName: string
     ): Promise<void> {
-        StatefulSetDescribeWebview.extensionContext = context;
         StatefulSetDescribeWebview.currentName = statefulSetName;
         StatefulSetDescribeWebview.currentNamespace = namespace;
         StatefulSetDescribeWebview.kubeconfigPath = kubeconfigPath;
@@ -50,6 +52,7 @@ export class StatefulSetDescribeWebview {
             StatefulSetDescribeWebview.currentPanel.webview.html = StatefulSetDescribeWebview.getWebviewContent(
                 StatefulSetDescribeWebview.currentPanel.webview
             );
+            StatefulSetDescribeWebview.attachPanelBindings(StatefulSetDescribeWebview.currentPanel);
             await StatefulSetDescribeWebview.refreshData();
             StatefulSetDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
             return;
@@ -64,6 +67,7 @@ export class StatefulSetDescribeWebview {
             StatefulSetDescribeWebview.currentPanel.webview.html = StatefulSetDescribeWebview.getWebviewContent(
                 StatefulSetDescribeWebview.currentPanel.webview
             );
+            StatefulSetDescribeWebview.attachPanelBindings(StatefulSetDescribeWebview.currentPanel);
             await StatefulSetDescribeWebview.refreshData();
             StatefulSetDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
             DescribeWebview.setSharedPanel(StatefulSetDescribeWebview.currentPanel);
@@ -81,21 +85,39 @@ export class StatefulSetDescribeWebview {
         DescribeWebview.setSharedPanel(panel);
 
         panel.webview.html = StatefulSetDescribeWebview.getWebviewContent(panel.webview);
-        StatefulSetDescribeWebview.setupMessageHandlers(panel, context);
+        StatefulSetDescribeWebview.attachPanelBindings(panel);
         await StatefulSetDescribeWebview.refreshData();
+    }
 
-        panel.onDidDispose(
-            () => {
+    /**
+     * (Re)attach webview subscriptions after replacing HTML when reusing {@link DescribeWebview}'s shared panel
+     * or this class's singleton panel so message commands target the StatefulSet handlers.
+     */
+    private static attachPanelBindings(panel: vscode.WebviewPanel): void {
+        StatefulSetDescribeWebview.detachPanelSubscriptions();
+        StatefulSetDescribeWebview.setupMessageHandlers(panel);
+
+        StatefulSetDescribeWebview.panelDisposeSubscription = panel.onDidDispose(() => {
+            if (StatefulSetDescribeWebview.currentPanel === panel) {
                 StatefulSetDescribeWebview.currentPanel = undefined;
                 StatefulSetDescribeWebview.currentName = undefined;
                 StatefulSetDescribeWebview.currentNamespace = undefined;
                 StatefulSetDescribeWebview.kubeconfigPath = undefined;
                 StatefulSetDescribeWebview.contextName = undefined;
-                DescribeWebview.setSharedPanel(undefined);
-            },
-            null,
-            context.subscriptions
-        );
+                if (DescribeWebview.getSharedPanel() === panel) {
+                    DescribeWebview.setSharedPanel(undefined);
+                }
+            }
+            StatefulSetDescribeWebview.messageSubscription?.dispose();
+            StatefulSetDescribeWebview.messageSubscription = undefined;
+        });
+    }
+
+    private static detachPanelSubscriptions(): void {
+        StatefulSetDescribeWebview.messageSubscription?.dispose();
+        StatefulSetDescribeWebview.messageSubscription = undefined;
+        StatefulSetDescribeWebview.panelDisposeSubscription?.dispose();
+        StatefulSetDescribeWebview.panelDisposeSubscription = undefined;
     }
 
     private static clearCache(contextName: string, namespace: string, name: string): void {
@@ -203,79 +225,75 @@ export class StatefulSetDescribeWebview {
         }
     }
 
-    private static setupMessageHandlers(panel: vscode.WebviewPanel, context: vscode.ExtensionContext): void {
-        panel.webview.onDidReceiveMessage(
-            async (message: WebviewMessage) => {
-                switch (message.command) {
-                    case 'refresh': {
-                        const ctx = StatefulSetDescribeWebview.contextName;
-                        const ns = StatefulSetDescribeWebview.currentNamespace;
-                        const n = StatefulSetDescribeWebview.currentName;
-                        if (ctx && ns && n) {
-                            StatefulSetDescribeWebview.clearCache(ctx, ns, n);
-                        }
-                        await StatefulSetDescribeWebview.refreshData();
-                        break;
+    private static setupMessageHandlers(panel: vscode.WebviewPanel): void {
+        StatefulSetDescribeWebview.messageSubscription = panel.webview.onDidReceiveMessage(async (message: WebviewMessage) => {
+            switch (message.command) {
+                case 'refresh': {
+                    const ctx = StatefulSetDescribeWebview.contextName;
+                    const ns = StatefulSetDescribeWebview.currentNamespace;
+                    const n = StatefulSetDescribeWebview.currentName;
+                    if (ctx && ns && n) {
+                        StatefulSetDescribeWebview.clearCache(ctx, ns, n);
                     }
-                    case 'viewYaml': {
-                        const n = StatefulSetDescribeWebview.currentName;
-                        const ns = StatefulSetDescribeWebview.currentNamespace;
-                        const cluster = StatefulSetDescribeWebview.contextName;
-                        if (!n || !ns || !cluster) {
-                            vscode.window.showErrorMessage('StatefulSet context not available');
-                            break;
-                        }
-                        try {
-                            const { getYAMLEditorManager } = await import('../extension');
-                            const yamlEditorManager = getYAMLEditorManager();
-                            await yamlEditorManager.openYAMLEditor({
-                                kind: 'StatefulSet',
-                                name: n,
-                                namespace: ns,
-                                apiVersion: 'apps/v1',
-                                cluster
-                            });
-                        } catch (e) {
-                            const msg = e instanceof Error ? e.message : String(e);
-                            vscode.window.showErrorMessage(`Failed to open YAML: ${msg}`);
-                        }
-                        break;
-                    }
-                    case 'navigateToPod': {
-                        const podName = message.podName;
-                        const ns = message.namespace || StatefulSetDescribeWebview.currentNamespace;
-                        if (!podName) {
-                            vscode.window.showErrorMessage('Pod name is required');
-                            break;
-                        }
-                        try {
-                            await vscode.commands.executeCommand('kube9.revealPod', podName, ns || 'default');
-                        } catch (e) {
-                            const msg = e instanceof Error ? e.message : String(e);
-                            vscode.window.showErrorMessage(`Failed to reveal pod: ${msg}`);
-                        }
-                        break;
-                    }
-                    case 'copyValue': {
-                        const value = message.value || message.content;
-                        if (value) {
-                            try {
-                                await vscode.env.clipboard.writeText(value);
-                                vscode.window.showInformationMessage('Copied to clipboard');
-                            } catch (e) {
-                                const msg = e instanceof Error ? e.message : String(e);
-                                vscode.window.showErrorMessage(`Failed to copy: ${msg}`);
-                            }
-                        }
-                        break;
-                    }
-                    default:
-                        console.log('Unknown StatefulSet describe message:', message.command);
+                    await StatefulSetDescribeWebview.refreshData();
+                    break;
                 }
-            },
-            null,
-            context.subscriptions
-        );
+                case 'viewYaml': {
+                    const n = StatefulSetDescribeWebview.currentName;
+                    const ns = StatefulSetDescribeWebview.currentNamespace;
+                    const cluster = StatefulSetDescribeWebview.contextName;
+                    if (!n || !ns || !cluster) {
+                        vscode.window.showErrorMessage('StatefulSet context not available');
+                        break;
+                    }
+                    try {
+                        const { getYAMLEditorManager } = await import('../extension');
+                        const yamlEditorManager = getYAMLEditorManager();
+                        await yamlEditorManager.openYAMLEditor({
+                            kind: 'StatefulSet',
+                            name: n,
+                            namespace: ns,
+                            apiVersion: 'apps/v1',
+                            cluster
+                        });
+                    } catch (e) {
+                        const msg = e instanceof Error ? e.message : String(e);
+                        vscode.window.showErrorMessage(`Failed to open YAML: ${msg}`);
+                    }
+                    break;
+                }
+                case 'navigateToPod': {
+                    const podName = message.podName;
+                    const ns = message.namespace || StatefulSetDescribeWebview.currentNamespace;
+                    if (!podName) {
+                        vscode.window.showErrorMessage('Pod name is required');
+                        break;
+                    }
+                    try {
+                        await vscode.commands.executeCommand('kube9.revealPod', podName, ns || 'default');
+                    } catch (e) {
+                        const msg = e instanceof Error ? e.message : String(e);
+                        vscode.window.showErrorMessage(`Failed to reveal pod: ${msg}`);
+                    }
+                    break;
+                }
+                case 'copyValue': {
+                    const value = message.value || message.content;
+                    if (value) {
+                        try {
+                            await vscode.env.clipboard.writeText(value);
+                            vscode.window.showInformationMessage('Copied to clipboard');
+                        } catch (e) {
+                            const msg = e instanceof Error ? e.message : String(e);
+                            vscode.window.showErrorMessage(`Failed to copy: ${msg}`);
+                        }
+                    }
+                    break;
+                }
+                default:
+                    console.log('Unknown StatefulSet describe message:', message.command);
+            }
+        });
     }
 
     private static getWebviewContent(webview: vscode.Webview): string {

--- a/src/webview/StatefulSetDescribeWebview.ts
+++ b/src/webview/StatefulSetDescribeWebview.ts
@@ -35,6 +35,7 @@ export class StatefulSetDescribeWebview {
         kubeconfigPath: string,
         contextName: string
     ): Promise<void> {
+        DescribeWebview.releaseSharedDescribeMessageBindings();
         StatefulSetDescribeWebview.currentName = statefulSetName;
         StatefulSetDescribeWebview.currentNamespace = namespace;
         StatefulSetDescribeWebview.kubeconfigPath = kubeconfigPath;

--- a/src/webview/deploymentDataTransformer.ts
+++ b/src/webview/deploymentDataTransformer.ts
@@ -250,7 +250,7 @@ export function transformDeploymentData(
         labels: metadata?.labels || {},
         selectors: spec?.selector?.matchLabels || {},
         annotations: metadata?.annotations || {},
-        events: transformEvents(events)
+        events: transformKubernetesEvents(events)
     };
 }
 
@@ -368,10 +368,9 @@ function extractStrategy(deployment: k8s.V1Deployment): DeploymentStrategy {
 }
 
 /**
- * Extracts pod template information.
+ * Extracts pod template information from a Pod spec (Deployment, StatefulSet, etc.).
  */
-function extractPodTemplate(deployment: k8s.V1Deployment): PodTemplateInfo {
-    const podSpec = deployment.spec?.template?.spec;
+export function extractPodTemplateInfoFromPodSpec(podSpec?: k8s.V1PodSpec): PodTemplateInfo {
     if (!podSpec) {
         return {
             containers: [],
@@ -387,7 +386,7 @@ function extractPodTemplate(deployment: k8s.V1Deployment): PodTemplateInfo {
             }
         };
     }
-    
+
     return {
         containers: (podSpec.containers || []).map(extractContainerInfo),
         initContainers: (podSpec.initContainers || []).map(extractContainerInfo),
@@ -396,6 +395,13 @@ function extractPodTemplate(deployment: k8s.V1Deployment): PodTemplateInfo {
         serviceAccount: podSpec.serviceAccountName || 'default',
         securityContext: extractPodSecurityContext(podSpec.securityContext)
     };
+}
+
+/**
+ * Extracts pod template information.
+ */
+function extractPodTemplate(deployment: k8s.V1Deployment): PodTemplateInfo {
+    return extractPodTemplateInfoFromPodSpec(deployment.spec?.template?.spec);
 }
 
 /**
@@ -746,7 +752,7 @@ function transformReplicaSets(
 /**
  * Transforms events into DeploymentEvent array, filtering to last hour and grouping by reason.
  */
-function transformEvents(events: k8s.CoreV1Event[]): DeploymentEvent[] {
+export function transformKubernetesEvents(events: k8s.CoreV1Event[]): DeploymentEvent[] {
     const now = Date.now();
     const oneHourAgo = now - (60 * 60 * 1000);
     

--- a/src/webview/describeSharedPanelBindings.ts
+++ b/src/webview/describeSharedPanelBindings.ts
@@ -1,0 +1,18 @@
+import { CronJobDescribeWebview } from './CronJobDescribeWebview';
+import { DeploymentDescribeWebview } from './DeploymentDescribeWebview';
+import { DescribeWebview } from './DescribeWebview';
+import { NodeDescribeWebview } from './NodeDescribeWebview';
+import { StatefulSetDescribeWebview } from './StatefulSetDescribeWebview';
+
+/**
+ * Releases every active message handler on the shared kube9 Describe webview panel
+ * (generic Describe plus structured workload/node detail views) so the next view
+ * can take exclusive ownership without stale refresh/YAML/navigation handlers.
+ */
+export function releaseExclusiveDescribePanelBindings(): void {
+    DescribeWebview.releaseSharedDescribeMessageBindings();
+    DeploymentDescribeWebview.releaseMessageBindings();
+    CronJobDescribeWebview.releaseMessageBindings();
+    NodeDescribeWebview.releaseMessageBindings();
+    StatefulSetDescribeWebview.releaseMessageBindings();
+}

--- a/src/webview/statefulSetDataTransformer.ts
+++ b/src/webview/statefulSetDataTransformer.ts
@@ -1,0 +1,413 @@
+/**
+ * Transforms Kubernetes StatefulSet, Pods, PVCs, and Events into a webview-ready shape.
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import { calculateAge } from '../utils/deploymentUtils';
+import { formatRelativeTime } from '../utils/timeFormatting';
+import {
+    DeploymentEvent,
+    extractPodTemplateInfoFromPodSpec,
+    PodTemplateInfo,
+    transformKubernetesEvents
+} from './deploymentDataTransformer';
+
+/** High-level rollout / revision summary for a StatefulSet. */
+export interface StatefulSetRolloutInfo {
+    currentRevision: string;
+    updateRevision: string;
+    collisionCount: number;
+    paused: boolean;
+    partition: number | null;
+}
+
+/** One row per desired ordinal (0 … replicas-1). */
+export interface StatefulSetOrdinalPodRow {
+    ordinal: number;
+    expectedPodName: string;
+    podPresent: boolean;
+    phase: string;
+    readyDisplay: string;
+    restartCount: number;
+    nodeName: string;
+    statusDetail: string;
+    age: string;
+}
+
+/** Declared volume claim template (from spec). */
+export interface VolumeClaimTemplateSummary {
+    name: string;
+    accessModes: string[];
+    storageRequest: string;
+    storageClassName: string;
+}
+
+/** PVC resolved for one ordinal × one template. */
+export interface OrdinalPvcRow {
+    ordinal: number;
+    templateName: string;
+    pvcName: string;
+    found: boolean;
+    phase: string;
+    capacity: string;
+    storageClassName: string;
+}
+
+export interface StatefulSetOverview {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    age: string;
+    generation: number;
+    observedGeneration: number;
+    /** Desired replicas */
+    replicas: number;
+    currentReplicas: number;
+    readyReplicas: number;
+    updatedReplicas: number;
+    serviceName: string;
+    updateStrategyType: string;
+    podManagementPolicy: string;
+    selectorDisplay: string;
+    /** Human-readable rollout health */
+    rolloutSummary: string;
+}
+
+export interface StatefulSetReplicaStatus {
+    desired: number;
+    current: number;
+    ready: number;
+    updated: number;
+    readyPercentage: number;
+    isHealthy: boolean;
+}
+
+export interface StatefulSetConditionRow {
+    type: string;
+    status: string;
+    reason: string;
+    message: string;
+    relativeTime: string;
+    severity: 'success' | 'warning' | 'error' | 'info';
+}
+
+export interface StatefulSetDescribeData {
+    name: string;
+    namespace: string;
+    overview: StatefulSetOverview;
+    replicaStatus: StatefulSetReplicaStatus;
+    rollout: StatefulSetRolloutInfo;
+    ordinalPods: StatefulSetOrdinalPodRow[];
+    volumeClaimTemplates: VolumeClaimTemplateSummary[];
+    ordinalPvcs: OrdinalPvcRow[];
+    conditions: StatefulSetConditionRow[];
+    podTemplate: PodTemplateInfo;
+    labels: Record<string, string>;
+    selectors: Record<string, string>;
+    annotations: Record<string, string>;
+    events: DeploymentEvent[];
+    /** Non-fatal fetch problems (RBAC, transient API), shown as page warnings */
+    dataLoadErrors?: {
+        pods?: string;
+        pvcs?: string;
+        events?: string;
+    };
+}
+
+function extractOrdinalFromPodName(statefulSetName: string, podName: string): number | null {
+    const prefix = `${statefulSetName}-`;
+    if (!podName.startsWith(prefix)) {
+        return null;
+    }
+    const suffix = podName.slice(prefix.length);
+    const n = parseInt(suffix, 10);
+    return Number.isFinite(n) && String(n) === suffix ? n : null;
+}
+
+function podReadyDisplay(pod: k8s.V1Pod): string {
+    const conditions = pod.status?.conditions || [];
+    const readyCond = conditions.find(c => c.type === 'Ready');
+    if (readyCond?.status === 'True') {
+        return 'Ready';
+    }
+    if (readyCond?.status === 'False') {
+        return `NotReady (${readyCond.reason || 'False'})`;
+    }
+    return readyCond?.status || pod.status?.phase || 'Unknown';
+}
+
+function podRestarts(pod: k8s.V1Pod): number {
+    let total = 0;
+    for (const cs of pod.status?.containerStatuses || []) {
+        total += cs.restartCount || 0;
+    }
+    for (const cs of pod.status?.initContainerStatuses || []) {
+        total += cs.restartCount || 0;
+    }
+    return total;
+}
+
+function podAge(pod: k8s.V1Pod): string {
+    const ts = pod.metadata?.creationTimestamp;
+    if (!ts) {
+        return '';
+    }
+    const creationTimestamp = typeof ts === 'string' ? ts : ts.toISOString();
+    return calculateAge(creationTimestamp);
+}
+
+function extractOverview(
+    statefulSet: k8s.V1StatefulSet,
+    replicaStatus: StatefulSetReplicaStatus
+): StatefulSetOverview {
+    const metadata = statefulSet.metadata;
+    const spec = statefulSet.spec;
+    const status = statefulSet.status;
+
+    let creationTimestamp = '';
+    if (metadata?.creationTimestamp) {
+        creationTimestamp =
+            typeof metadata.creationTimestamp === 'string'
+                ? metadata.creationTimestamp
+                : metadata.creationTimestamp.toISOString();
+    }
+
+    const matchLabels = spec?.selector?.matchLabels || {};
+    const selectorDisplay = Object.entries(matchLabels)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(', ');
+
+    let rolloutSummary = 'Unknown';
+    const conds = status?.conditions || [];
+    const readyCond = conds.find(c => c.type === 'Ready');
+    if (readyCond?.status === 'True') {
+        rolloutSummary = 'Ready';
+    } else if (readyCond?.status === 'False') {
+        rolloutSummary = readyCond.message || readyCond.reason || 'Not ready';
+    } else if (replicaStatus.desired > 0 && replicaStatus.ready === replicaStatus.desired) {
+        rolloutSummary = 'Replicas ready';
+    } else if (replicaStatus.desired > 0) {
+        rolloutSummary = `Waiting for pods (${replicaStatus.ready}/${replicaStatus.desired} ready)`;
+    }
+
+    const st = spec?.updateStrategy;
+    const updateStrategyType = st?.type || 'RollingUpdate';
+
+    return {
+        name: metadata?.name || 'Unknown',
+        namespace: metadata?.namespace || 'default',
+        creationTimestamp,
+        age: creationTimestamp ? calculateAge(creationTimestamp) : '',
+        generation: metadata?.generation || 0,
+        observedGeneration: status?.observedGeneration || 0,
+        replicas: spec?.replicas ?? 0,
+        currentReplicas: status?.currentReplicas ?? 0,
+        readyReplicas: status?.readyReplicas ?? 0,
+        updatedReplicas: status?.updatedReplicas ?? 0,
+        serviceName: spec?.serviceName || '',
+        updateStrategyType,
+        podManagementPolicy: spec?.podManagementPolicy || 'OrderedReady',
+        selectorDisplay,
+        rolloutSummary
+    };
+}
+
+function extractReplicaStatus(statefulSet: k8s.V1StatefulSet): StatefulSetReplicaStatus {
+    const spec = statefulSet.spec;
+    const status = statefulSet.status;
+    const desired = spec?.replicas ?? 0;
+    const current = status?.currentReplicas ?? 0;
+    const ready = status?.readyReplicas ?? 0;
+    const updated = status?.updatedReplicas ?? 0;
+    return {
+        desired,
+        current,
+        ready,
+        updated,
+        readyPercentage: desired > 0 ? (ready / desired) * 100 : 0,
+        isHealthy: desired > 0 && ready === desired && current === desired
+    };
+}
+
+function extractRollout(statefulSet: k8s.V1StatefulSet): StatefulSetRolloutInfo {
+    const status = statefulSet.status;
+    const spec = statefulSet.spec;
+    const ru = spec?.updateStrategy?.rollingUpdate;
+    let partition: number | null = null;
+    if (ru && ru.partition !== undefined && ru.partition !== null) {
+        partition = ru.partition;
+    }
+    return {
+        currentRevision: status?.currentRevision || '',
+        updateRevision: status?.updateRevision || '',
+        collisionCount: status?.collisionCount ?? 0,
+        paused: false,
+        partition
+    };
+}
+
+function buildOrdinalPodRows(
+    statefulSet: k8s.V1StatefulSet,
+    pods: k8s.V1Pod[]
+): StatefulSetOrdinalPodRow[] {
+    const name = statefulSet.metadata?.name || '';
+    const desired = statefulSet.spec?.replicas ?? 0;
+    const podByOrdinal = new Map<number, k8s.V1Pod>();
+
+    for (const pod of pods) {
+        const podName = pod.metadata?.name || '';
+        const ord = extractOrdinalFromPodName(name, podName);
+        if (ord !== null) {
+            podByOrdinal.set(ord, pod);
+        }
+    }
+
+    const rows: StatefulSetOrdinalPodRow[] = [];
+    for (let i = 0; i < desired; i++) {
+        const expectedPodName = `${name}-${i}`;
+        const pod = podByOrdinal.get(i);
+        if (!pod) {
+            rows.push({
+                ordinal: i,
+                expectedPodName,
+                podPresent: false,
+                phase: '—',
+                readyDisplay: 'Pod not created yet',
+                restartCount: 0,
+                nodeName: '—',
+                statusDetail: 'No pod matching this ordinal',
+                age: '—'
+            });
+            continue;
+        }
+
+        const conditions = pod.status?.conditions || [];
+        const scheduled = conditions.find(c => c.type === 'PodScheduled');
+        let statusDetail = pod.status?.reason || '';
+        if (!statusDetail && scheduled?.status === 'False') {
+            statusDetail = scheduled.message || scheduled.reason || 'Unscheduled';
+        }
+        if (!statusDetail) {
+            statusDetail = pod.status?.message || '';
+        }
+
+        rows.push({
+            ordinal: i,
+            expectedPodName: pod.metadata?.name || expectedPodName,
+            podPresent: true,
+            phase: pod.status?.phase || 'Unknown',
+            readyDisplay: podReadyDisplay(pod),
+            restartCount: podRestarts(pod),
+            nodeName: pod.spec?.nodeName || 'Pending',
+            statusDetail: statusDetail || '—',
+            age: podAge(pod)
+        });
+    }
+
+    return rows;
+}
+
+function summarizeVolumeClaimTemplates(statefulSet: k8s.V1StatefulSet): VolumeClaimTemplateSummary[] {
+    const templates = statefulSet.spec?.volumeClaimTemplates || [];
+    return templates.map(t => {
+        const req = t.spec?.resources?.requests?.storage || '';
+        return {
+            name: t.metadata?.name || '',
+            accessModes: t.spec?.accessModes || [],
+            storageRequest: typeof req === 'string' ? req : String(req || ''),
+            storageClassName: t.spec?.storageClassName || ''
+        };
+    });
+}
+
+function buildOrdinalPvcRows(
+    statefulSet: k8s.V1StatefulSet,
+    pvcs: k8s.V1PersistentVolumeClaim[]
+): OrdinalPvcRow[] {
+    const stsName = statefulSet.metadata?.name || '';
+    const desired = statefulSet.spec?.replicas ?? 0;
+    const templates = statefulSet.spec?.volumeClaimTemplates || [];
+    const pvcByName = new Map<string, k8s.V1PersistentVolumeClaim>();
+    for (const p of pvcs) {
+        const n = p.metadata?.name;
+        if (n) {
+            pvcByName.set(n, p);
+        }
+    }
+
+    const rows: OrdinalPvcRow[] = [];
+    for (const t of templates) {
+        const tname = t.metadata?.name || '';
+        for (let i = 0; i < desired; i++) {
+            const pvcName = `${tname}-${stsName}-${i}`;
+            const pvc = pvcByName.get(pvcName);
+            rows.push({
+                ordinal: i,
+                templateName: tname,
+                pvcName,
+                found: !!pvc,
+                phase: pvc?.status?.phase || (pvc ? 'Unknown' : 'Not found'),
+                capacity: pvc?.status?.capacity?.storage || '—',
+                storageClassName: pvc?.spec?.storageClassName || t.spec?.storageClassName || '—'
+            });
+        }
+    }
+    return rows;
+}
+
+function extractConditions(statefulSet: k8s.V1StatefulSet): StatefulSetConditionRow[] {
+    const conditions = statefulSet.status?.conditions || [];
+    return conditions.map(c => {
+        const lastTransition = c.lastTransitionTime;
+        let lastTransitionStr = '';
+        if (lastTransition) {
+            lastTransitionStr =
+                typeof lastTransition === 'string' ? lastTransition : lastTransition.toISOString();
+        }
+        let severity: StatefulSetConditionRow['severity'] = 'info';
+        if (c.type === 'Ready' && c.status === 'True') {
+            severity = 'success';
+        } else if (c.status === 'False') {
+            severity = 'error';
+        }
+        return {
+            type: c.type || '',
+            status: c.status || '',
+            reason: c.reason || '',
+            message: c.message || '',
+            relativeTime: lastTransitionStr ? formatRelativeTime(lastTransitionStr) : '',
+            severity
+        };
+    });
+}
+
+/**
+ * Transforms API objects into data for the StatefulSet describe webview.
+ */
+export function transformStatefulSetData(
+    statefulSet: k8s.V1StatefulSet,
+    pods: k8s.V1Pod[],
+    pvcs: k8s.V1PersistentVolumeClaim[],
+    events: k8s.CoreV1Event[]
+): StatefulSetDescribeData {
+    const metadata = statefulSet.metadata;
+    const spec = statefulSet.spec;
+    const replicaStatus = extractReplicaStatus(statefulSet);
+
+    return {
+        name: metadata?.name || 'Unknown',
+        namespace: metadata?.namespace || 'default',
+        overview: extractOverview(statefulSet, replicaStatus),
+        replicaStatus,
+        rollout: extractRollout(statefulSet),
+        ordinalPods: buildOrdinalPodRows(statefulSet, pods),
+        volumeClaimTemplates: summarizeVolumeClaimTemplates(statefulSet),
+        ordinalPvcs: buildOrdinalPvcRows(statefulSet, pvcs),
+        conditions: extractConditions(statefulSet),
+        podTemplate: extractPodTemplateInfoFromPodSpec(spec?.template?.spec),
+        labels: metadata?.labels || {},
+        selectors: spec?.selector?.matchLabels || {},
+        annotations: metadata?.annotations || {},
+        events: transformKubernetesEvents(events)
+    };
+}

--- a/src/webview/statefulSetDataTransformer.ts
+++ b/src/webview/statefulSetDataTransformer.ts
@@ -21,7 +21,7 @@ export interface StatefulSetRolloutInfo {
     partition: number | null;
 }
 
-/** One row per desired ordinal (0 … replicas-1). */
+/** One row per desired ordinal (respects spec.ordinals.start when set). */
 export interface StatefulSetOrdinalPodRow {
     ordinal: number;
     expectedPodName: string;
@@ -112,6 +112,19 @@ export interface StatefulSetDescribeData {
         pvcs?: string;
         events?: string;
     };
+}
+
+/** First ordinal index for this StatefulSet (defaults to 0). */
+export function statefulSetOrdinalStart(statefulSet: k8s.V1StatefulSet): number {
+    const start = statefulSet.spec?.ordinals?.start;
+    return start !== undefined && start !== null ? start : 0;
+}
+
+/** Ordered list of ordinal indices for desired replicas. */
+export function statefulSetDesiredOrdinals(statefulSet: k8s.V1StatefulSet): number[] {
+    const desired = statefulSet.spec?.replicas ?? 0;
+    const start = statefulSetOrdinalStart(statefulSet);
+    return Array.from({ length: desired }, (_, i) => start + i);
 }
 
 function extractOrdinalFromPodName(statefulSetName: string, podName: string): number | null {
@@ -251,7 +264,7 @@ function buildOrdinalPodRows(
     pods: k8s.V1Pod[]
 ): StatefulSetOrdinalPodRow[] {
     const name = statefulSet.metadata?.name || '';
-    const desired = statefulSet.spec?.replicas ?? 0;
+    const ordinals = statefulSetDesiredOrdinals(statefulSet);
     const podByOrdinal = new Map<number, k8s.V1Pod>();
 
     for (const pod of pods) {
@@ -263,7 +276,7 @@ function buildOrdinalPodRows(
     }
 
     const rows: StatefulSetOrdinalPodRow[] = [];
-    for (let i = 0; i < desired; i++) {
+    for (const i of ordinals) {
         const expectedPodName = `${name}-${i}`;
         const pod = podByOrdinal.get(i);
         if (!pod) {
@@ -325,7 +338,7 @@ function buildOrdinalPvcRows(
     pvcs: k8s.V1PersistentVolumeClaim[]
 ): OrdinalPvcRow[] {
     const stsName = statefulSet.metadata?.name || '';
-    const desired = statefulSet.spec?.replicas ?? 0;
+    const ordinals = statefulSetDesiredOrdinals(statefulSet);
     const templates = statefulSet.spec?.volumeClaimTemplates || [];
     const pvcByName = new Map<string, k8s.V1PersistentVolumeClaim>();
     for (const p of pvcs) {
@@ -338,7 +351,7 @@ function buildOrdinalPvcRows(
     const rows: OrdinalPvcRow[] = [];
     for (const t of templates) {
         const tname = t.metadata?.name || '';
-        for (let i = 0; i < desired; i++) {
+        for (const i of ordinals) {
             const pvcName = `${tname}-${stsName}-${i}`;
             const pvc = pvcByName.get(pvcName);
             rows.push({


### PR DESCRIPTION
## Description

Adds a StatefulSet-specific Describe webview with overview, ordinal pod matrix, volumeClaimTemplates / PVC binding, revisions, conditions, events, YAML entry, and RBAC-aware warnings for partial API failures.

Closes #147.

## Motivation and Context

StatefulSet Describe previously fell through to the generic "Coming soon" stub. Operators need the same structured surface as Deployments for rollout and storage diagnostics.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests (`statefulSetDataTransformer`)
- [x] `npm run compile`, `npm run lint`, `npm run test:unit`, `npm run build` (local + pre-push)

## Checklist

- [x] Telemetry: N/A (no new product telemetry)
- [x] Tests added
- [x] Lint / tests / build passing

## Summary

- Route tree/context-menu Describe for `StatefulSet` to a dedicated webview sharing the global describe panel.
- Fetch STS, pods (label selector), namespace PVC list, and STS-scoped events; shape data for ordinal rows and PVC name pattern `{template}-{sts}-{ordinal}`.

## Test plan

- [ ] Extension Development Host: Describe a StatefulSet with volumeClaimTemplates; confirm ordinal pods and PVC rows match cluster state.
- [ ] Confirm View YAML opens the existing kube9 YAML editor for the same STS.
- [ ] (Optional) Restrict list pods permission and verify warning banner + overview still loads.