### PR TITLE
feat(describe): DaemonSet structured detail webview (#148)

### DIFF
--- a/src/kubectl/WorkloadCommands.ts
+++ b/src/kubectl/WorkloadCommands.ts
@@ -220,6 +220,44 @@ export interface DaemonSetsResult {
 }
 
 /**
+ * Result of a single DaemonSet read operation.
+ */
+export interface DaemonSetDetailsResult {
+    /**
+     * Complete V1DaemonSet object, undefined if query failed.
+     */
+    daemonSet?: k8s.V1DaemonSet;
+    /**
+     * Error information if the query failed.
+     */
+    error?: KubectlError;
+}
+
+/**
+ * Events scoped to a DaemonSet and its Pods.
+ */
+export interface DaemonSetEventsResult {
+    events: k8s.CoreV1Event[];
+    error?: KubectlError;
+}
+
+/**
+ * Cluster nodes for DaemonSet node coverage (optional; may fail under RBAC).
+ */
+export interface ClusterNodesResult {
+    nodes: k8s.V1Node[];
+    error?: KubectlError;
+}
+
+/**
+ * Full Pod objects for DaemonSet describe (richer than PodInfo).
+ */
+export interface DaemonSetPodsFullResult {
+    pods: k8s.V1Pod[];
+    error?: KubectlError;
+}
+
+/**
  * Result of a cronjob query operation.
  */
 export interface CronJobsResult {
@@ -667,6 +705,40 @@ export class WorkloadCommands {
     }
 
     /**
+     * Reads a single namespaced DaemonSet.
+     */
+    public static async getDaemonSetDetails(
+        daemonSetName: string,
+        namespace: string,
+        kubeconfigPath: string,
+        contextName: string
+    ): Promise<DaemonSetDetailsResult> {
+        try {
+            const apiClient = getKubernetesApiClient();
+            apiClient.setContext(contextName);
+
+            const v1DaemonSet = await apiClient.apps.readNamespacedDaemonSet({
+                name: daemonSetName,
+                namespace
+            });
+
+            return {
+                daemonSet: v1DaemonSet,
+                error: undefined
+            };
+        } catch (error: unknown) {
+            const kubectlError = KubectlError.fromExecError(error, contextName);
+            console.log(
+                `DaemonSet details query failed for ${daemonSetName} in namespace ${namespace} in context ${contextName}: ${kubectlError.getDetails()}`
+            );
+            return {
+                daemonSet: undefined,
+                error: kubectlError
+            };
+        }
+    }
+
+    /**
      * Lists namespace events involving this StatefulSet.
      */
     public static async getStatefulSetEvents(
@@ -720,6 +792,61 @@ export class WorkloadCommands {
     }
 
     /**
+     * Lists namespace events involving the DaemonSet or one of its Pods.
+     */
+    public static async getDaemonSetEvents(
+        daemonSetName: string,
+        namespace: string,
+        kubeconfigPath: string,
+        contextName: string,
+        relatedPodNames: string[]
+    ): Promise<DaemonSetEventsResult> {
+        try {
+            const apiClient = getKubernetesApiClient();
+            apiClient.setContext(contextName);
+
+            const response = await apiClient.core.listNamespacedEvent({
+                namespace,
+                timeoutSeconds: 10
+            });
+
+            const allEvents = response.items || [];
+            const podSet = new Set(relatedPodNames);
+            const filteredEvents = allEvents.filter(event =>
+                (event.involvedObject?.kind === 'DaemonSet' &&
+                    event.involvedObject?.name === daemonSetName) ||
+                (event.involvedObject?.kind === 'Pod' && podSet.has(event.involvedObject?.name || ''))
+            );
+
+            const sortedEvents = filteredEvents.sort((a, b) => {
+                const aTimestamp = a.lastTimestamp || a.firstTimestamp || '';
+                const bTimestamp = b.lastTimestamp || b.firstTimestamp || '';
+                if (aTimestamp > bTimestamp) {
+                    return -1;
+                }
+                if (aTimestamp < bTimestamp) {
+                    return 1;
+                }
+                return 0;
+            });
+
+            return {
+                events: sortedEvents,
+                error: undefined
+            };
+        } catch (error: unknown) {
+            const kubectlError = KubectlError.fromExecError(error, contextName);
+            console.log(
+                `DaemonSet events query failed for ${daemonSetName} in namespace ${namespace} in context ${contextName}: ${kubectlError.getDetails()}`
+            );
+            return {
+                events: [],
+                error: kubectlError
+            };
+        }
+    }
+
+    /**
      * Returns full Pod objects for a namespaced label selector (used by StatefulSet describe).
      */
     public static async getV1PodsForLabelSelector(
@@ -745,6 +872,67 @@ export class WorkloadCommands {
         } catch (error: unknown) {
             const kubectlError = KubectlError.fromExecError(error, contextName);
             console.log(`Pod query failed for labelSelector in ${namespace}: ${kubectlError.getDetails()}`);
+            return {
+                pods: [],
+                error: kubectlError
+            };
+        }
+    }
+
+    /**
+     * Lists cluster nodes for DaemonSet scheduling coverage (may fail if nodes cannot be listed).
+     */
+    public static async listClusterNodes(
+        kubeconfigPath: string,
+        contextName: string
+    ): Promise<ClusterNodesResult> {
+        try {
+            const apiClient = getKubernetesApiClient();
+            apiClient.setContext(contextName);
+            const response = await apiClient.core.listNode({
+                timeoutSeconds: 10
+            });
+            return {
+                nodes: response.items || [],
+                error: undefined
+            };
+        } catch (error: unknown) {
+            const kubectlError = KubectlError.fromExecError(error, contextName);
+            console.log(`Node list failed for context ${contextName}: ${kubectlError.getDetails()}`);
+            return {
+                nodes: [],
+                error: kubectlError
+            };
+        }
+    }
+
+    /**
+     * Lists Pods for a DaemonSet using its label selector (full objects for describe UI).
+     */
+    public static async listPodsForDaemonSetFull(
+        kubeconfigPath: string,
+        contextName: string,
+        daemonSetName: string,
+        namespace: string,
+        labelSelector: string
+    ): Promise<DaemonSetPodsFullResult> {
+        if (!labelSelector) {
+            return { pods: [] };
+        }
+        try {
+            const apiClient = getKubernetesApiClient();
+            apiClient.setContext(contextName);
+            const v1Pods = await fetchPods({
+                namespace,
+                labelSelector,
+                timeout: 10
+            });
+            return { pods: v1Pods };
+        } catch (error: unknown) {
+            const kubectlError = KubectlError.fromExecError(error, contextName);
+            console.log(
+                `Full pod list failed for daemonset ${daemonSetName} in namespace ${namespace}: ${kubectlError.getDetails()}`
+            );
             return {
                 pods: [],
                 error: kubectlError

--- a/src/test/suite/webview/daemonSetDataTransformer.test.ts
+++ b/src/test/suite/webview/daemonSetDataTransformer.test.ts
@@ -1,0 +1,109 @@
+import * as assert from 'assert';
+import * as k8s from '@kubernetes/client-node';
+import { transformDaemonSetData } from '../../../webview/daemonSetDataTransformer';
+
+suite('daemonSetDataTransformer', () => {
+    test('derives scheduling counts and pod rows from DaemonSet and Pods', () => {
+        const ds: k8s.V1DaemonSet = {
+            metadata: { name: 'ds1', namespace: 'ns1', uid: 'uid-ds', creationTimestamp: new Date('2020-01-01T00:00:00Z') },
+            spec: {
+                selector: { matchLabels: { app: 'x' } },
+                template: {
+                    spec: {
+                        containers: [{ name: 'c1', image: 'img:v1' }]
+                    }
+                }
+            },
+            status: {
+                desiredNumberScheduled: 2,
+                currentNumberScheduled: 2,
+                numberReady: 1,
+                numberAvailable: 1,
+                numberUnavailable: 1,
+                numberMisscheduled: 0,
+                updatedNumberScheduled: 2
+            }
+        };
+
+        const podOwned: k8s.V1Pod = {
+            metadata: {
+                name: 'ds1-aaa',
+                namespace: 'ns1',
+                ownerReferences: [
+                    { apiVersion: 'apps/v1', kind: 'DaemonSet', name: 'ds1', uid: 'uid-ds' }
+                ],
+                creationTimestamp: new Date('2020-01-02T00:00:00Z')
+            },
+            spec: { nodeName: 'node-a', containers: [] },
+            status: {
+                phase: 'Running',
+                containerStatuses: [
+                    { name: 'c1', ready: true, restartCount: 0, image: 'img:v1', imageID: 'docker://img' }
+                ]
+            }
+        };
+
+        const out = transformDaemonSetData(ds, [podOwned], undefined, 'forbidden: nodes', [], undefined, undefined);
+
+        assert.strictEqual(out.replicaCounts.desiredScheduled, 2);
+        assert.strictEqual(out.replicaCounts.ready, 1);
+        assert.strictEqual(out.pods.length, 1);
+        assert.strictEqual(out.pods[0].node, 'node-a');
+        assert.strictEqual(out.pods[0].ready, '1/1');
+        assert.ok(out.nodeCoverageLimitedMessage?.includes('Node coverage'));
+        assert.strictEqual(out.podTemplate.containers.length, 1);
+        assert.strictEqual(out.podTemplate.containers[0].image, 'img:v1');
+    });
+
+    test('builds node coverage when nodes list succeeds', () => {
+        const ds: k8s.V1DaemonSet = {
+            metadata: { name: 'ds1', namespace: 'ns1', uid: 'uid-ds', creationTimestamp: new Date() },
+            spec: {
+                selector: { matchLabels: { app: 'x' } },
+                template: {
+                    metadata: { labels: { app: 'x' } },
+                    spec: {
+                        nodeSelector: { disktype: 'ssd' },
+                        containers: [{ name: 'c1', image: 'img:v1' }]
+                    }
+                }
+            },
+            status: {
+                desiredNumberScheduled: 1,
+                currentNumberScheduled: 1,
+                numberReady: 1,
+                numberAvailable: 1,
+                numberUnavailable: 0,
+                numberMisscheduled: 0,
+                updatedNumberScheduled: 1
+            }
+        };
+
+        const node: k8s.V1Node = {
+            metadata: { name: 'n1', labels: { disktype: 'ssd' } }
+        };
+
+        const pod: k8s.V1Pod = {
+            metadata: {
+                name: 'p1',
+                namespace: 'ns1',
+                ownerReferences: [{ apiVersion: 'apps/v1', kind: 'DaemonSet', name: 'ds1', uid: 'uid-ds' }],
+                creationTimestamp: new Date()
+            },
+            spec: { nodeName: 'n1', containers: [] },
+            status: {
+                phase: 'Running',
+                containerStatuses: [
+                    { name: 'c1', ready: true, restartCount: 1, image: 'img:v1', imageID: 'docker://img' }
+                ]
+            }
+        };
+
+        const out = transformDaemonSetData(ds, [pod], [node], undefined, [], undefined, undefined);
+
+        assert.strictEqual(out.nodeCoverage.length, 1);
+        assert.strictEqual(out.nodeCoverage[0].state, 'ready');
+        assert.strictEqual(out.nodeCoverage[0].podName, 'p1');
+        assert.strictEqual(out.pods[0].restartCount, 1);
+    });
+});

--- a/src/test/suite/webview/daemonSetDescribeWebviewBindings.test.ts
+++ b/src/test/suite/webview/daemonSetDescribeWebviewBindings.test.ts
@@ -245,7 +245,7 @@ suite('DaemonSetDescribeWebview panel bindings', () => {
                         selector: { matchLabels: { app: 'web' } },
                         template: { spec: { containers: [{ name: 'nginx', image: 'nginx' }] } }
                     },
-                    status: {}
+                    status: { replicas: 1 }
                 },
                 error: undefined
             } as Awaited<ReturnType<typeof WorkloadCommands.getStatefulSetDetails>>;

--- a/src/test/suite/webview/daemonSetDescribeWebviewBindings.test.ts
+++ b/src/test/suite/webview/daemonSetDescribeWebviewBindings.test.ts
@@ -1,0 +1,373 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as k8s from '@kubernetes/client-node';
+import { getResourceCache } from '../../../kubernetes/cache';
+import { KubectlError, KubectlErrorType } from '../../../kubernetes/KubectlError';
+import { WorkloadCommands } from '../../../kubectl/WorkloadCommands';
+import { DaemonSetDescribeWebview } from '../../../webview/DaemonSetDescribeWebview';
+import { DeploymentDescribeWebview } from '../../../webview/DeploymentDescribeWebview';
+import { DescribeWebview } from '../../../webview/DescribeWebview';
+import { StatefulSetDescribeWebview } from '../../../webview/StatefulSetDescribeWebview';
+
+type MockWebviewWithFire = vscode.Webview & { _fireMessage(message: unknown): void };
+
+async function flushAsyncWork(): Promise<void> {
+    await new Promise<void>(resolve => setImmediate(resolve));
+}
+
+async function flushUntil(predicate: () => boolean, maxTicks = 80): Promise<void> {
+    for (let i = 0; i < maxTicks; i++) {
+        if (predicate()) {
+            return;
+        }
+        await flushAsyncWork();
+    }
+}
+
+function dsPanel(): vscode.WebviewPanel | undefined {
+    return (DaemonSetDescribeWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel;
+}
+
+const MIN_DS_TEMPLATE: () => k8s.V1DaemonSet = () => ({
+    metadata: {
+        name: 'fluentd',
+        namespace: 'ns1',
+        creationTimestamp: new Date('2020-01-01T00:00:00.000Z'),
+        generation: 1,
+        labels: { app: 'fluentd' }
+    },
+    spec: {
+        selector: { matchLabels: { app: 'fluentd' } },
+        template: {
+            spec: {
+                containers: [{ name: 'fluentd', image: 'fluentd:latest' }]
+            }
+        },
+        updateStrategy: { type: 'RollingUpdate' }
+    },
+    status: {
+        desiredNumberScheduled: 1,
+        currentNumberScheduled: 1,
+        numberReady: 1,
+        numberAvailable: 1,
+        numberUnavailable: 0,
+        numberMisscheduled: 0,
+        updatedNumberScheduled: 1
+    }
+});
+
+suite('DaemonSetDescribeWebview panel bindings', () => {
+    let mockContext: vscode.ExtensionContext;
+
+    let origGetDetails: typeof WorkloadCommands.getDaemonSetDetails;
+    let origListPods: typeof WorkloadCommands.listPodsForDaemonSetFull;
+    let origListNodes: typeof WorkloadCommands.listClusterNodes;
+    let origEvents: typeof WorkloadCommands.getDaemonSetEvents;
+
+    setup(() => {
+        mockContext = {
+            subscriptions: [],
+            extensionUri: vscode.Uri.file('/mock/extension/path'),
+            extensionPath: '/mock/extension/path'
+        } as unknown as vscode.ExtensionContext;
+
+        origGetDetails = WorkloadCommands.getDaemonSetDetails;
+        origListPods = WorkloadCommands.listPodsForDaemonSetFull;
+        origListNodes = WorkloadCommands.listClusterNodes;
+        origEvents = WorkloadCommands.getDaemonSetEvents;
+
+        WorkloadCommands.getDaemonSetDetails = async () =>
+            ({
+                daemonSet: MIN_DS_TEMPLATE(),
+                error: undefined
+            }) as Awaited<ReturnType<typeof WorkloadCommands.getDaemonSetDetails>>;
+
+        WorkloadCommands.listPodsForDaemonSetFull = async () => ({ pods: [] });
+        WorkloadCommands.listClusterNodes = async () => ({ nodes: [] });
+        WorkloadCommands.getDaemonSetEvents = async () => ({ events: [] });
+
+        getResourceCache().clear();
+        (vscode.window as unknown as { _clearMessages(): void })._clearMessages();
+        DescribeWebview.setSharedPanel(undefined);
+    });
+
+    teardown(async () => {
+        WorkloadCommands.getDaemonSetDetails = origGetDetails;
+        WorkloadCommands.listPodsForDaemonSetFull = origListPods;
+        WorkloadCommands.listClusterNodes = origListNodes;
+        WorkloadCommands.getDaemonSetEvents = origEvents;
+
+        const panel = dsPanel();
+        DescribeWebview.setSharedPanel(undefined);
+        panel?.dispose();
+        await flushAsyncWork();
+
+        getResourceCache().clear();
+        (vscode.commands as unknown as { _unregisterCommand(name: string): void })._unregisterCommand('kube9.revealPod');
+
+        if (mockContext?.subscriptions?.length) {
+            for (const sub of mockContext.subscriptions) {
+                sub?.dispose?.();
+            }
+            mockContext.subscriptions.length = 0;
+        }
+    });
+
+    test('shared Describe panel path wires message handlers (navigateToPod)', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        const revealArgs: unknown[] = [];
+        (vscode.commands as unknown as { _registerCommand(c: string, h: (...args: unknown[]) => Thenable<unknown>): void })._registerCommand(
+            'kube9.revealPod',
+            async (...args: unknown[]) => {
+                revealArgs.push(args);
+            }
+        );
+
+        await DaemonSetDescribeWebview.show(mockContext, 'fluentd', 'ns1', '/kc', 'ctx-a');
+
+        const panel = dsPanel();
+        assert.ok(panel);
+        assert.strictEqual(panel, prePanel);
+
+        const wv = panel!.webview as unknown as MockWebviewWithFire;
+        wv._fireMessage({ command: 'navigateToPod', name: 'fluentd-abc' });
+        await flushAsyncWork();
+
+        assert.strictEqual(revealArgs.length, 1);
+        assert.deepStrictEqual(revealArgs[0], ['fluentd-abc', 'ns1']);
+    });
+
+    test('re-show on shared panel replaces handlers so refresh does not stack duplicate API calls', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        let detailHits = 0;
+        WorkloadCommands.getDaemonSetDetails = async () => {
+            detailHits += 1;
+            return {
+                daemonSet: MIN_DS_TEMPLATE(),
+                error: undefined
+            } as Awaited<ReturnType<typeof WorkloadCommands.getDaemonSetDetails>>;
+        };
+
+        await DaemonSetDescribeWebview.show(mockContext, 'ds-a', 'ns1', '/kc', 'ctx-a');
+        assert.strictEqual(detailHits, 1);
+
+        const panel = dsPanel()!;
+        const wv = panel.webview as unknown as MockWebviewWithFire;
+        wv._fireMessage({ command: 'refresh' });
+        await flushAsyncWork();
+        assert.strictEqual(detailHits, 2);
+
+        await DaemonSetDescribeWebview.show(mockContext, 'ds-b', 'ns1', '/kc', 'ctx-a');
+        assert.strictEqual(detailHits, 3);
+
+        wv._fireMessage({ command: 'refresh' });
+        await flushAsyncWork();
+        assert.strictEqual(detailHits, 4, 'Duplicate message listeners would issue extra getDaemonSetDetails calls');
+    });
+
+    test('shared panel path surfaces API failures via webview error message', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        WorkloadCommands.getDaemonSetDetails = async () =>
+            ({
+                daemonSet: undefined,
+                error: new KubectlError(
+                    KubectlErrorType.PermissionDenied,
+                    'Forbidden',
+                    'forbidden',
+                    'ctx-a'
+                )
+            }) as Awaited<ReturnType<typeof WorkloadCommands.getDaemonSetDetails>>;
+
+        const posted: unknown[] = [];
+        const bindPm = prePanel.webview.postMessage.bind(prePanel.webview);
+        prePanel.webview.postMessage = (msg: unknown) => {
+            posted.push(msg);
+            return bindPm(msg);
+        };
+
+        await DaemonSetDescribeWebview.show(mockContext, 'fluentd', 'ns1', '/kc', 'ctx-a');
+        await flushAsyncWork();
+
+        assert.ok(posted.some(m => typeof m === 'object' && m !== null && (m as { command?: string }).command === 'error'));
+    });
+
+    test('disposing the panel clears DaemonSet Describe static panel pointer', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        await DaemonSetDescribeWebview.show(mockContext, 'fluentd', 'ns1', '/kc', 'ctx-a');
+        assert.strictEqual(dsPanel(), prePanel);
+
+        prePanel.dispose();
+        await flushAsyncWork();
+        assert.strictEqual(dsPanel(), undefined);
+    });
+
+    test('reusing panel after StatefulSet describe clears StatefulSet refresh handlers', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        const origGetSts = WorkloadCommands.getStatefulSetDetails;
+        const origGetPods = WorkloadCommands.getV1PodsForLabelSelector;
+        const origPvcs = WorkloadCommands.listNamespacedPersistentVolumeClaims;
+        const origStsEvents = WorkloadCommands.getStatefulSetEvents;
+
+        let stsDetailHits = 0;
+        WorkloadCommands.getStatefulSetDetails = async () => {
+            stsDetailHits += 1;
+            return {
+                statefulSet: {
+                    metadata: { name: 'web', namespace: 'ns1', creationTimestamp: new Date() },
+                    spec: {
+                        replicas: 1,
+                        serviceName: 'web',
+                        selector: { matchLabels: { app: 'web' } },
+                        template: { spec: { containers: [{ name: 'nginx', image: 'nginx' }] } }
+                    },
+                    status: {}
+                },
+                error: undefined
+            } as Awaited<ReturnType<typeof WorkloadCommands.getStatefulSetDetails>>;
+        };
+        WorkloadCommands.getV1PodsForLabelSelector = async () => ({ pods: [] });
+        WorkloadCommands.listNamespacedPersistentVolumeClaims = async () => ({ items: [] });
+        WorkloadCommands.getStatefulSetEvents = async () => ({ events: [] });
+
+        try {
+            await StatefulSetDescribeWebview.show(mockContext, 'web', 'ns1', '/kc', 'ctx-a');
+            assert.strictEqual(stsDetailHits, 1);
+
+            await DaemonSetDescribeWebview.show(mockContext, 'fluentd', 'ns1', '/kc', 'ctx-a');
+
+            const stsDw = StatefulSetDescribeWebview as unknown as {
+                messageSubscription?: vscode.Disposable;
+            };
+            assert.strictEqual(
+                stsDw.messageSubscription,
+                undefined,
+                'StatefulSet subscription must be released when DaemonSet takes the shared panel'
+            );
+
+            let dsDetailHits = 0;
+            WorkloadCommands.getDaemonSetDetails = async () => {
+                dsDetailHits += 1;
+                return {
+                    daemonSet: MIN_DS_TEMPLATE(),
+                    error: undefined
+                } as Awaited<ReturnType<typeof WorkloadCommands.getDaemonSetDetails>>;
+            };
+
+            const wv = prePanel.webview as unknown as MockWebviewWithFire;
+            const stsHitsBeforeRefresh = stsDetailHits;
+            const dsHitsBeforeRefresh = dsDetailHits;
+            wv._fireMessage({ command: 'refresh' });
+            await flushUntil(() => dsDetailHits > dsHitsBeforeRefresh);
+
+            assert.strictEqual(
+                stsDetailHits,
+                stsHitsBeforeRefresh,
+                'Leaked StatefulSet refresh must not fetch StatefulSet data after DaemonSet takeover'
+            );
+            assert.ok(dsDetailHits > dsHitsBeforeRefresh, 'Refresh should reload DaemonSet data');
+        } finally {
+            WorkloadCommands.getStatefulSetDetails = origGetSts;
+            WorkloadCommands.getV1PodsForLabelSelector = origGetPods;
+            WorkloadCommands.listNamespacedPersistentVolumeClaims = origPvcs;
+            WorkloadCommands.getStatefulSetEvents = origStsEvents;
+        }
+    });
+
+    test('reusing panel after Deployment describe clears Deployment refresh handlers', async () => {
+        const prePanel = vscode.window.createWebviewPanel('kube9Describe', 'stub', vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+        DescribeWebview.setSharedPanel(prePanel);
+
+        let deploymentDetailHits = 0;
+        const origGetDeployment = WorkloadCommands.getDeploymentDetails;
+        const origGetRs = WorkloadCommands.getRelatedReplicaSets;
+        const origGetEvents = WorkloadCommands.getDeploymentEvents;
+
+        WorkloadCommands.getDeploymentDetails = async () => {
+            deploymentDetailHits += 1;
+            return {
+                deployment: {
+                    metadata: { name: 'nginx', namespace: 'ns1', uid: 'dep-uid' },
+                    spec: {
+                        replicas: 1,
+                        selector: { matchLabels: { app: 'nginx' } },
+                        template: { spec: { containers: [{ name: 'nginx', image: 'nginx' }] } }
+                    },
+                    status: {}
+                },
+                error: undefined
+            } as Awaited<ReturnType<typeof WorkloadCommands.getDeploymentDetails>>;
+        };
+        WorkloadCommands.getRelatedReplicaSets = async () => ({ replicaSets: [] });
+        WorkloadCommands.getDeploymentEvents = async () => ({ events: [] });
+
+        try {
+            await DeploymentDescribeWebview.show(mockContext, 'nginx', 'ns1', '/kc', 'ctx-a');
+            assert.strictEqual(deploymentDetailHits, 1);
+
+            await DaemonSetDescribeWebview.show(mockContext, 'fluentd', 'ns1', '/kc', 'ctx-a');
+
+            const dw = DeploymentDescribeWebview as unknown as {
+                messageSubscription?: vscode.Disposable;
+            };
+            assert.strictEqual(
+                dw.messageSubscription,
+                undefined,
+                'Deployment subscription must be released when DaemonSet takes the shared panel'
+            );
+
+            let dsDetailHits = 0;
+            WorkloadCommands.getDaemonSetDetails = async () => {
+                dsDetailHits += 1;
+                return {
+                    daemonSet: MIN_DS_TEMPLATE(),
+                    error: undefined
+                } as Awaited<ReturnType<typeof WorkloadCommands.getDaemonSetDetails>>;
+            };
+
+            const wv = prePanel.webview as unknown as MockWebviewWithFire;
+            const deploymentHitsBeforeRefresh = deploymentDetailHits;
+            const dsHitsBeforeRefresh = dsDetailHits;
+            wv._fireMessage({ command: 'refresh' });
+            await flushUntil(() => dsDetailHits > dsHitsBeforeRefresh);
+
+            assert.strictEqual(
+                deploymentDetailHits,
+                deploymentHitsBeforeRefresh,
+                'Leaked Deployment refresh must not fetch deployment data after DaemonSet takeover'
+            );
+            assert.ok(dsDetailHits > dsHitsBeforeRefresh, 'Refresh should reload DaemonSet data');
+        } finally {
+            WorkloadCommands.getDeploymentDetails = origGetDeployment;
+            WorkloadCommands.getRelatedReplicaSets = origGetRs;
+            WorkloadCommands.getDeploymentEvents = origGetEvents;
+        }
+    });
+});

--- a/src/test/suite/webview/describeTreeRouting.test.ts
+++ b/src/test/suite/webview/describeTreeRouting.test.ts
@@ -178,4 +178,16 @@ suite('describeTreeRouting (context-menu Describe parity)', () => {
 
         assert.strictEqual(resolveSpecializedDescribeFromTreeItem(item), undefined);
     });
+
+    test('DaemonSet is not specialized here', () => {
+        const item = new ClusterTreeItem(
+            'ds1',
+            'daemonset',
+            vscode.TreeItemCollapsibleState.None,
+            baseResourceData({ namespace: 'ns', resourceName: 'ds1' })
+        );
+        item.contextValue = 'resource:DaemonSet';
+
+        assert.strictEqual(resolveSpecializedDescribeFromTreeItem(item), undefined);
+    });
 });

