### PR TITLE
feat(argocd): cap ApplicationResourceGraph at 200 managed nodes (#156)

### DIFF
--- a/src/services/ApplicationResourceGraphAssembler.ts
+++ b/src/services/ApplicationResourceGraphAssembler.ts
@@ -16,6 +16,7 @@ import {
     type ResourceGraphEdge,
     type ResourceGraphNode
 } from '../types/applicationResourceGraph';
+import { truncateApplicationResourceGraph } from './ApplicationResourceGraphTruncation';
 
 export interface CrdFlatGraphAssemblyResult {
     graph: ApplicationResourceGraph;
@@ -137,7 +138,7 @@ export function buildCrdFlatApplicationResourceGraph(
         relationship: 'manages' as const
     }));
 
-    const graph: ApplicationResourceGraph = {
+    const graph: ApplicationResourceGraph = truncateApplicationResourceGraph({
         applicationKey,
         nodes,
         edges,
@@ -145,7 +146,7 @@ export function buildCrdFlatApplicationResourceGraph(
         topologyMode: topologyModeFromSource(TOPOLOGY_SOURCE),
         structureVersion: computeStructureVersion({ nodes, edges }),
         observedAt
-    };
+    });
 
     return { graph, assemblyWarnings };
 }

--- a/src/services/ApplicationResourceGraphTruncation.ts
+++ b/src/services/ApplicationResourceGraphTruncation.ts
@@ -1,0 +1,85 @@
+/**
+ * Caps ApplicationResourceGraph managed node count for host/webview responsiveness.
+ *
+ * Progressive disclosure (M12): when `truncated === true`, the webview SHOULD show a
+ * non-blocking banner: "Showing 200 of N managed resources. Topology may be incomplete."
+ * where N is full `application.resources.length` from latest applicationData.
+ */
+
+import {
+    buildGraphEdgeId,
+    computeStructureVersion,
+    type ApplicationResourceGraph,
+    type ManagedResourceKey,
+    type ResourceGraphEdge,
+    type ResourceGraphNode
+} from '../types/applicationResourceGraph';
+import { MAX_MANAGED_GRAPH_NODES } from './applicationResourceGraphLimits';
+
+function compareManagedResourceKeys(a: ManagedResourceKey, b: ManagedResourceKey): number {
+    const namespaceOrder = a.namespace.localeCompare(b.namespace);
+    if (namespaceOrder !== 0) {
+        return namespaceOrder;
+    }
+    const kindOrder = a.kind.localeCompare(b.kind);
+    if (kindOrder !== 0) {
+        return kindOrder;
+    }
+    return a.name.localeCompare(b.name);
+}
+
+function sortManagedNodes(nodes: ResourceGraphNode[]): ResourceGraphNode[] {
+    return [...nodes].sort((left, right) => {
+        const leftKey = left.resourceKey;
+        const rightKey = right.resourceKey;
+        if (!leftKey || !rightKey) {
+            return 0;
+        }
+        return compareManagedResourceKeys(leftKey, rightKey);
+    });
+}
+
+export function truncateApplicationResourceGraph(
+    graph: ApplicationResourceGraph,
+    maxManaged: number = MAX_MANAGED_GRAPH_NODES
+): ApplicationResourceGraph {
+    const rootNode = graph.nodes.find((node) => node.role === 'application');
+    const managedNodes = graph.nodes.filter((node) => node.role === 'managed_resource');
+
+    if (managedNodes.length <= maxManaged) {
+        if (graph.truncated === true) {
+            return {
+                applicationKey: graph.applicationKey,
+                nodes: graph.nodes,
+                edges: graph.edges,
+                topologySource: graph.topologySource,
+                topologyMode: graph.topologyMode,
+                structureVersion: graph.structureVersion,
+                observedAt: graph.observedAt,
+                layoutHint: graph.layoutHint
+            };
+        }
+        return graph;
+    }
+
+    if (!rootNode) {
+        return graph;
+    }
+
+    const keptManaged = sortManagedNodes(managedNodes).slice(0, maxManaged);
+    const nodes = [rootNode, ...keptManaged];
+    const edges: ResourceGraphEdge[] = keptManaged.map((node) => ({
+        id: buildGraphEdgeId(rootNode.id, node.id, 'manages'),
+        source: rootNode.id,
+        target: node.id,
+        relationship: 'manages' as const
+    }));
+
+    return {
+        ...graph,
+        nodes,
+        edges,
+        structureVersion: computeStructureVersion({ nodes, edges }),
+        truncated: true
+    };
+}

