### PR TITLE
feat(argocd): ApplicationResourceGraph DTO and identity helpers (#153)

### DIFF
--- a/src/test/suite/types/applicationResourceGraph.test.ts
+++ b/src/test/suite/types/applicationResourceGraph.test.ts
@@ -1,0 +1,210 @@
+import * as assert from 'assert';
+import {
+    buildApplicationRootNodeId,
+    buildGraphEdgeId,
+    buildManagedResourceNodeId,
+    computeStructureVersion,
+    managedResourceKeysEqual,
+    topologyModeFromSource,
+    type ResourceGraphEdge,
+    type ResourceGraphNode
+} from '../../../types/applicationResourceGraph';
+
+suite('applicationResourceGraph', () => {
+    test('buildApplicationRootNodeId uses app namespace/name prefix', () => {
+        assert.strictEqual(buildApplicationRootNodeId('argocd', 'guestbook'), 'app:argocd/guestbook');
+    });
+
+    test('buildManagedResourceNodeId omits apiGroup suffix when unset', () => {
+        assert.strictEqual(
+            buildManagedResourceNodeId({ namespace: 'prod', kind: 'Deployment', name: 'api' }),
+            'res:prod/Deployment/api'
+        );
+    });
+
+    test('buildManagedResourceNodeId appends apiGroup when set', () => {
+        assert.strictEqual(
+            buildManagedResourceNodeId({
+                namespace: 'prod',
+                kind: 'Ingress',
+                name: 'api',
+                apiGroup: 'networking.k8s.io'
+            }),
+            'res:prod/Ingress/api/networking.k8s.io'
+        );
+    });
+
+    test('buildGraphEdgeId encodes source target and relationship', () => {
+        assert.strictEqual(
+            buildGraphEdgeId('app:argocd/guestbook', 'res:prod/Deployment/api', 'manages'),
+            'app:argocd/guestbook->res:prod/Deployment/api:manages'
+        );
+    });
+
+    suite('managedResourceKeysEqual', () => {
+        test('matches namespace kind and name', () => {
+            assert.strictEqual(
+                managedResourceKeysEqual(
+                    { namespace: 'prod', kind: 'Service', name: 'api' },
+                    { namespace: 'prod', kind: 'Service', name: 'api' }
+                ),
+                true
+            );
+        });
+
+        test('requires matching apiGroup when both sides provide it', () => {
+            assert.strictEqual(
+                managedResourceKeysEqual(
+                    { namespace: 'prod', kind: 'Ingress', name: 'api', apiGroup: 'networking.k8s.io' },
+                    { namespace: 'prod', kind: 'Ingress', name: 'api', apiGroup: 'extensions' }
+                ),
+                false
+            );
+        });
+
+        test('matches when only one side provides apiGroup', () => {
+            assert.strictEqual(
+                managedResourceKeysEqual(
+                    { namespace: 'prod', kind: 'Deployment', name: 'api', apiGroup: 'apps' },
+                    { namespace: 'prod', kind: 'Deployment', name: 'api' }
+                ),
+                true
+            );
+        });
+
+        test('rejects mismatched core identity fields', () => {
+            assert.strictEqual(
+                managedResourceKeysEqual(
+                    { namespace: 'prod', kind: 'Deployment', name: 'api' },
+                    { namespace: 'staging', kind: 'Deployment', name: 'api' }
+                ),
+                false
+            );
+        });
+    });
+
+    suite('topologyModeFromSource', () => {
+        test('maps argocd_resource_tree to full', () => {
+            assert.strictEqual(topologyModeFromSource('argocd_resource_tree'), 'full');
+        });
+
+        test('maps crd_flat to limited', () => {
+            assert.strictEqual(topologyModeFromSource('crd_flat'), 'limited');
+        });
+
+        test('maps kubernetes_owner_ref and operator_snapshot to limited', () => {
+            assert.strictEqual(topologyModeFromSource('kubernetes_owner_ref'), 'limited');
+            assert.strictEqual(topologyModeFromSource('operator_snapshot'), 'limited');
+        });
+    });
+
+    suite('computeStructureVersion', () => {
+        const rootId = buildApplicationRootNodeId('argocd', 'guestbook');
+        const deploymentId = buildManagedResourceNodeId({
+            namespace: 'prod',
+            kind: 'Deployment',
+            name: 'api'
+        });
+
+        const baseNodes: ResourceGraphNode[] = [
+            {
+                id: rootId,
+                role: 'application',
+                resourceKey: null,
+                status: { syncStatus: 'Synced', healthStatus: 'Healthy' },
+                label: 'guestbook',
+                kindLabel: 'Application'
+            },
+            {
+                id: deploymentId,
+                role: 'managed_resource',
+                resourceKey: { namespace: 'prod', kind: 'Deployment', name: 'api' },
+                status: { syncStatus: 'Synced', healthStatus: 'Healthy' },
+                label: 'api',
+                kindLabel: 'Deployment'
+            }
+        ];
+
+        const baseEdges: ResourceGraphEdge[] = [
+            {
+                id: buildGraphEdgeId(rootId, deploymentId, 'manages'),
+                source: rootId,
+                target: deploymentId,
+                relationship: 'manages'
+            }
+        ];
+
+        test('is deterministic for the same topology', () => {
+            const first = computeStructureVersion({ nodes: baseNodes, edges: baseEdges });
+            const second = computeStructureVersion({ nodes: baseNodes, edges: baseEdges });
+            assert.strictEqual(first, second);
+        });
+
+        test('is unchanged when only node status changes', () => {
+            const statusOnlyChange: ResourceGraphNode[] = baseNodes.map((node) =>
+                node.role === 'managed_resource'
+                    ? {
+                          ...node,
+                          status: { syncStatus: 'OutOfSync', healthStatus: 'Degraded', message: 'drift' },
+                          label: 'api-renamed'
+                      }
+                    : node
+            );
+
+            assert.strictEqual(
+                computeStructureVersion({ nodes: statusOnlyChange, edges: baseEdges }),
+                computeStructureVersion({ nodes: baseNodes, edges: baseEdges })
+            );
+        });
+
+        test('changes when a node id is added', () => {
+            const withExtraNode: ResourceGraphNode[] = [
+                ...baseNodes,
+                {
+                    id: buildManagedResourceNodeId({ namespace: 'prod', kind: 'Service', name: 'api' }),
+                    role: 'managed_resource',
+                    resourceKey: { namespace: 'prod', kind: 'Service', name: 'api' },
+                    status: { syncStatus: 'Synced', healthStatus: 'Healthy' },
+                    label: 'api',
+                    kindLabel: 'Service'
+                }
+            ];
+
+            assert.notStrictEqual(
+                computeStructureVersion({ nodes: withExtraNode, edges: baseEdges }),
+                computeStructureVersion({ nodes: baseNodes, edges: baseEdges })
+            );
+        });
+
+        test('changes when an edge endpoint pair changes', () => {
+            const serviceId = buildManagedResourceNodeId({ namespace: 'prod', kind: 'Service', name: 'api' });
+            const extraEdge: ResourceGraphEdge[] = [
+                ...baseEdges,
+                {
+                    id: buildGraphEdgeId(deploymentId, serviceId, 'depends_on'),
+                    source: deploymentId,
+                    target: serviceId,
+                    relationship: 'depends_on'
+                }
+            ];
+
+            assert.notStrictEqual(
+                computeStructureVersion({ nodes: baseNodes, edges: extraEdge }),
+                computeStructureVersion({ nodes: baseNodes, edges: baseEdges })
+            );
+        });
+
+        test('ignores edge relationship when endpoints are unchanged', () => {
+            const relationshipOnlyChange: ResourceGraphEdge[] = baseEdges.map((edge) => ({
+                ...edge,
+                relationship: 'owns',
+                id: buildGraphEdgeId(edge.source, edge.target, 'owns')
+            }));
+
+            assert.strictEqual(
+                computeStructureVersion({ nodes: baseNodes, edges: relationshipOnlyChange }),
+                computeStructureVersion({ nodes: baseNodes, edges: baseEdges })
+            );
+        });
+    });
+});

--- a/src/types/applicationResourceGraph.ts
+++ b/src/types/applicationResourceGraph.ts
@@ -1,0 +1,124 @@
+/**
+ * Application resource graph DTOs and identity helpers.
+ *
+ * Aligned with `.forge/data/data_model.md` and `.forge/data/consistency.md`.
+ */
+
+import { createHash } from 'crypto';
+import type { HealthStatusCode, SyncStatusCode } from './argocd';
+
+export type GraphNodeId = string;
+
+export interface ApplicationKey {
+    context: string;
+    namespace: string;
+    name: string;
+}
+
+export interface ManagedResourceKey {
+    namespace: string;
+    kind: string;
+    name: string;
+    apiGroup?: string;
+}
+
+export type TopologySource =
+    | 'crd_flat'
+    | 'argocd_resource_tree'
+    | 'kubernetes_owner_ref'
+    | 'operator_snapshot';
+
+export type TopologyMode = 'full' | 'limited';
+
+export type EdgeRelationship = 'manages' | 'owns' | 'depends_on';
+
+export type ResourceGraphNodeRole = 'application' | 'managed_resource';
+
+export interface ResourceGraphNodeStatus {
+    syncStatus: SyncStatusCode;
+    healthStatus: HealthStatusCode;
+    message?: string;
+}
+
+export interface ResourceGraphNode {
+    id: GraphNodeId;
+    role: ResourceGraphNodeRole;
+    resourceKey: ManagedResourceKey | null;
+    status: ResourceGraphNodeStatus;
+    label: string;
+    kindLabel: string;
+}
+
+export interface ResourceGraphEdge {
+    id: string;
+    source: GraphNodeId;
+    target: GraphNodeId;
+    relationship: EdgeRelationship;
+}
+
+export interface ApplicationResourceGraph {
+    applicationKey: ApplicationKey;
+    nodes: ResourceGraphNode[];
+    edges: ResourceGraphEdge[];
+    topologySource: TopologySource;
+    topologyMode: TopologyMode;
+    structureVersion: string;
+    observedAt: string;
+    layoutHint?: {
+        algorithm?: string;
+        version?: string;
+        [key: string]: unknown;
+    };
+    truncated?: boolean;
+}
+
+export function buildApplicationRootNodeId(namespace: string, name: string): GraphNodeId {
+    return `app:${namespace}/${name}`;
+}
+
+export function buildManagedResourceNodeId(key: ManagedResourceKey): GraphNodeId {
+    const base = `res:${key.namespace}/${key.kind}/${key.name}`;
+    if (key.apiGroup) {
+        return `${base}/${key.apiGroup}`;
+    }
+    return base;
+}
+
+export function buildGraphEdgeId(
+    source: GraphNodeId,
+    target: GraphNodeId,
+    relationship: EdgeRelationship
+): string {
+    return `${source}->${target}:${relationship}`;
+}
+
+export function managedResourceKeysEqual(a: ManagedResourceKey, b: ManagedResourceKey): boolean {
+    if (a.namespace !== b.namespace || a.kind !== b.kind || a.name !== b.name) {
+        return false;
+    }
+    const aHasApiGroup = a.apiGroup !== undefined && a.apiGroup !== '';
+    const bHasApiGroup = b.apiGroup !== undefined && b.apiGroup !== '';
+    if (aHasApiGroup && bHasApiGroup) {
+        return a.apiGroup === b.apiGroup;
+    }
+    return true;
+}
+
+export function topologyModeFromSource(source: TopologySource): TopologyMode {
+    if (source === 'argocd_resource_tree') {
+        return 'full';
+    }
+    return 'limited';
+}
+
+export function computeStructureVersion(input: {
+    nodes: Array<Pick<ResourceGraphNode, 'id'>>;
+    edges: Array<Pick<ResourceGraphEdge, 'source' | 'target'>>;
+}): string {
+    const nodeIds = input.nodes.map((node) => node.id).sort();
+    const edgePairs = input.edges
+        .map((edge) => `${edge.source}\t${edge.target}`)
+        .sort();
+    const payload = `nodes:${nodeIds.join('\n')}\nedges:${edgePairs.join('\n')}`;
+    return createHash('sha256').update(payload).digest('hex');
+}


### PR DESCRIPTION
## Summary

- Add `src/types/applicationResourceGraph.ts` with forge-aligned DTO types for the Argo CD resource graph initiative.
- Export pure identity helpers: `buildApplicationRootNodeId`, `buildManagedResourceNodeId`, `managedResourceKeysEqual`, `topologyModeFromSource`, and `computeStructureVersion` (SHA-256 over sorted node ids and edge endpoint pairs).
- Add unit tests covering id builders, key equality edge cases, topology mode mapping, and structural vs status-only fingerprint behavior.

Closes #153

## Test plan

- [x] `npm run test:unit` passes in `kube9/kube9-vscode`
- [x] `npm run lint` passes (warnings only, pre-existing)
- [ ] CI green on PR