--- a/src/utils/webviewManager.ts
+++ b/src/utils/webviewManager.ts
@@ -8,6 +8,7 @@ import { HelmPackageManagerPanel } from '../webview/HelmPackageManagerPanel';
 import { NodeDescribeWebview } from '../webview/NodeDescribeWebview';
 import { DeploymentDescribeWebview } from '../webview/DeploymentDescribeWebview';
 import { StatefulSetDescribeWebview } from '../webview/StatefulSetDescribeWebview';
+import { DaemonSetDescribeWebview } from '../webview/DaemonSetDescribeWebview';
 import { TutorialWebview } from '../webview/TutorialWebview';
 import { ClusterManagerWebview } from '../webview/ClusterManagerWebview';
 import { ArgoCDApplicationWebviewProvider } from '../webview/ArgoCDApplicationWebviewProvider';
@@ -51,6 +52,7 @@ export async function closeWebviewsForContext(contextName: string): Promise<void
             { name: 'TutorialWebview', getPanel: () => (TutorialWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel },
             { name: 'DeploymentDescribeWebview', getPanel: () => (DeploymentDescribeWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel },
             { name: 'StatefulSetDescribeWebview', getPanel: () => (StatefulSetDescribeWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel },
+            { name: 'DaemonSetDescribeWebview', getPanel: () => (DaemonSetDescribeWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel },
             { name: 'NodeDescribeWebview', getPanel: () => (NodeDescribeWebview as unknown as { currentPanel?: vscode.WebviewPanel }).currentPanel }
         ];
 

--- a/src/webview/DaemonSetDescribeWebview.ts
+++ b/src/webview/DaemonSetDescribeWebview.ts
@@ -1,0 +1,522 @@
+import * as vscode from 'vscode';
+import { WorkloadCommands } from '../kubectl/WorkloadCommands';
+import { transformDaemonSetData, DaemonSetDescribeData } from './daemonSetDataTransformer';
+import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
+import { DescribeWebview } from './DescribeWebview';
+import { releaseExclusiveDescribePanelBindings } from './describeSharedPanelBindings';
+import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
+import { getYAMLEditorManager } from '../extension';
+
+interface WebviewMessage {
+    command: 'refresh' | 'copyValue' | 'viewYaml' | 'navigateToPod';
+    name?: string;
+    namespace?: string;
+    value?: string;
+    content?: string;
+}
+
+/**
+ * Structured describe panel for namespaced DaemonSet resources.
+ */
+export class DaemonSetDescribeWebview {
+    private static currentPanel: vscode.WebviewPanel | undefined;
+    private static currentDaemonSetName: string | undefined;
+    private static currentNamespace: string | undefined;
+    private static kubeconfigPath: string | undefined;
+    private static contextName: string | undefined;
+    /** Owned subscription for DaemonSet messages; swapped whenever HTML/handlers refresh on a reused panel. */
+    private static messageSubscription: vscode.Disposable | undefined;
+    /** Clears DaemonSet bindings when this panel closes (including shared Describe reuse). */
+    private static panelDisposeSubscription: vscode.Disposable | undefined;
+
+    public static async show(
+        context: vscode.ExtensionContext,
+        daemonSetName: string,
+        namespace: string,
+        kubeconfigPath: string,
+        contextName: string
+    ): Promise<void> {
+        releaseExclusiveDescribePanelBindings();
+        DaemonSetDescribeWebview.currentDaemonSetName = daemonSetName;
+        DaemonSetDescribeWebview.currentNamespace = namespace;
+        DaemonSetDescribeWebview.kubeconfigPath = kubeconfigPath;
+        DaemonSetDescribeWebview.contextName = contextName;
+
+        const sharedPanel = DescribeWebview.getSharedPanel();
+
+        if (sharedPanel) {
+            DaemonSetDescribeWebview.currentPanel = sharedPanel;
+            DaemonSetDescribeWebview.currentPanel.title = `DaemonSet / ${daemonSetName}`;
+            DaemonSetDescribeWebview.currentDaemonSetName = daemonSetName;
+            DaemonSetDescribeWebview.currentNamespace = namespace;
+            DaemonSetDescribeWebview.kubeconfigPath = kubeconfigPath;
+            DaemonSetDescribeWebview.contextName = contextName;
+            DaemonSetDescribeWebview.currentPanel.webview.html =
+                DaemonSetDescribeWebview.getWebviewContent(DaemonSetDescribeWebview.currentPanel.webview);
+            DaemonSetDescribeWebview.attachPanelBindings(DaemonSetDescribeWebview.currentPanel);
+            await DaemonSetDescribeWebview.refreshDaemonSetData();
+            DaemonSetDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
+            return;
+        }
+
+        if (DaemonSetDescribeWebview.currentPanel) {
+            DaemonSetDescribeWebview.currentPanel.title = `DaemonSet / ${daemonSetName}`;
+            DaemonSetDescribeWebview.currentDaemonSetName = daemonSetName;
+            DaemonSetDescribeWebview.currentNamespace = namespace;
+            DaemonSetDescribeWebview.kubeconfigPath = kubeconfigPath;
+            DaemonSetDescribeWebview.contextName = contextName;
+            DaemonSetDescribeWebview.currentPanel.webview.html = DaemonSetDescribeWebview.getWebviewContent(
+                DaemonSetDescribeWebview.currentPanel.webview
+            );
+            DaemonSetDescribeWebview.attachPanelBindings(DaemonSetDescribeWebview.currentPanel);
+            await DaemonSetDescribeWebview.refreshDaemonSetData();
+            DaemonSetDescribeWebview.currentPanel.reveal(vscode.ViewColumn.One);
+            DescribeWebview.setSharedPanel(DaemonSetDescribeWebview.currentPanel);
+            return;
+        }
+
+        notifyMajorWebviewOpened('resource_describe');
+        const panel = vscode.window.createWebviewPanel('kube9Describe', `DaemonSet / ${daemonSetName}`, vscode.ViewColumn.One, {
+            enableScripts: true,
+            retainContextWhenHidden: true
+        });
+
+        DaemonSetDescribeWebview.currentPanel = panel;
+        DescribeWebview.setSharedPanel(panel);
+
+        panel.webview.html = DaemonSetDescribeWebview.getWebviewContent(panel.webview);
+        DaemonSetDescribeWebview.attachPanelBindings(panel);
+        await DaemonSetDescribeWebview.refreshDaemonSetData();
+
+        panel.onDidDispose(
+            () => {
+                if (DaemonSetDescribeWebview.currentPanel === panel) {
+                    DaemonSetDescribeWebview.currentPanel = undefined;
+                    DaemonSetDescribeWebview.currentDaemonSetName = undefined;
+                    DaemonSetDescribeWebview.currentNamespace = undefined;
+                    DaemonSetDescribeWebview.kubeconfigPath = undefined;
+                    DaemonSetDescribeWebview.contextName = undefined;
+                    if (DescribeWebview.getSharedPanel() === panel) {
+                        DescribeWebview.setSharedPanel(undefined);
+                    }
+                }
+            },
+            null,
+            context.subscriptions
+        );
+    }
+
+    private static attachPanelBindings(panel: vscode.WebviewPanel): void {
+        DaemonSetDescribeWebview.detachPanelSubscriptions();
+        DaemonSetDescribeWebview.setupMessageHandlers(panel);
+
+        DaemonSetDescribeWebview.panelDisposeSubscription = panel.onDidDispose(() => {
+            if (DaemonSetDescribeWebview.currentPanel === panel) {
+                DaemonSetDescribeWebview.currentPanel = undefined;
+                DaemonSetDescribeWebview.currentDaemonSetName = undefined;
+                DaemonSetDescribeWebview.currentNamespace = undefined;
+                DaemonSetDescribeWebview.kubeconfigPath = undefined;
+                DaemonSetDescribeWebview.contextName = undefined;
+                if (DescribeWebview.getSharedPanel() === panel) {
+                    DescribeWebview.setSharedPanel(undefined);
+                }
+            }
+            DaemonSetDescribeWebview.messageSubscription?.dispose();
+            DaemonSetDescribeWebview.messageSubscription = undefined;
+        });
+    }
+
+    /** Drops DaemonSet message handlers when another describe view takes the shared panel. */
+    public static releaseMessageBindings(): void {
+        DaemonSetDescribeWebview.detachPanelSubscriptions();
+    }
+
+    private static detachPanelSubscriptions(): void {
+        DaemonSetDescribeWebview.messageSubscription?.dispose();
+        DaemonSetDescribeWebview.messageSubscription = undefined;
+        DaemonSetDescribeWebview.panelDisposeSubscription?.dispose();
+        DaemonSetDescribeWebview.panelDisposeSubscription = undefined;
+    }
+
+    private static clearDaemonSetCache(contextName: string, namespace: string, daemonSetName: string): void {
+        const cache = getResourceCache();
+        cache.invalidate(`daemonset-describe:${contextName}:${namespace}:${daemonSetName}`);
+    }
+
+    private static async refreshDaemonSetData(): Promise<void> {
+        if (!DaemonSetDescribeWebview.currentPanel) {
+            return;
+        }
+        const panel = DaemonSetDescribeWebview.currentPanel;
+        const daemonSetName = DaemonSetDescribeWebview.currentDaemonSetName;
+        const namespace = DaemonSetDescribeWebview.currentNamespace;
+        const kubeconfigPath = DaemonSetDescribeWebview.kubeconfigPath;
+        const contextName = DaemonSetDescribeWebview.contextName;
+
+        if (!daemonSetName || !namespace || !kubeconfigPath || !contextName) {
+            panel.webview.postMessage({
+                command: 'error',
+                message: 'Missing required parameters for DaemonSet describe'
+            });
+            return;
+        }
+
+        const cache = getResourceCache();
+        const cacheKey = `daemonset-describe:${contextName}:${namespace}:${daemonSetName}`;
+        const cached = cache.get<DaemonSetDescribeData>(cacheKey);
+        if (cached) {
+            panel.webview.postMessage({ command: 'updateDaemonSetData', data: cached });
+            return;
+        }
+
+        try {
+            const dsResult = await WorkloadCommands.getDaemonSetDetails(
+                daemonSetName,
+                namespace,
+                kubeconfigPath,
+                contextName
+            );
+            if (dsResult.error) {
+                panel.webview.postMessage({
+                    command: 'error',
+                    message: `Failed to load DaemonSet: ${dsResult.error.getDetails()}`
+                });
+                return;
+            }
+            if (!dsResult.daemonSet) {
+                panel.webview.postMessage({ command: 'error', message: 'DaemonSet not found or unavailable' });
+                return;
+            }
+            const ds = dsResult.daemonSet;
+            const matchLabels = ds.spec?.selector?.matchLabels || {};
+            const labelSelector = Object.entries(matchLabels)
+                .map(([k, v]) => `${k}=${v}`)
+                .join(',');
+
+            const [podsResult, nodesResult] = await Promise.all([
+                WorkloadCommands.listPodsForDaemonSetFull(
+                    kubeconfigPath,
+                    contextName,
+                    daemonSetName,
+                    namespace,
+                    labelSelector
+                ),
+                WorkloadCommands.listClusterNodes(kubeconfigPath, contextName)
+            ]);
+
+            const pods = podsResult.pods || [];
+            const podNames = pods.map(p => p.metadata?.name).filter((n): n is string => Boolean(n));
+            const eventsResult = await WorkloadCommands.getDaemonSetEvents(
+                daemonSetName,
+                namespace,
+                kubeconfigPath,
+                contextName,
+                podNames
+            );
+
+            const nodes = nodesResult.error ? undefined : nodesResult.nodes;
+            const nodesErr = nodesResult.error?.getDetails();
+            const podsErr = podsResult.error?.getDetails();
+            const eventsErr = eventsResult.error?.getDetails();
+
+            const transformed = transformDaemonSetData(
+                ds,
+                pods,
+                nodes,
+                nodesErr,
+                eventsResult.events || [],
+                podsErr,
+                eventsErr
+            );
+
+            cache.set(cacheKey, transformed, CACHE_TTL.DEPLOYMENTS);
+            panel.webview.postMessage({ command: 'updateDaemonSetData', data: transformed });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            panel.webview.postMessage({ command: 'error', message: `Failed to refresh DaemonSet: ${msg}` });
+        }
+    }
+
+    private static setupMessageHandlers(panel: vscode.WebviewPanel): void {
+        DaemonSetDescribeWebview.messageSubscription = panel.webview.onDidReceiveMessage(async (message: WebviewMessage) => {
+                switch (message.command) {
+                    case 'refresh': {
+                        const ctx = DaemonSetDescribeWebview.contextName;
+                        const ns = DaemonSetDescribeWebview.currentNamespace;
+                        const name = DaemonSetDescribeWebview.currentDaemonSetName;
+                        if (ctx && ns && name) {
+                            DaemonSetDescribeWebview.clearDaemonSetCache(ctx, ns, name);
+                        }
+                        await DaemonSetDescribeWebview.refreshDaemonSetData();
+                        break;
+                    }
+                    case 'viewYaml': {
+                        const ns = DaemonSetDescribeWebview.currentNamespace;
+                        const name = DaemonSetDescribeWebview.currentDaemonSetName;
+                        const cluster = DaemonSetDescribeWebview.contextName;
+                        if (!ns || !name || !cluster) {
+                            vscode.window.showErrorMessage('DaemonSet context is not available');
+                            break;
+                        }
+                        try {
+                            const yamlEditorManager = getYAMLEditorManager();
+                            await yamlEditorManager.openYAMLEditor({
+                                kind: 'DaemonSet',
+                                name,
+                                namespace: ns,
+                                apiVersion: 'apps/v1',
+                                cluster
+                            });
+                        } catch (err) {
+                            const errorMessage = err instanceof Error ? err.message : String(err);
+                            vscode.window.showErrorMessage(`Failed to open YAML editor: ${errorMessage}`);
+                        }
+                        break;
+                    }
+                    case 'navigateToPod': {
+                        const podName = message.name;
+                        const ns = message.namespace || DaemonSetDescribeWebview.currentNamespace;
+                        if (!podName || !ns) {
+                            vscode.window.showErrorMessage('Pod name and namespace are required');
+                            break;
+                        }
+                        try {
+                            await vscode.commands.executeCommand('kube9.revealPod', podName, ns);
+                        } catch (err) {
+                            const errorMessage = err instanceof Error ? err.message : String(err);
+                            vscode.window.showErrorMessage(`Failed to reveal pod: ${errorMessage}`);
+                        }
+                        break;
+                    }
+                    case 'copyValue': {
+                        const value = message.value || message.content;
+                        if (value) {
+                            try {
+                                await vscode.env.clipboard.writeText(value);
+                                vscode.window.showInformationMessage('Copied to clipboard');
+                            } catch (err) {
+                                const errorMessage = err instanceof Error ? err.message : String(err);
+                                vscode.window.showErrorMessage(`Failed to copy: ${errorMessage}`);
+                            }
+                        }
+                        break;
+                    }
+                    default:
+                        break;
+                }
+        });
+    }
+
+    private static getWebviewContent(webview: vscode.Webview): string {
+        const csp = webview.cspSource;
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src ${csp} 'unsafe-inline';" />
+  <title>DaemonSet Describe</title>
+  <style>
+    body { font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); color: var(--vscode-foreground); background: var(--vscode-editor-background); margin: 0; padding: 0; }
+    .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
+    .hdr { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 12px; margin-bottom: 16px; }
+    .hdr h1 { margin: 0; font-size: 22px; font-weight: 600; }
+    .actions { display: flex; gap: 8px; flex-wrap: wrap; }
+    .action-btn { padding: 6px 12px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 2px; cursor: pointer; font: inherit; }
+    .action-btn:hover { background: var(--vscode-button-hoverBackground); }
+    .section { margin-bottom: 28px; }
+    .section h2 { margin: 0 0 10px; font-size: 17px; border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 6px; }
+    .info-grid { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 12px; }
+    .info-item { display: flex; flex-direction: column; gap: 4px; }
+    .info-label { font-size: 11px; color: var(--vscode-descriptionForeground); text-transform: uppercase; letter-spacing: 0.4px; }
+    .info-value { word-break: break-word; }
+    .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px,1fr)); gap: 10px; }
+    .stat { padding: 10px; border: 1px solid var(--vscode-panel-border); border-radius: 4px; }
+    .stat .lbl { font-size: 11px; color: var(--vscode-descriptionForeground); }
+    .stat .num { font-size: 20px; font-weight: 600; }
+    .banner { padding: 10px 12px; border-radius: 4px; background: rgba(255,170,0,.12); border: 1px solid #ffaa00; margin-bottom: 12px; font-size: 13px; }
+    .banner.err { background: rgba(255,0,0,.08); border-color: var(--vscode-errorForeground); }
+    table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+    th, td { text-align: left; padding: 8px; border-bottom: 1px solid var(--vscode-panel-border); font-size: 13px; }
+    th { font-weight: 600; text-transform: uppercase; font-size: 11px; letter-spacing: 0.4px; }
+    tr:hover { background: var(--vscode-list-hoverBackground); }
+    .pod-link { color: var(--vscode-textLink-foreground); cursor: pointer; text-decoration: none; }
+    .pod-link:hover { text-decoration: underline; }
+    .label-list, .selector-list { list-style: none; padding: 0; margin: 0; }
+    .label-item, .selector-item { display: flex; align-items: center; gap: 8px; padding: 6px 0; border-bottom: 1px solid var(--vscode-panel-border); }
+    .copy-btn { background: none; border: none; color: var(--vscode-textLink-foreground); cursor: pointer; padding: 4px; }
+    .empty-state { padding: 16px; text-align: center; color: var(--vscode-descriptionForeground); font-style: italic; }
+    .loading { text-align: center; padding: 32px; color: var(--vscode-descriptionForeground); }
+    .error-message { display: none; padding: 14px; border-radius: 4px; background: rgba(255,0,0,.1); border: 1px solid var(--vscode-errorForeground); color: var(--vscode-errorForeground); margin-bottom: 12px; }
+    .error-message.visible { display: block; }
+    .hidden { display: none !important; }
+    .status-ok { color: #00c800; }
+    .status-warn { color: #ffaa00; }
+    .status-bad { color: var(--vscode-errorForeground); }
+    .annotation-item { padding: 10px 0; border-bottom: 1px solid var(--vscode-panel-border); }
+    .annotation-key { font-weight: 600; margin-bottom: 4px; }
+    .annotation-val { font-family: var(--vscode-editor-font-family); white-space: pre-wrap; word-break: break-all; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="hdr">
+      <h1>DaemonSet / <span id="ds-name">…</span></h1>
+      <div class="actions">
+        <button class="action-btn" id="btn-refresh">Refresh</button>
+        <button class="action-btn" id="btn-yaml">View YAML</button>
+      </div>
+    </div>
+    <div id="loading" class="loading">Loading DaemonSet…</div>
+    <div id="err" class="error-message"></div>
+    <div id="main" class="hidden">
+      <div class="section" id="sec-overview"><h2>Overview</h2><div class="info-grid" id="overview-grid"></div></div>
+      <div class="section" id="sec-sched"><h2>Scheduling status</h2><div class="stat-grid" id="sched-grid"></div></div>
+      <div class="section" id="sec-strategy"><h2>Update strategy</h2><div class="info-grid" id="strategy-grid"></div></div>
+      <div class="section" id="sec-nodes"><h2>Node coverage</h2><div id="node-banner"></div><table><thead><tr><th>Node</th><th>State</th><th>Pod</th><th>Detail</th></tr></thead><tbody id="node-body"></tbody></table></div>
+      <div class="section" id="sec-pods"><h2>Pods</h2><div id="pod-banner"></div><table><thead><tr><th>Name</th><th>Node</th><th>Phase</th><th>Ready</th><th>Restarts</th><th>Age</th></tr></thead><tbody id="pod-body"></tbody></table></div>
+      <div class="section" id="sec-template"><h2>Pod template</h2><div id="template-body"></div></div>
+      <div class="section" id="sec-cond"><h2>Conditions</h2><table><thead><tr><th>Type</th><th>Status</th><th>Reason</th><th>Message</th><th>Age</th></tr></thead><tbody id="cond-body"></tbody></table></div>
+      <div class="section" id="sec-labels"><h2>Selectors &amp; labels</h2><div id="labels-body"></div></div>
+      <div class="section" id="sec-events"><h2>Events</h2><div id="events-banner"></div><table><thead><tr><th>Type</th><th>Reason</th><th>Message</th><th>Age</th><th>From</th><th>Count</th></tr></thead><tbody id="events-body"></tbody></table></div>
+      <div class="section" id="sec-annotations"><h2>Annotations</h2><div id="ann-body"></div></div>
+    </div>
+  </div>
+  <script>
+  (function(){
+    const vscode = acquireVsCodeApi();
+    const $ = id => document.getElementById(id);
+    function esc(s){ if(s==null) return ''; return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+    window.addEventListener('message', ev => {
+      const m = ev.data;
+      if (m.command === 'updateDaemonSetData') { render(m.data); hideLoading(); hideErr(); $('main').classList.remove('hidden'); }
+      if (m.command === 'error') { showErr(m.message); hideLoading(); }
+    });
+    function hideLoading(){ $('loading').classList.add('hidden'); }
+    function showErr(msg){ const e=$('err'); e.textContent = msg; e.classList.add('visible'); $('main').classList.add('hidden'); }
+    function hideErr(){ $('err').classList.remove('visible'); }
+    function render(d){
+      $('ds-name').textContent = d.name || '';
+      // overview
+      const og = $('overview-grid');
+      const ov = d.overview || {};
+      og.innerHTML = [
+        ['Namespace', ov.namespace],
+        ['Status', ov.statusSummary],
+        ['Detail', ov.statusDetail || '—'],
+        ['Age', ov.age],
+        ['Created', ov.creationTimestamp],
+        ['Generation', String(ov.generation||0)]
+      ].map(([k,v])=>'<div class="info-item"><div class="info-label">'+esc(k)+'</div><div class="info-value">'+esc(v)+'</div></div>').join('');
+      // scheduling
+      const rc = d.replicaCounts || {};
+      const sg = $('sched-grid');
+      const stats = [
+        ['Desired (nodes)', rc.desiredScheduled],
+        ['Current scheduled', rc.currentScheduled],
+        ['Ready', rc.ready],
+        ['Available', rc.available],
+        ['Unavailable', rc.unavailable],
+        ['Misscheduled', rc.misscheduled],
+        ['Updated scheduled', rc.updatedScheduled]
+      ];
+      sg.innerHTML = stats.map(([lbl,val])=>{
+        var cls = 'num';
+        if (lbl.indexOf('Misscheduled') !== -1 && val > 0) cls += ' status-bad';
+        if (lbl.indexOf('Unavailable') !== -1 && val > 0) cls += ' status-warn';
+        return '<div class="stat"><div class="lbl">'+esc(lbl)+'</div><div class="'+cls+'">'+esc(String(val))+'</div></div>';
+      }).join('');
+      // strategy
+      const us = d.updateStrategy || {};
+      $('strategy-grid').innerHTML = ['Type','Max unavailable','Max surge'].map((k,i)=>{
+        const val = i===0?us.type:(i===1?us.maxUnavailable:us.maxSurge);
+        return '<div class="info-item"><div class="info-label">'+k+'</div><div class="info-value">'+esc(val)+'</div></div>';
+      }).join('');
+      // node coverage
+      const nb = $('node-banner');
+      nb.innerHTML = '';
+      if (d.nodeCoverageLimitedMessage) {
+        nb.innerHTML = '<div class="banner">'+esc(d.nodeCoverageLimitedMessage)+'</div>';
+      }
+      const nbody = $('node-body');
+      const nrows = d.nodeCoverage || [];
+      if (nrows.length === 0 && !d.nodeCoverageLimitedMessage) {
+        nbody.innerHTML = '<tr><td colspan="4" class="empty-state">No node rows (list nodes to derive expected placement, or rely on pod table below).</td></tr>';
+      } else if (nrows.length === 0) {
+        nbody.innerHTML = '<tr><td colspan="4" class="empty-state">See banner above — per-node table needs node list permissions.</td></tr>';
+      } else {
+        nbody.innerHTML = nrows.map(r => '<tr><td>'+esc(r.nodeName)+'</td><td>'+esc(r.state)+'</td><td>'+esc(r.podName)+'</td><td>'+esc(r.detail)+'</td></tr>').join('');
+      }
+      // pods
+      const pb = $('pod-banner');
+      pb.innerHTML = d.podsFetchError ? '<div class="banner err">Pods: '+esc(d.podsFetchError)+'</div>' : '';
+      const podb = $('pod-body');
+      const pods = d.pods || [];
+      if (!pods.length && d.podsFetchError) {
+        podb.innerHTML = '<tr><td colspan="6" class="empty-state">Could not list pods.</td></tr>';
+      } else if (!pods.length) {
+        podb.innerHTML = '<tr><td colspan="6" class="empty-state">No DaemonSet pods matched the selector.</td></tr>';
+      } else {
+        podb.innerHTML = pods.map(p => {
+          const link = '<a href="#" class="pod-link" data-pod="'+esc(p.name)+'">'+esc(p.name)+'</a>';
+          return '<tr><td>'+link+'</td><td>'+esc(p.node)+'</td><td>'+esc(p.phase)+'</td><td>'+esc(p.ready)+'</td><td>'+esc(String(p.restartCount))+'</td><td>'+esc(p.age)+'</td></tr>';
+        }).join('');
+        podb.querySelectorAll('.pod-link').forEach(a => {
+          a.addEventListener('click', e => { e.preventDefault(); vscode.postMessage({ command:'navigateToPod', name:a.getAttribute('data-pod'), namespace: d.namespace }); });
+        });
+      }
+      // template
+      const tb = $('template-body');
+      const pt = d.podTemplate;
+      if (!pt || (!pt.containers || !pt.containers.length)) {
+        tb.innerHTML = '<div class="empty-state">No container template</div>';
+      } else {
+        tb.innerHTML = '<div class="info-grid">'+pt.containers.map(c =>
+          '<div class="info-item"><div class="info-label">'+esc(c.name)+'</div><div class="info-value">'+esc(c.image)+'</div></div>'
+        ).join('')+'</div>';
+      }
+      // conditions
+      const cb = $('cond-body');
+      const conds = d.conditions || [];
+      cb.innerHTML = conds.length ? conds.map(c=>'<tr><td>'+esc(c.type)+'</td><td>'+esc(c.status)+'</td><td>'+esc(c.reason)+'</td><td>'+esc(c.message)+'</td><td>'+esc(c.relativeTime)+'</td></tr>').join('')
+        : '<tr><td colspan="5" class="empty-state">No conditions</td></tr>';
+      // labels
+      const lb = $('labels-body');
+      let lh = '';
+      const sel = d.selectors || {};
+      const lab = d.labels || {};
+      if (Object.keys(sel).length) {
+        lh += '<h3 style="margin:0 0 8px;font-size:13px;">Selectors</h3><ul class="selector-list">';
+        lh += Object.entries(sel).map(([k,v])=>'<li class="selector-item"><span>'+esc(k)+'='+esc(v)+'</span><button class="copy-btn" data-copy="'+esc(k+'='+v)+'">copy</button></li>').join('');
+        lh += '</ul>';
+      }
+      if (Object.keys(lab).length) {
+        lh += '<h3 style="margin:12px 0 8px;font-size:13px;">Labels</h3><ul class="label-list">';
+        lh += Object.entries(lab).map(([k,v])=>'<li class="label-item"><span>'+esc(k)+'='+esc(v)+'</span><button class="copy-btn" data-copy="'+esc(k+'='+v)+'">copy</button></li>').join('');
+        lh += '</ul>';
+      }
+      lb.innerHTML = lh || '<div class="empty-state">None</div>';
+      lb.querySelectorAll('.copy-btn').forEach(b => b.addEventListener('click', () => vscode.postMessage({ command:'copyValue', value: b.getAttribute('data-copy') })));
+      // events
+      const evb = $('events-banner');
+      evb.innerHTML = d.eventsFetchError ? '<div class="banner err">Events: '+esc(d.eventsFetchError)+'</div>' : '';
+      const eb = $('events-body');
+      const evs = d.events || [];
+      eb.innerHTML = evs.length ? evs.map(ev=>'<tr><td>'+esc(ev.type)+'</td><td>'+esc(ev.reason)+'</td><td>'+esc(ev.message)+'</td><td>'+esc(ev.relativeTime)+'</td><td>'+esc(ev.source)+'</td><td>'+esc(String(ev.count))+'</td></tr>').join('')
+        : '<tr><td colspan="6" class="empty-state">'+(d.eventsFetchError?'Could not load events.':'No recent events')+'</td></tr>';
+      // annotations
+      const ab = $('ann-body');
+      const anns = d.annotations || {};
+      const ak = Object.keys(anns);
+      ab.innerHTML = ak.length ? ak.map(k=>'<div class="annotation-item"><div class="annotation-key">'+esc(k)+'</div><div class="annotation-val">'+esc(anns[k])+'</div><button class="copy-btn" data-copy="'+esc(anns[k])+'">copy</button></div>').join('')
+        : '<div class="empty-state">No annotations</div>';
+      ab.querySelectorAll('.copy-btn').forEach(b => b.addEventListener('click', () => vscode.postMessage({ command:'copyValue', value: b.getAttribute('data-copy') })));
+    }
+    $('btn-refresh').addEventListener('click', () => { $('loading').classList.remove('hidden'); vscode.postMessage({ command:'refresh' }); });
+    $('btn-yaml').addEventListener('click', () => vscode.postMessage({ command:'viewYaml' }));
+  })();
+  </script>
+</body>
+</html>`;
+    }
+}

--- a/src/webview/DescribeWebview.ts
+++ b/src/webview/DescribeWebview.ts
@@ -15,6 +15,7 @@ import { CRDDescribeProvider } from '../providers/CRDDescribeProvider';
 import { getKubernetesApiClient } from '../kubernetes/apiClient';
 import { DeploymentDescribeWebview } from './DeploymentDescribeWebview';
 import { StatefulSetDescribeWebview } from './StatefulSetDescribeWebview';
+import { DaemonSetDescribeWebview } from './DaemonSetDescribeWebview';
 import { KubeconfigParser } from '../kubernetes/KubeconfigParser';
 import { WebviewHelpHandler } from './WebviewHelpHandler';
 import { getHelpController } from '../extension';
@@ -539,6 +540,16 @@ export class DescribeWebview {
             }
             const kubeconfigPath = KubeconfigParser.getKubeconfigPath();
             await StatefulSetDescribeWebview.show(context, name, namespace, kubeconfigPath, contextName);
+            return;
+        }
+
+        if (kind === 'DaemonSet') {
+            if (!namespace) {
+                vscode.window.showErrorMessage('Unable to describe DaemonSet: namespace is required');
+                return;
+            }
+            const kubeconfigPath = KubeconfigParser.getKubeconfigPath();
+            await DaemonSetDescribeWebview.show(context, name, namespace, kubeconfigPath, contextName);
             return;
         }
 

--- a/src/webview/daemonSetDataTransformer.ts
+++ b/src/webview/daemonSetDataTransformer.ts
@@ -1,0 +1,382 @@
+/**
+ * Transforms V1DaemonSet, related Pods, optional Nodes, and Events into structured describe data.
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import { calculateAge } from '../utils/deploymentUtils';
+import { formatRelativeTime } from '../utils/timeFormatting';
+import {
+    buildPodTemplateInfoFromTemplateSpec,
+    transformKubernetesEvents,
+    DeploymentEvent,
+    PodTemplateInfo
+} from './deploymentDataTransformer';
+
+export interface DaemonSetOverview {
+    name: string;
+    namespace: string;
+    statusSummary: string;
+    statusDetail: string;
+    creationTimestamp: string;
+    age: string;
+    generation: number;
+}
+
+export interface DaemonSetReplicaCounts {
+    desiredScheduled: number;
+    currentScheduled: number;
+    ready: number;
+    available: number;
+    unavailable: number;
+    misscheduled: number;
+    updatedScheduled: number;
+}
+
+export interface DaemonSetUpdateStrategyInfo {
+    type: string;
+    maxUnavailable: string;
+    maxSurge: string;
+}
+
+export interface DaemonSetConditionRow {
+    type: string;
+    status: string;
+    reason: string;
+    message: string;
+    lastTransitionTime: string;
+    relativeTime: string;
+    severity: 'success' | 'warning' | 'error' | 'info';
+}
+
+export interface DaemonSetNodeCoverageRow {
+    nodeName: string;
+    state: 'ready' | 'not-ready' | 'missing' | 'unexpected';
+    podName: string;
+    detail: string;
+}
+
+export interface DaemonSetPodRow {
+    name: string;
+    node: string;
+    phase: string;
+    ready: string;
+    restartCount: number;
+    age: string;
+}
+
+export interface DaemonSetDescribeData {
+    name: string;
+    namespace: string;
+    overview: DaemonSetOverview;
+    replicaCounts: DaemonSetReplicaCounts;
+    updateStrategy: DaemonSetUpdateStrategyInfo;
+    podTemplate: PodTemplateInfo;
+    conditions: DaemonSetConditionRow[];
+    nodeCoverage: DaemonSetNodeCoverageRow[];
+    nodeCoverageLimitedMessage: string | null;
+    pods: DaemonSetPodRow[];
+    podsFetchError: string | null;
+    labels: Record<string, string>;
+    selectors: Record<string, string>;
+    annotations: Record<string, string>;
+    events: DeploymentEvent[];
+    eventsFetchError: string | null;
+}
+
+function ownedByDaemonSet(pod: k8s.V1Pod, daemonSetName: string, daemonSetUid?: string): boolean {
+    return (
+        pod.metadata?.ownerReferences?.some(
+            ref =>
+                ref.kind === 'DaemonSet' &&
+                ref.name === daemonSetName &&
+                (!daemonSetUid || ref.uid === daemonSetUid)
+        ) ?? false
+    );
+}
+
+function nodeMatchesSelector(node: k8s.V1Node, selector: Record<string, string>): boolean {
+    const labels = node.metadata?.labels || {};
+    return Object.entries(selector).every(([k, v]) => labels[k] === v);
+}
+
+function podReadyString(pod: k8s.V1Pod): string {
+    const statuses = pod.status?.containerStatuses || [];
+    if (statuses.length === 0) {
+        return '0/0';
+    }
+    const ready = statuses.filter(s => s.ready).length;
+    return `${ready}/${statuses.length}`;
+}
+
+function podRestartTotal(pod: k8s.V1Pod): number {
+    const statuses = pod.status?.containerStatuses || [];
+    return statuses.reduce((sum, s) => sum + (s.restartCount || 0), 0);
+}
+
+function podIsReady(pod: k8s.V1Pod): boolean {
+    const statuses = pod.status?.containerStatuses || [];
+    if (statuses.length === 0) {
+        return false;
+    }
+    return statuses.every(s => s.ready);
+}
+
+function extractOverview(ds: k8s.V1DaemonSet): DaemonSetOverview {
+    const metadata = ds.metadata;
+    const status = ds.status;
+    const conditions = status?.conditions || [];
+    const desired = status?.desiredNumberScheduled ?? 0;
+    const ready = status?.numberReady ?? 0;
+    const misscheduled = status?.numberMisscheduled ?? 0;
+
+    let statusSummary = 'Unknown';
+    let statusDetail = '';
+
+    const failureCond = conditions.find(
+        c => (c.type === 'DaemonSetReplicaFailure' || c.reason === 'ReplicaFailure') && c.status === 'True'
+    );
+    if (failureCond) {
+        statusSummary = 'Degraded';
+        statusDetail = failureCond.message || failureCond.reason || 'Replica failure reported';
+    } else if (misscheduled > 0) {
+        statusSummary = 'Misscheduled pods';
+        statusDetail = `${misscheduled} pod(s) reported as misscheduled`;
+    } else if (desired > 0 && ready === desired) {
+        statusSummary = 'Healthy';
+        statusDetail = `All ${desired} scheduled node(s) report ready pods`;
+    } else if (desired > 0) {
+        statusSummary = 'Rolling out';
+        statusDetail = `${ready} of ${desired} node(s) ready`;
+    } else {
+        const prog = conditions.find(c => c.type === 'DaemonSetRolloutProgressing');
+        if (prog?.message) {
+            statusDetail = prog.message;
+            statusSummary = prog.status === 'False' ? 'Blocked' : 'Progressing';
+        }
+    }
+
+    let creationTimestamp = '';
+    if (metadata?.creationTimestamp) {
+        creationTimestamp =
+            typeof metadata.creationTimestamp === 'string'
+                ? metadata.creationTimestamp
+                : metadata.creationTimestamp.toISOString();
+    }
+
+    return {
+        name: metadata?.name || 'Unknown',
+        namespace: metadata?.namespace || 'default',
+        statusSummary,
+        statusDetail,
+        creationTimestamp,
+        age: creationTimestamp ? calculateAge(creationTimestamp) : '',
+        generation: metadata?.generation || 0
+    };
+}
+
+function extractReplicaCounts(ds: k8s.V1DaemonSet): DaemonSetReplicaCounts {
+    const st = ds.status;
+    const desired = st?.desiredNumberScheduled ?? 0;
+    const current = st?.currentNumberScheduled ?? 0;
+    const ready = st?.numberReady ?? 0;
+    const available = st?.numberAvailable ?? 0;
+    const unavailable = st?.numberUnavailable ?? 0;
+    const misscheduled = st?.numberMisscheduled ?? 0;
+    const updated = st?.updatedNumberScheduled ?? 0;
+
+    return {
+        desiredScheduled: desired,
+        currentScheduled: current,
+        ready,
+        available,
+        unavailable,
+        misscheduled,
+        updatedScheduled: updated
+    };
+}
+
+function extractUpdateStrategy(ds: k8s.V1DaemonSet): DaemonSetUpdateStrategyInfo {
+    const strategy = ds.spec?.updateStrategy;
+    const t = strategy?.type || 'RollingUpdate';
+    if (t === 'OnDelete') {
+        return { type: 'OnDelete', maxUnavailable: 'N/A', maxSurge: 'N/A' };
+    }
+    const ru = strategy?.rollingUpdate;
+    return {
+        type: 'RollingUpdate',
+        maxUnavailable: ru?.maxUnavailable !== undefined ? String(ru.maxUnavailable) : 'N/A',
+        maxSurge: ru?.maxSurge !== undefined ? String(ru.maxSurge) : 'N/A'
+    };
+}
+
+function extractConditions(ds: k8s.V1DaemonSet): DaemonSetConditionRow[] {
+    const conditions = ds.status?.conditions || [];
+    return conditions.map(c => {
+        const lastTransition = c.lastTransitionTime
+            ? typeof c.lastTransitionTime === 'string'
+                ? c.lastTransitionTime
+                : c.lastTransitionTime.toISOString()
+            : '';
+        let severity: DaemonSetConditionRow['severity'] = 'info';
+        if (c.status === 'True' && c.type?.includes('Failure')) {
+            severity = 'error';
+        } else if (c.status === 'False') {
+            severity = 'success';
+        } else if (c.status === 'True') {
+            severity = 'success';
+        }
+        return {
+            type: c.type || 'Unknown',
+            status: c.status || 'Unknown',
+            reason: c.reason || '',
+            message: c.message || '',
+            lastTransitionTime: lastTransition,
+            relativeTime: lastTransition ? formatRelativeTime(lastTransition) : '',
+            severity
+        };
+    });
+}
+
+function buildNodeCoverage(
+    ds: k8s.V1DaemonSet,
+    pods: k8s.V1Pod[],
+    nodes: k8s.V1Node[] | undefined,
+    nodesError: string | undefined
+): { rows: DaemonSetNodeCoverageRow[]; limitedMessage: string | null } {
+    const dsName = ds.metadata?.name || '';
+    const dsUid = ds.metadata?.uid;
+    const ownedPods = pods.filter(p => ownedByDaemonSet(p, dsName, dsUid));
+
+    if (nodesError || !nodes || nodes.length === 0) {
+        return {
+            rows: [],
+            limitedMessage: nodesError
+                ? `Node coverage is limited: ${nodesError}`
+                : 'Node coverage requires listing cluster nodes; none were returned or listing failed.'
+        };
+    }
+
+    const nodeSelector = ds.spec?.template?.spec?.nodeSelector || {};
+    const eligible = nodeSelector && Object.keys(nodeSelector).length > 0
+        ? nodes.filter(n => nodeMatchesSelector(n, nodeSelector))
+        : [...nodes];
+
+    const byNode = new Map<string, k8s.V1Pod>();
+    for (const p of ownedPods) {
+        const nodeName = p.spec?.nodeName;
+        if (nodeName) {
+            byNode.set(nodeName, p);
+        }
+    }
+
+    const rows: DaemonSetNodeCoverageRow[] = [];
+    const eligibleNames = new Set(eligible.map(n => n.metadata?.name || '').filter(Boolean));
+
+    for (const node of eligible) {
+        const nodeName = node.metadata?.name || 'unknown';
+        const pod = byNode.get(nodeName);
+        if (!pod) {
+            rows.push({
+                nodeName,
+                state: 'missing',
+                podName: '',
+                detail: 'No DaemonSet pod scheduled on this node'
+            });
+        } else if (podIsReady(pod)) {
+            rows.push({
+                nodeName,
+                state: 'ready',
+                podName: pod.metadata?.name || '',
+                detail: 'Pod is ready'
+            });
+        } else {
+            rows.push({
+                nodeName,
+                state: 'not-ready',
+                podName: pod.metadata?.name || '',
+                detail: `Phase ${pod.status?.phase || 'Unknown'}`
+            });
+        }
+    }
+
+    for (const p of ownedPods) {
+        const nn = p.spec?.nodeName;
+        if (nn && !eligibleNames.has(nn)) {
+            rows.push({
+                nodeName: nn,
+                state: 'unexpected',
+                podName: p.metadata?.name || '',
+                detail: 'Pod on a node that does not match the DaemonSet nodeSelector (may be misscheduled)'
+            });
+        }
+    }
+
+    rows.sort((a, b) => a.nodeName.localeCompare(b.nodeName));
+    return { rows, limitedMessage: null };
+}
+
+function buildPodRows(pods: k8s.V1Pod[], daemonSetName: string, daemonSetUid?: string): DaemonSetPodRow[] {
+    const owned = pods.filter(p => ownedByDaemonSet(p, daemonSetName, daemonSetUid));
+    return owned.map(p => {
+        let created = '';
+        if (p.metadata?.creationTimestamp) {
+            created =
+                typeof p.metadata.creationTimestamp === 'string'
+                    ? p.metadata.creationTimestamp
+                    : p.metadata.creationTimestamp.toISOString();
+        }
+        return {
+            name: p.metadata?.name || 'Unknown',
+            node: p.spec?.nodeName || 'Pending',
+            phase: p.status?.phase || 'Unknown',
+            ready: podReadyString(p),
+            restartCount: podRestartTotal(p),
+            age: created ? calculateAge(created) : ''
+        };
+    });
+}
+
+/**
+ * Build structured DaemonSet describe payload for the webview.
+ */
+export function transformDaemonSetData(
+    ds: k8s.V1DaemonSet,
+    pods: k8s.V1Pod[],
+    nodes: k8s.V1Node[] | undefined,
+    nodesListError: string | undefined,
+    events: k8s.CoreV1Event[],
+    podsFetchError: string | undefined,
+    eventsFetchError: string | undefined
+): DaemonSetDescribeData {
+    const metadata = ds.metadata;
+    const spec = ds.spec;
+    const dsName = metadata?.name || 'Unknown';
+    const dsUid = metadata?.uid;
+    const { rows: nodeCoverage, limitedMessage: covLimited } = buildNodeCoverage(ds, pods, nodes, nodesListError);
+
+    let nodeCoverageLimitedMessage = covLimited;
+    if (podsFetchError) {
+        nodeCoverageLimitedMessage = nodeCoverageLimitedMessage
+            ? `${nodeCoverageLimitedMessage} Pod list error: ${podsFetchError}`
+            : `Pod list error: ${podsFetchError}`;
+    }
+
+    return {
+        name: dsName,
+        namespace: metadata?.namespace || 'default',
+        overview: extractOverview(ds),
+        replicaCounts: extractReplicaCounts(ds),
+        updateStrategy: extractUpdateStrategy(ds),
+        podTemplate: buildPodTemplateInfoFromTemplateSpec(spec?.template),
+        conditions: extractConditions(ds),
+        nodeCoverage,
+        nodeCoverageLimitedMessage: nodeCoverageLimitedMessage || null,
+        pods: buildPodRows(pods, dsName, dsUid),
+        podsFetchError: podsFetchError || null,
+        labels: metadata?.labels || {},
+        selectors: spec?.selector?.matchLabels || {},
+        annotations: metadata?.annotations || {},
+        events: transformKubernetesEvents(events),
+        eventsFetchError: eventsFetchError || null
+    };
+}

--- a/src/webview/deploymentDataTransformer.ts
+++ b/src/webview/deploymentDataTransformer.ts
@@ -398,6 +398,15 @@ export function extractPodTemplateInfoFromPodSpec(podSpec?: k8s.V1PodSpec): PodT
 }
 
 /**
+ * Builds pod template describe data from a Pod template spec (Deployment, DaemonSet, etc.).
+ */
+export function buildPodTemplateInfoFromTemplateSpec(
+    template: k8s.V1PodTemplateSpec | undefined
+): PodTemplateInfo {
+    return extractPodTemplateInfoFromPodSpec(template?.spec);
+}
+
+/**
  * Extracts pod template information.
  */
 function extractPodTemplate(deployment: k8s.V1Deployment): PodTemplateInfo {

--- a/src/webview/describeSharedPanelBindings.ts
+++ b/src/webview/describeSharedPanelBindings.ts
@@ -1,4 +1,5 @@
 import { CronJobDescribeWebview } from './CronJobDescribeWebview';
+import { DaemonSetDescribeWebview } from './DaemonSetDescribeWebview';
 import { DeploymentDescribeWebview } from './DeploymentDescribeWebview';
 import { DescribeWebview } from './DescribeWebview';
 import { NodeDescribeWebview } from './NodeDescribeWebview';
@@ -15,4 +16,5 @@ export function releaseExclusiveDescribePanelBindings(): void {
     CronJobDescribeWebview.releaseMessageBindings();
     NodeDescribeWebview.releaseMessageBindings();
     StatefulSetDescribeWebview.releaseMessageBindings();
+    DaemonSetDescribeWebview.releaseMessageBindings();
 }


### PR DESCRIPTION
## Description

Adds a dedicated DaemonSet describe webview (scheduling counts, update strategy, node coverage when nodes can be listed, DaemonSet-owned pods with navigation, conditions, labels/selectors, scoped events, YAML button) so Describe no longer falls through to the generic “Coming soon” stub for this kind.

## Motivation and Context

Implements alto9/kube9-vscode#148 (structured DaemonSet inspection parity with Deployment describe).

Closes #148

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Manual testing in Extension Development Host (F5)
- [x] Unit tests added/updated
- [ ] Integration tests added/updated

Automated: `npm run compile`, `npm run lint` (warnings only, pre-existing), `npm run test:unit` (all passing).

## Checklist

- [x] Telemetry: no new telemetry paths for this change (existing `resource_describe` open only).
- [x] Tests added for transformer + describe routing
- [x] All new and existing unit tests pass

## How to Test this Work

1. `npm ci && npm run compile && npm run test:unit`
2. F5 → Kube9 cluster tree → Workloads → DaemonSet → Describe → confirm structured page and View YAML.