--- a/src/services/applicationResourceGraphLimits.ts
+++ b/src/services/applicationResourceGraphLimits.ts
@@ -1,0 +1,5 @@
+/**
+ * Product cap for managed resource nodes in ApplicationResourceGraph (excludes Application root).
+ * See `.forge/interface/presentation.md` and issue #156.
+ */
+export const MAX_MANAGED_GRAPH_NODES = 200;

--- a/src/test/suite/services/ApplicationResourceGraphTruncation.test.ts
+++ b/src/test/suite/services/ApplicationResourceGraphTruncation.test.ts
@@ -1,0 +1,155 @@
+import * as assert from 'assert';
+import { buildCrdFlatApplicationResourceGraph } from '../../../services/ApplicationResourceGraphAssembler';
+import { MAX_MANAGED_GRAPH_NODES } from '../../../services/applicationResourceGraphLimits';
+import { truncateApplicationResourceGraph } from '../../../services/ApplicationResourceGraphTruncation';
+import {
+    buildApplicationRootNodeId,
+    buildManagedResourceNodeId,
+    computeStructureVersion,
+    type ApplicationKey
+} from '../../../types/applicationResourceGraph';
+import type { ArgoCDApplication, ArgoCDResource } from '../../../types/argocd';
+
+const APPLICATION_KEY: ApplicationKey = {
+    context: 'minikube',
+    namespace: 'argocd',
+    name: 'guestbook'
+};
+
+function baseApplication(overrides: Partial<ArgoCDApplication> = {}): ArgoCDApplication {
+    return {
+        name: 'guestbook',
+        namespace: 'argocd',
+        project: 'default',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        syncStatus: {
+            status: 'Synced',
+            revision: 'abc123',
+            comparedTo: {
+                source: {
+                    repoURL: 'https://github.com/example/guestbook',
+                    path: '.',
+                    targetRevision: 'main'
+                }
+            }
+        },
+        healthStatus: {
+            status: 'Healthy'
+        },
+        source: {
+            repoURL: 'https://github.com/example/guestbook',
+            path: '.',
+            targetRevision: 'main'
+        },
+        destination: {
+            server: 'https://kubernetes.default.svc',
+            namespace: 'guestbook'
+        },
+        resources: [],
+        ...overrides
+    };
+}
+
+function deploymentRow(name: string, namespace = 'guestbook'): ArgoCDResource {
+    return {
+        kind: 'Deployment',
+        name,
+        namespace,
+        syncStatus: 'Synced',
+        healthStatus: 'Healthy'
+    };
+}
+
+function managedResourceRows(count: number): ArgoCDResource[] {
+    const rows: ArgoCDResource[] = [];
+    for (let index = 0; index < count; index += 1) {
+        rows.push(deploymentRow(`workload-${String(index).padStart(4, '0')}`));
+    }
+    return rows;
+}
+
+suite('ApplicationResourceGraphTruncation', () => {
+    test('assembler leaves graph unchanged at 199 managed resources', () => {
+        const { graph } = buildCrdFlatApplicationResourceGraph({
+            application: baseApplication({ resources: managedResourceRows(199) }),
+            applicationKey: APPLICATION_KEY
+        });
+
+        assert.strictEqual(graph.nodes.filter((node) => node.role === 'managed_resource').length, 199);
+        assert.strictEqual(graph.nodes.length, 200);
+        assert.strictEqual(graph.edges.length, 199);
+        assert.notStrictEqual(graph.truncated, true);
+    });
+
+    test('assembler truncates at 201 managed resources with truncated flag', () => {
+        const { graph } = buildCrdFlatApplicationResourceGraph({
+            application: baseApplication({ resources: managedResourceRows(201) }),
+            applicationKey: APPLICATION_KEY
+        });
+
+        assert.strictEqual(graph.truncated, true);
+        assert.strictEqual(graph.nodes.filter((node) => node.role === 'managed_resource').length, 200);
+        assert.strictEqual(graph.nodes.length, 201);
+        assert.strictEqual(graph.edges.length, 200);
+        assert.strictEqual(
+            graph.structureVersion,
+            computeStructureVersion({ nodes: graph.nodes, edges: graph.edges })
+        );
+    });
+
+    test('truncateApplicationResourceGraph keeps deterministic managed node selection', () => {
+        const resources = [
+            deploymentRow('z-last', 'zebra'),
+            deploymentRow('a-first', 'alpha'),
+            deploymentRow('m-mid', 'middle')
+        ];
+        const { graph: fullGraph } = buildCrdFlatApplicationResourceGraph({
+            application: baseApplication({ resources }),
+            applicationKey: APPLICATION_KEY
+        });
+
+        const first = truncateApplicationResourceGraph(fullGraph, 2);
+        const second = truncateApplicationResourceGraph(fullGraph, 2);
+
+        assert.deepStrictEqual(
+            first.nodes.filter((node) => node.role === 'managed_resource').map((node) => node.id),
+            second.nodes.filter((node) => node.role === 'managed_resource').map((node) => node.id)
+        );
+        assert.deepStrictEqual(
+            first.nodes
+                .filter((node) => node.role === 'managed_resource')
+                .map((node) => node.id),
+            [
+                buildManagedResourceNodeId({ namespace: 'alpha', kind: 'Deployment', name: 'a-first' }),
+                buildManagedResourceNodeId({ namespace: 'middle', kind: 'Deployment', name: 'm-mid' })
+            ]
+        );
+    });
+
+    test('application root is always present when truncated', () => {
+        const { graph } = buildCrdFlatApplicationResourceGraph({
+            application: baseApplication({ resources: managedResourceRows(250) }),
+            applicationKey: APPLICATION_KEY
+        });
+
+        assert.strictEqual(graph.truncated, true);
+        const root = graph.nodes.find((node) => node.role === 'application');
+        assert.ok(root);
+        assert.strictEqual(root.id, buildApplicationRootNodeId('argocd', 'guestbook'));
+    });
+
+    test('truncateApplicationResourceGraph omits truncated when under cap', () => {
+        const { graph } = buildCrdFlatApplicationResourceGraph({
+            application: baseApplication({ resources: managedResourceRows(5) }),
+            applicationKey: APPLICATION_KEY
+        });
+
+        const result = truncateApplicationResourceGraph(graph);
+        assert.notStrictEqual(result.truncated, true);
+        assert.strictEqual(result.nodes.length, graph.nodes.length);
+    });
+
+    test('product cap constant is 200 managed nodes', () => {
+        assert.strictEqual(MAX_MANAGED_GRAPH_NODES, 200);
+    });
+});


### PR DESCRIPTION
## Summary

- Add `MAX_MANAGED_GRAPH_NODES` (200) and `truncateApplicationResourceGraph` with deterministic `(namespace, kind, name)` selection.
- Apply truncation at `buildCrdFlatApplicationResourceGraph` exit so host assembly never posts uncapped graphs.
- Set `truncated: true` and recompute `structureVersion` for the reduced topology; document M12 progressive-disclosure banner contract in code.

Closes #156

## Test plan

- [x] `npm run test:unit` in `kube9/kube9-vscode` (includes `ApplicationResourceGraphTruncation.test.ts`)
- [x] `npm run lint`