### PR TITLE
feat(argocd): assemble crd_flat ApplicationResourceGraph (#154)

### DIFF
--- a/src/services/ApplicationResourceGraphAssembler.ts
+++ b/src/services/ApplicationResourceGraphAssembler.ts
@@ -1,0 +1,151 @@
+/**
+ * Pure host-side assembler for ApplicationResourceGraph snapshots (Tier A / crd_flat).
+ */
+
+import type { ArgoCDApplication, ArgoCDResource, HealthStatusCode, SyncStatusCode } from '../types/argocd';
+import {
+    buildApplicationRootNodeId,
+    buildGraphEdgeId,
+    buildManagedResourceNodeId,
+    computeStructureVersion,
+    managedResourceKeysEqual,
+    topologyModeFromSource,
+    type ApplicationKey,
+    type ApplicationResourceGraph,
+    type ManagedResourceKey,
+    type ResourceGraphEdge,
+    type ResourceGraphNode
+} from '../types/applicationResourceGraph';
+
+export interface CrdFlatGraphAssemblyResult {
+    graph: ApplicationResourceGraph;
+    assemblyWarnings: string[];
+}
+
+export interface BuildCrdFlatApplicationResourceGraphInput {
+    application: ArgoCDApplication;
+    applicationKey: ApplicationKey;
+    observedAt?: string;
+}
+
+const TOPOLOGY_SOURCE = 'crd_flat' as const;
+
+function trimOrEmpty(value: string | undefined): string {
+    return value?.trim() ?? '';
+}
+
+function isValidResourceRow(row: ArgoCDResource): boolean {
+    return trimOrEmpty(row.kind) !== '' && trimOrEmpty(row.name) !== '';
+}
+
+function toSyncStatusCode(status: string): SyncStatusCode {
+    if (status === 'Synced' || status === 'OutOfSync' || status === 'Unknown') {
+        return status;
+    }
+    return 'Unknown';
+}
+
+function toHealthStatusCode(status: HealthStatusCode | undefined): HealthStatusCode {
+    return status ?? 'Unknown';
+}
+
+function toManagedResourceKey(row: ArgoCDResource): ManagedResourceKey {
+    return {
+        namespace: row.namespace,
+        kind: trimOrEmpty(row.kind),
+        name: trimOrEmpty(row.name)
+    };
+}
+
+function formatManagedResourceKey(key: ManagedResourceKey): string {
+    return `${key.namespace}/${key.kind}/${key.name}`;
+}
+
+function buildApplicationRootNode(application: ArgoCDApplication): ResourceGraphNode {
+    const rootId = buildApplicationRootNodeId(application.namespace, application.name);
+    const status: ResourceGraphNode['status'] = {
+        syncStatus: application.syncStatus.status,
+        healthStatus: application.healthStatus.status
+    };
+    if (application.healthStatus.message) {
+        status.message = application.healthStatus.message;
+    }
+    return {
+        id: rootId,
+        role: 'application',
+        resourceKey: null,
+        status,
+        label: application.name,
+        kindLabel: 'Application'
+    };
+}
+
+function buildManagedResourceNode(row: ArgoCDResource): ResourceGraphNode {
+    const resourceKey = toManagedResourceKey(row);
+    const status: ResourceGraphNode['status'] = {
+        syncStatus: toSyncStatusCode(row.syncStatus),
+        healthStatus: toHealthStatusCode(row.healthStatus)
+    };
+    if (row.message) {
+        status.message = row.message;
+    }
+    return {
+        id: buildManagedResourceNodeId(resourceKey),
+        role: 'managed_resource',
+        resourceKey,
+        status,
+        label: resourceKey.name,
+        kindLabel: resourceKey.kind
+    };
+}
+
+export function buildCrdFlatApplicationResourceGraph(
+    input: BuildCrdFlatApplicationResourceGraphInput
+): CrdFlatGraphAssemblyResult {
+    const { application, applicationKey } = input;
+    const observedAt = input.observedAt ?? new Date().toISOString();
+    const assemblyWarnings: string[] = [];
+
+    const rootNode = buildApplicationRootNode(application);
+    const managedNodes: ResourceGraphNode[] = [];
+    const seenKeys: ManagedResourceKey[] = [];
+
+    for (const row of application.resources) {
+        if (!isValidResourceRow(row)) {
+            assemblyWarnings.push('Skipped resource row: missing kind or name');
+            continue;
+        }
+
+        const resourceKey = toManagedResourceKey(row);
+        const isDuplicate = seenKeys.some((seen) => managedResourceKeysEqual(seen, resourceKey));
+        if (isDuplicate) {
+            assemblyWarnings.push(
+                `Skipped duplicate managed resource: ${formatManagedResourceKey(resourceKey)}`
+            );
+            continue;
+        }
+
+        seenKeys.push(resourceKey);
+        managedNodes.push(buildManagedResourceNode(row));
+    }
+
+    const nodes = [rootNode, ...managedNodes];
+    const edges: ResourceGraphEdge[] = managedNodes.map((node) => ({
+        id: buildGraphEdgeId(rootNode.id, node.id, 'manages'),
+        source: rootNode.id,
+        target: node.id,
+        relationship: 'manages' as const
+    }));
+
+    const graph: ApplicationResourceGraph = {
+        applicationKey,
+        nodes,
+        edges,
+        topologySource: TOPOLOGY_SOURCE,
+        topologyMode: topologyModeFromSource(TOPOLOGY_SOURCE),
+        structureVersion: computeStructureVersion({ nodes, edges }),
+        observedAt
+    };
+
+    return { graph, assemblyWarnings };
+}

--- a/src/test/suite/services/ApplicationResourceGraphAssembler.test.ts
+++ b/src/test/suite/services/ApplicationResourceGraphAssembler.test.ts
@@ -1,0 +1,283 @@
+import * as assert from 'assert';
+import { buildCrdFlatApplicationResourceGraph } from '../../../services/ApplicationResourceGraphAssembler';
+import {
+    buildApplicationRootNodeId,
+    buildManagedResourceNodeId,
+    computeStructureVersion,
+    type ApplicationKey
+} from '../../../types/applicationResourceGraph';
+import type { ArgoCDApplication, ArgoCDResource } from '../../../types/argocd';
+
+const APPLICATION_KEY: ApplicationKey = {
+    context: 'minikube',
+    namespace: 'argocd',
+    name: 'guestbook'
+};
+
+function baseApplication(overrides: Partial<ArgoCDApplication> = {}): ArgoCDApplication {
+    return {
+        name: 'guestbook',
+        namespace: 'argocd',
+        project: 'default',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        syncStatus: {
+            status: 'Synced',
+            revision: 'abc123',
+            comparedTo: {
+                source: {
+                    repoURL: 'https://github.com/example/guestbook',
+                    path: '.',
+                    targetRevision: 'main'
+                }
+            }
+        },
+        healthStatus: {
+            status: 'Healthy'
+        },
+        source: {
+            repoURL: 'https://github.com/example/guestbook',
+            path: '.',
+            targetRevision: 'main'
+        },
+        destination: {
+            server: 'https://kubernetes.default.svc',
+            namespace: 'guestbook'
+        },
+        resources: [],
+        ...overrides
+    };
+}
+
+function deploymentRow(overrides: Partial<ArgoCDResource> = {}): ArgoCDResource {
+    return {
+        kind: 'Deployment',
+        name: 'guestbook-ui',
+        namespace: 'guestbook',
+        syncStatus: 'Synced',
+        healthStatus: 'Healthy',
+        ...overrides
+    };
+}
+
+function serviceRow(overrides: Partial<ArgoCDResource> = {}): ArgoCDResource {
+    return {
+        kind: 'Service',
+        name: 'guestbook-ui',
+        namespace: 'guestbook',
+        syncStatus: 'Synced',
+        healthStatus: 'Healthy',
+        ...overrides
+    };
+}
+
+suite('ApplicationResourceGraphAssembler', () => {
+    test('builds root, managed nodes, and manages edges for multi-resource app', () => {
+        const application = baseApplication({
+            resources: [deploymentRow(), serviceRow()]
+        });
+
+        const { graph } = buildCrdFlatApplicationResourceGraph({
+            application,
+            applicationKey: APPLICATION_KEY,
+            observedAt: '2024-06-01T12:00:00.000Z'
+        });
+
+        const rootId = buildApplicationRootNodeId('argocd', 'guestbook');
+        assert.strictEqual(graph.nodes.length, 3);
+        assert.strictEqual(graph.edges.length, 2);
+        assert.strictEqual(graph.topologySource, 'crd_flat');
+        assert.strictEqual(graph.topologyMode, 'limited');
+        assert.strictEqual(graph.applicationKey, APPLICATION_KEY);
+        assert.strictEqual(graph.observedAt, '2024-06-01T12:00:00.000Z');
+
+        const root = graph.nodes.find((node) => node.role === 'application');
+        assert.ok(root);
+        assert.strictEqual(root.id, rootId);
+        assert.strictEqual(root.resourceKey, null);
+        assert.strictEqual(root.kindLabel, 'Application');
+
+        const managed = graph.nodes.filter((node) => node.role === 'managed_resource');
+        assert.strictEqual(managed.length, 2);
+        assert.strictEqual(
+            managed[0].id,
+            buildManagedResourceNodeId({ namespace: 'guestbook', kind: 'Deployment', name: 'guestbook-ui' })
+        );
+        assert.strictEqual(
+            managed[1].id,
+            buildManagedResourceNodeId({ namespace: 'guestbook', kind: 'Service', name: 'guestbook-ui' })
+        );
+
+        for (const edge of graph.edges) {
+            assert.strictEqual(edge.source, rootId);
+            assert.strictEqual(edge.relationship, 'manages');
+            assert.strictEqual(edge.id, `${rootId}->${edge.target}:manages`);
+        }
+    });
+
+    test('propagates application and managed resource status fields', () => {
+        const application = baseApplication({
+            syncStatus: {
+                status: 'OutOfSync',
+                revision: 'abc123',
+                comparedTo: {
+                    source: {
+                        repoURL: 'https://github.com/example/guestbook',
+                        path: '.',
+                        targetRevision: 'main'
+                    }
+                }
+            },
+            healthStatus: {
+                status: 'Degraded',
+                message: 'Application is degraded'
+            },
+            resources: [
+                deploymentRow({
+                    syncStatus: 'OutOfSync',
+                    healthStatus: 'Degraded',
+                    message: 'Deployment drift detected'
+                })
+            ]
+        });
+
+        const { graph } = buildCrdFlatApplicationResourceGraph({
+            application,
+            applicationKey: APPLICATION_KEY
+        });
+
+        const root = graph.nodes.find((node) => node.role === 'application');
+        assert.ok(root);
+        assert.strictEqual(root.status.syncStatus, 'OutOfSync');
+        assert.strictEqual(root.status.healthStatus, 'Degraded');
+        assert.strictEqual(root.status.message, 'Application is degraded');
+
+        const managed = graph.nodes.find((node) => node.role === 'managed_resource');
+        assert.ok(managed);
+        assert.strictEqual(managed.status.syncStatus, 'OutOfSync');
+        assert.strictEqual(managed.status.healthStatus, 'Degraded');
+        assert.strictEqual(managed.status.message, 'Deployment drift detected');
+    });
+
+    test('returns root-only graph when resources is empty', () => {
+        const { graph, assemblyWarnings } = buildCrdFlatApplicationResourceGraph({
+            application: baseApplication({ resources: [] }),
+            applicationKey: APPLICATION_KEY
+        });
+
+        assert.deepStrictEqual(assemblyWarnings, []);
+        assert.strictEqual(graph.nodes.length, 1);
+        assert.strictEqual(graph.edges.length, 0);
+        assert.strictEqual(graph.topologySource, 'crd_flat');
+        assert.strictEqual(
+            graph.structureVersion,
+            computeStructureVersion({ nodes: graph.nodes, edges: graph.edges })
+        );
+    });
+
+    test('omits invalid rows missing kind or name and records warnings', () => {
+        const application = baseApplication({
+            resources: [
+                deploymentRow(),
+                { kind: '', name: 'missing-kind', namespace: 'guestbook', syncStatus: 'Synced' },
+                { kind: 'Service', name: '   ', namespace: 'guestbook', syncStatus: 'Synced' }
+            ]
+        });
+
+        const { graph, assemblyWarnings } = buildCrdFlatApplicationResourceGraph({
+            application,
+            applicationKey: APPLICATION_KEY
+        });
+
+        assert.strictEqual(graph.nodes.filter((node) => node.role === 'managed_resource').length, 1);
+        assert.strictEqual(graph.edges.length, 1);
+        assert.strictEqual(
+            assemblyWarnings.filter((warning) => warning === 'Skipped resource row: missing kind or name').length,
+            2
+        );
+    });
+
+    test('keeps first duplicate managed resource key and warns deterministically', () => {
+        const application = baseApplication({
+            resources: [
+                deploymentRow({ syncStatus: 'Synced', healthStatus: 'Healthy' }),
+                deploymentRow({ syncStatus: 'OutOfSync', healthStatus: 'Degraded', message: 'duplicate' })
+            ]
+        });
+
+        const { graph, assemblyWarnings } = buildCrdFlatApplicationResourceGraph({
+            application,
+            applicationKey: APPLICATION_KEY
+        });
+
+        assert.strictEqual(graph.nodes.filter((node) => node.role === 'managed_resource').length, 1);
+        const managed = graph.nodes.find((node) => node.role === 'managed_resource');
+        assert.ok(managed);
+        assert.strictEqual(managed.status.syncStatus, 'Synced');
+        assert.strictEqual(managed.status.healthStatus, 'Healthy');
+        assert.deepStrictEqual(assemblyWarnings, [
+            'Skipped duplicate managed resource: guestbook/Deployment/guestbook-ui'
+        ]);
+    });
+
+    test('structureVersion changes only for structural graph changes', () => {
+        const baseResources = [deploymentRow(), serviceRow()];
+        const baseResult = buildCrdFlatApplicationResourceGraph({
+            application: baseApplication({ resources: baseResources }),
+            applicationKey: APPLICATION_KEY
+        });
+
+        const statusOnlyResult = buildCrdFlatApplicationResourceGraph({
+            application: baseApplication({
+                resources: baseResources.map((row) => ({
+                    ...row,
+                    syncStatus: 'OutOfSync',
+                    healthStatus: 'Degraded'
+                }))
+            }),
+            applicationKey: APPLICATION_KEY
+        });
+
+        const structuralResult = buildCrdFlatApplicationResourceGraph({
+            application: baseApplication({
+                resources: [...baseResources, deploymentRow({ name: 'guestbook-api' })]
+            }),
+            applicationKey: APPLICATION_KEY
+        });
+
+        assert.strictEqual(
+            statusOnlyResult.graph.structureVersion,
+            baseResult.graph.structureVersion
+        );
+        assert.notStrictEqual(
+            structuralResult.graph.structureVersion,
+            baseResult.graph.structureVersion
+        );
+    });
+
+    test('managed node status matches corresponding ArgoCDResource row', () => {
+        const resources = [
+            deploymentRow({ syncStatus: 'OutOfSync', healthStatus: 'Progressing' }),
+            serviceRow({ syncStatus: 'Synced', healthStatus: 'Healthy', message: 'ok' })
+        ];
+        const { graph } = buildCrdFlatApplicationResourceGraph({
+            application: baseApplication({ resources }),
+            applicationKey: APPLICATION_KEY
+        });
+
+        for (const row of resources) {
+            const node = graph.nodes.find(
+                (candidate) =>
+                    candidate.role === 'managed_resource' &&
+                    candidate.resourceKey?.kind === row.kind &&
+                    candidate.resourceKey?.name === row.name &&
+                    candidate.resourceKey?.namespace === row.namespace
+            );
+            assert.ok(node, `expected node for ${row.kind}/${row.name}`);
+            assert.strictEqual(node.status.syncStatus, row.syncStatus);
+            assert.strictEqual(node.status.healthStatus, row.healthStatus ?? 'Unknown');
+            if (row.message) {
+                assert.strictEqual(node.status.message, row.message);
+            }
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Add `buildCrdFlatApplicationResourceGraph` in `src/services/ApplicationResourceGraphAssembler.ts` — a pure host-side assembler that builds Tier A (`crd_flat`) `ApplicationResourceGraph` snapshots from a parsed `ArgoCDApplication`.
- Produces exactly one Application root node, one managed resource node per valid `status.resources` row, and `manages` edges from root to each managed node.
- Handles invalid rows (missing kind/name), duplicate `ManagedResourceKey` deduplication with deterministic warnings, and `structureVersion` via #153 helpers.
- Unit tests cover multi-resource assembly, status propagation, empty resources, invalid/duplicate rows, and structure-version stability.

Closes #154

## Test plan

- [x] `npm run test:unit` passes locally (including new `ApplicationResourceGraphAssembler.test.ts`)
- [x] `npm run lint` passes locally
- [ ] CI green on this PR