### PR TITLE
feat(argocd): kind capability registry for graph resource actions (#160)

### DIFF
--- a/src/services/KindCapabilityRegistry.ts
+++ b/src/services/KindCapabilityRegistry.ts
@@ -1,0 +1,363 @@
+import * as vscode from 'vscode';
+import {
+    applyRestartAnnotation,
+    RolloutTimeoutError,
+    showRestartConfirmationDialog,
+    watchRolloutStatus
+} from '../commands/restartWorkload';
+import { KubectlError, KubectlErrorType } from '../kubernetes/KubectlError';
+import type {
+    ExtensionToWebviewMessage,
+    OperationPhase,
+    ResourceActionWebviewMessage,
+    ResourceNodeRef
+} from '../types/argocdWebviewProtocol';
+import { ClusterTreeProvider } from '../tree/ClusterTreeProvider';
+
+export const ACTION_DEPLOYMENT_RESTART_ROLLOUT = 'deployment.restartRollout';
+export const ACTION_RESOURCE_NAVIGATE_TREE = 'resource.navigateTree';
+
+/** Kinds that can be revealed in the cluster tree via resource.navigateTree. */
+export const NAVIGATE_TREE_SUPPORTED_KINDS = new Set([
+    'Deployment',
+    'StatefulSet',
+    'DaemonSet',
+    'CronJob',
+    'Pod',
+    'Service',
+    'ConfigMap',
+    'Secret'
+]);
+
+export interface ResourceActionContext {
+    context: string;
+    treeProvider: ClusterTreeProvider;
+    panel: vscode.WebviewPanel;
+    kubeconfigPath: string;
+}
+
+export type ResourceActionHandler = (
+    ctx: ResourceActionContext,
+    message: ResourceActionWebviewMessage
+) => Promise<void>;
+
+const ACTION_REGISTRY: Record<
+    string,
+    { supportedKinds: Set<string>; handler: ResourceActionHandler }
+> = {
+    [ACTION_DEPLOYMENT_RESTART_ROLLOUT]: {
+        supportedKinds: new Set(['Deployment']),
+        handler: handleDeploymentRestartRollout
+    },
+    [ACTION_RESOURCE_NAVIGATE_TREE]: {
+        supportedKinds: NAVIGATE_TREE_SUPPORTED_KINDS,
+        handler: handleResourceNavigateTree
+    }
+};
+
+export function buildResourceNodeRef(message: ResourceActionWebviewMessage): ResourceNodeRef {
+    return {
+        kind: message.kind,
+        name: message.name,
+        namespace: message.namespace,
+        ...(message.group !== undefined ? { group: message.group } : {}),
+        ...(message.version !== undefined ? { version: message.version } : {})
+    };
+}
+
+export function postResourceActionProgress(
+    panel: vscode.WebviewPanel,
+    message: ResourceActionWebviewMessage,
+    phase: OperationPhase,
+    progressMessage?: string
+): void {
+    panel.webview.postMessage({
+        type: 'resourceActionProgress',
+        actionId: message.actionId,
+        phase,
+        ...(progressMessage !== undefined ? { message: progressMessage } : {}),
+        nodeRef: buildResourceNodeRef(message)
+    } satisfies ExtensionToWebviewMessage);
+}
+
+export function postResourceActionResult(
+    panel: vscode.WebviewPanel,
+    message: ResourceActionWebviewMessage,
+    success: boolean,
+    resultMessage: string
+): void {
+    panel.webview.postMessage({
+        type: 'resourceActionResult',
+        actionId: message.actionId,
+        success,
+        message: resultMessage,
+        nodeRef: buildResourceNodeRef(message)
+    } satisfies ExtensionToWebviewMessage);
+}
+
+export function resolveResourceActionHandler(
+    actionId: string,
+    kind: string
+): ResourceActionHandler | 'unsupported_kind' | undefined {
+    const entry = ACTION_REGISTRY[actionId];
+    if (!entry) {
+        return undefined;
+    }
+    if (!entry.supportedKinds.has(kind)) {
+        return 'unsupported_kind';
+    }
+    return entry.handler;
+}
+
+export async function dispatchResourceAction(
+    ctx: ResourceActionContext,
+    message: ResourceActionWebviewMessage
+): Promise<void> {
+    const resolved = resolveResourceActionHandler(message.actionId, message.kind);
+    if (resolved === undefined) {
+        postResourceActionResult(
+            ctx.panel,
+            message,
+            false,
+            `Unknown action: ${message.actionId}`
+        );
+        return;
+    }
+    if (resolved === 'unsupported_kind') {
+        postResourceActionResult(
+            ctx.panel,
+            message,
+            false,
+            `Action ${message.actionId} is not supported for kind ${message.kind}`
+        );
+        return;
+    }
+
+    try {
+        await resolved(ctx, message);
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        postResourceActionResult(ctx.panel, message, false, errorMessage);
+    }
+}
+
+function isKubectlLikeError(error: unknown): error is KubectlError {
+    if (typeof error !== 'object' || error === null) {
+        return false;
+    }
+    const candidate = error as Partial<KubectlError>;
+    return (
+        typeof candidate.type === 'string' &&
+        typeof candidate.message === 'string' &&
+        typeof candidate.getDetails === 'function'
+    );
+}
+
+function isRolloutTimeoutLikeError(error: unknown): error is RolloutTimeoutError {
+    return (
+        typeof error === 'object' &&
+        error !== null &&
+        (error as RolloutTimeoutError).name === 'RolloutTimeoutError'
+    );
+}
+
+function formatRestartFailureMessage(
+    actionId: string,
+    kind: string,
+    name: string,
+    error: unknown
+): string {
+    if (isRolloutTimeoutLikeError(error)) {
+        return `${actionId} timed out for ${kind} ${name}: rollout did not complete within 5 minutes`;
+    }
+
+    if (isKubectlLikeError(error)) {
+        let reason: string;
+        switch (error.type) {
+            case KubectlErrorType.PermissionDenied:
+                reason = 'insufficient permissions';
+                break;
+            case KubectlErrorType.ConnectionFailed:
+                reason = 'cannot connect to cluster';
+                break;
+            case KubectlErrorType.Timeout:
+                reason = 'request timed out';
+                break;
+            case KubectlErrorType.BinaryNotFound:
+                reason = 'kubectl not found';
+                break;
+            case KubectlErrorType.Unknown: {
+                const lowerDetails = error.getDetails().toLowerCase();
+                if (
+                    lowerDetails.includes('notfound') ||
+                    lowerDetails.includes('not found') ||
+                    lowerDetails.includes('404') ||
+                    lowerDetails.includes('does not exist')
+                ) {
+                    reason = 'resource may have been deleted';
+                } else {
+                    reason = 'kubernetes API request failed';
+                }
+                break;
+            }
+            default:
+                reason = 'kubernetes API request failed';
+        }
+        return `${actionId} failed for ${kind} ${name}: ${reason}`;
+    }
+
+    const detail = error instanceof Error ? error.message : String(error);
+    return `${actionId} failed for ${kind} ${name}: ${detail}`;
+}
+
+async function handleDeploymentRestartRollout(
+    ctx: ResourceActionContext,
+    message: ResourceActionWebviewMessage
+): Promise<void> {
+    const { kind, name, namespace, actionId } = message;
+
+    if (!ctx.kubeconfigPath) {
+        postResourceActionResult(
+            ctx.panel,
+            message,
+            false,
+            `${actionId} failed for ${kind} ${name}: kubeconfig path not available`
+        );
+        return;
+    }
+
+    const confirmation = await showRestartConfirmationDialog(name);
+    if (!confirmation) {
+        postResourceActionResult(ctx.panel, message, false, 'Cancelled');
+        return;
+    }
+
+    postResourceActionProgress(
+        ctx.panel,
+        message,
+        'Running',
+        `Restarting ${kind} ${name}...`
+    );
+
+    try {
+        await applyRestartAnnotation(
+            name,
+            namespace,
+            kind,
+            ctx.context,
+            ctx.kubeconfigPath
+        );
+
+        if (confirmation.waitForRollout) {
+            await watchRolloutStatus(
+                name,
+                namespace,
+                kind,
+                ctx.context,
+                ctx.kubeconfigPath,
+                {
+                    report: ({ message: rolloutMessage }) => {
+                        if (rolloutMessage) {
+                            postResourceActionProgress(
+                                ctx.panel,
+                                message,
+                                'Running',
+                                rolloutMessage
+                            );
+                        }
+                    }
+                }
+            );
+        }
+
+        postResourceActionProgress(ctx.panel, message, 'Succeeded', `Restarted ${kind} ${name}`);
+        postResourceActionResult(
+            ctx.panel,
+            message,
+            true,
+            `Restarted ${kind} ${name} successfully`
+        );
+        ctx.treeProvider.refresh();
+    } catch (error) {
+        const failureMessage = formatRestartFailureMessage(actionId, kind, name, error);
+        postResourceActionProgress(ctx.panel, message, 'Failed', failureMessage);
+        postResourceActionResult(ctx.panel, message, false, failureMessage);
+        ctx.treeProvider.refresh();
+    }
+}
+
+async function handleResourceNavigateTree(
+    ctx: ResourceActionContext,
+    message: ResourceActionWebviewMessage
+): Promise<void> {
+    const { kind, name, namespace, actionId } = message;
+
+    postResourceActionProgress(
+        ctx.panel,
+        message,
+        'Running',
+        `Navigating to ${kind} ${name}...`
+    );
+
+    if (!ctx.treeProvider.getKubeconfigPath()) {
+        postResourceActionProgress(ctx.panel, message, 'Failed', 'Tree view is unavailable');
+        postResourceActionResult(
+            ctx.panel,
+            message,
+            false,
+            `${actionId} failed for ${kind} ${name}: tree view is unavailable`
+        );
+        return;
+    }
+
+    const contextMatches = await ctx.treeProvider.isCurrentContext(ctx.context);
+    if (!contextMatches) {
+        postResourceActionProgress(ctx.panel, message, 'Failed', 'Cluster context mismatch');
+        postResourceActionResult(
+            ctx.panel,
+            message,
+            false,
+            `${actionId} failed for ${kind} ${name}: active cluster context does not match this application`
+        );
+        return;
+    }
+
+    try {
+        await vscode.commands.executeCommand('kube9.treeView.focus');
+        ctx.treeProvider.refresh();
+
+        const revealed = await ctx.treeProvider.revealTreeResource(kind, name, namespace);
+        if (revealed) {
+            postResourceActionProgress(
+                ctx.panel,
+                message,
+                'Succeeded',
+                `Focused ${kind} ${name} in cluster tree`
+            );
+            postResourceActionResult(
+                ctx.panel,
+                message,
+                true,
+                `Focused ${kind} ${name} in cluster tree`
+            );
+            return;
+        }
+
+        postResourceActionProgress(ctx.panel, message, 'Failed', 'Resource not found in tree');
+        postResourceActionResult(
+            ctx.panel,
+            message,
+            false,
+            `${actionId} failed for ${kind} ${name}: resource not found in cluster tree`
+        );
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        postResourceActionProgress(ctx.panel, message, 'Failed', detail);
+        postResourceActionResult(
+            ctx.panel,
+            message,
+            false,
+            `${actionId} failed for ${kind} ${name}: ${detail}`
+        );
+    }
+}

--- a/src/test/suite/services/kindCapabilityRegistry.test.ts
+++ b/src/test/suite/services/kindCapabilityRegistry.test.ts
@@ -1,0 +1,311 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import * as assert from 'assert';
+import * as Module from 'module';
+import * as vscode from 'vscode';
+import { KubectlError, KubectlErrorType } from '../../../kubernetes/KubectlError';
+import { ClusterTreeProvider } from '../../../tree/ClusterTreeProvider';
+import {
+    ACTION_DEPLOYMENT_RESTART_ROLLOUT,
+    ACTION_RESOURCE_NAVIGATE_TREE,
+    resolveResourceActionHandler,
+    type ResourceActionContext
+} from '../../../services/KindCapabilityRegistry';
+import type { ResourceActionWebviewMessage } from '../../../types/argocdWebviewProtocol';
+import { isExtensionMessage, type ExtensionToWebviewMessage } from '../../../types/argocdWebviewProtocol';
+
+const originalRequire = Module.prototype.require;
+
+function resourceActionMessage(
+    overrides: Partial<ResourceActionWebviewMessage> = {}
+): ResourceActionWebviewMessage {
+    return {
+        type: 'resourceAction',
+        actionId: ACTION_DEPLOYMENT_RESTART_ROLLOUT,
+        kind: 'Deployment',
+        name: 'guestbook-ui',
+        namespace: 'guestbook',
+        ...overrides
+    };
+}
+
+function capturePostMessages(panel: vscode.WebviewPanel): ExtensionToWebviewMessage[] {
+    const messages: ExtensionToWebviewMessage[] = [];
+    const webview = panel.webview;
+    const originalPostMessage = webview.postMessage.bind(webview);
+    webview.postMessage = (message: unknown) => {
+        if (isExtensionMessage(message)) {
+            messages.push(message);
+        }
+        return originalPostMessage(message);
+    };
+    return messages;
+}
+
+function lastResult(messages: ExtensionToWebviewMessage[]) {
+    return messages.filter((m) => m.type === 'resourceActionResult').at(-1);
+}
+
+suite('KindCapabilityRegistry', () => {
+    const contextName = 'minikube';
+    let mockRestartBehavior: {
+        confirmation?: { confirmed: boolean; waitForRollout: boolean } | undefined;
+        applyError?: unknown;
+        watchError?: unknown;
+    };
+    let applyCalls = 0;
+    let watchCalls = 0;
+
+    setup(() => {
+        mockRestartBehavior = {};
+        applyCalls = 0;
+        watchCalls = 0;
+
+        (vscode.commands as unknown as { _registerCommand: (id: string, fn: () => Promise<void>) => void })
+            ._registerCommand('kube9.treeView.focus', async () => {
+                /**/
+            });
+        (vscode.commands as unknown as { _registerCommand: (id: string, fn: () => Promise<void>) => void })
+            ._registerCommand('kube9ClusterView.focus', async () => {
+                /**/
+            });
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        Module.prototype.require = function (this: unknown, ...args: any[]): any {
+            const id = args[0] as string;
+            if (typeof id === 'string' && id.includes('restartWorkload')) {
+                return {
+                    showRestartConfirmationDialog: async () => mockRestartBehavior.confirmation,
+                    applyRestartAnnotation: async () => {
+                        applyCalls += 1;
+                        if (mockRestartBehavior.applyError) {
+                            throw mockRestartBehavior.applyError;
+                        }
+                    },
+                    watchRolloutStatus: async () => {
+                        watchCalls += 1;
+                        if (mockRestartBehavior.watchError) {
+                            throw mockRestartBehavior.watchError;
+                        }
+                    }
+                };
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return (originalRequire as any).apply(this, args);
+        };
+
+        delete require.cache[require.resolve('../../../services/KindCapabilityRegistry')];
+    });
+
+    teardown(() => {
+        Module.prototype.require = originalRequire;
+        delete require.cache[require.resolve('../../../services/KindCapabilityRegistry')];
+        (vscode.window as unknown as { _clearMessages(): void })._clearMessages();
+    });
+
+    function buildContext(panel: vscode.WebviewPanel): ResourceActionContext {
+        const treeProvider = {
+            getKubeconfigPath: () => '/mock/kubeconfig',
+            refresh: () => {
+                /**/
+            },
+            isCurrentContext: async () => true,
+            revealTreeResource: async () => true
+        } as unknown as ClusterTreeProvider;
+
+        return {
+            panel,
+            treeProvider,
+            context: contextName,
+            kubeconfigPath: '/mock/kubeconfig'
+        };
+    }
+
+    function loadDispatch() {
+        delete require.cache[require.resolve('../../../services/KindCapabilityRegistry')];
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        return require('../../../services/KindCapabilityRegistry')
+            .dispatchResourceAction as typeof import('../../../services/KindCapabilityRegistry').dispatchResourceAction;
+    }
+
+    test('resolveResourceActionHandler returns undefined for unknown actionId', () => {
+        assert.strictEqual(resolveResourceActionHandler('unknown.action', 'Deployment'), undefined);
+    });
+
+    test('resolveResourceActionHandler returns unsupported_kind for wrong kind', () => {
+        assert.strictEqual(
+            resolveResourceActionHandler(ACTION_DEPLOYMENT_RESTART_ROLLOUT, 'Service'),
+            'unsupported_kind'
+        );
+    });
+
+    test('dispatch posts failure for unknown actionId', async () => {
+        const dispatch = loadDispatch();
+        const panel = vscode.window.createWebviewPanel(
+            'kube9.argocdApplication',
+            'test',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+        const messages = capturePostMessages(panel);
+
+        await dispatch(
+            buildContext(panel),
+            resourceActionMessage({ actionId: 'unknown.action' })
+        );
+
+        const result = lastResult(messages);
+        assert.ok(result);
+        assert.strictEqual(result.success, false);
+        assert.match(result.message, /Unknown action/);
+        panel.dispose();
+    });
+
+    test('dispatch posts failure for unsupported kind', async () => {
+        const dispatch = loadDispatch();
+        const panel = vscode.window.createWebviewPanel(
+            'kube9.argocdApplication',
+            'test',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+        const messages = capturePostMessages(panel);
+
+        await dispatch(
+            buildContext(panel),
+            resourceActionMessage({ kind: 'Service' })
+        );
+
+        const result = lastResult(messages);
+        assert.ok(result);
+        assert.strictEqual(result.success, false);
+        assert.match(result.message, /not supported for kind Service/);
+        panel.dispose();
+    });
+
+    test('deployment.restartRollout cancelled posts Cancelled result', async () => {
+        mockRestartBehavior.confirmation = undefined;
+        const dispatch = loadDispatch();
+        const panel = vscode.window.createWebviewPanel(
+            'kube9.argocdApplication',
+            'test',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+        const messages = capturePostMessages(panel);
+
+        await dispatch(buildContext(panel), resourceActionMessage());
+
+        const result = lastResult(messages);
+        assert.ok(result);
+        assert.strictEqual(result.success, false);
+        assert.strictEqual(result.message, 'Cancelled');
+        assert.strictEqual(applyCalls, 0);
+        panel.dispose();
+    });
+
+    test('deployment.restartRollout success emits progress and result', async () => {
+        mockRestartBehavior.confirmation = { confirmed: true, waitForRollout: false };
+        const dispatch = loadDispatch();
+        const panel = vscode.window.createWebviewPanel(
+            'kube9.argocdApplication',
+            'test',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+        const messages = capturePostMessages(panel);
+
+        await dispatch(buildContext(panel), resourceActionMessage());
+
+        assert.strictEqual(applyCalls, 1);
+        assert.strictEqual(watchCalls, 0);
+        const progress = messages.filter((m) => m.type === 'resourceActionProgress');
+        assert.ok(progress.some((m) => m.phase === 'Running'));
+        assert.ok(progress.some((m) => m.phase === 'Succeeded'));
+        const result = lastResult(messages);
+        assert.ok(result);
+        assert.strictEqual(result.success, true);
+        panel.dispose();
+    });
+
+    test('deployment.restartRollout maps permission errors to action result', async () => {
+        mockRestartBehavior.confirmation = { confirmed: true, waitForRollout: false };
+        mockRestartBehavior.applyError = new KubectlError(
+            KubectlErrorType.PermissionDenied,
+            'Permission denied',
+            'forbidden',
+            contextName
+        );
+        const dispatch = loadDispatch();
+        const panel = vscode.window.createWebviewPanel(
+            'kube9.argocdApplication',
+            'test',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+        const messages = capturePostMessages(panel);
+
+        await dispatch(buildContext(panel), resourceActionMessage());
+
+        const result = lastResult(messages);
+        assert.ok(result);
+        assert.strictEqual(result.success, false);
+        assert.match(result.message, /insufficient permissions/);
+        assert.ok(result.message.includes(ACTION_DEPLOYMENT_RESTART_ROLLOUT));
+        panel.dispose();
+    });
+
+    test('resource.navigateTree posts success when tree reveal succeeds', async () => {
+        const dispatch = loadDispatch();
+        const panel = vscode.window.createWebviewPanel(
+            'kube9.argocdApplication',
+            'test',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+        const messages = capturePostMessages(panel);
+        const ctx = buildContext(panel);
+        (ctx.treeProvider as unknown as { revealTreeResource: () => Promise<boolean> }).revealTreeResource =
+            async () => true;
+
+        await dispatch(
+            ctx,
+            resourceActionMessage({
+                actionId: ACTION_RESOURCE_NAVIGATE_TREE,
+                kind: 'Deployment'
+            })
+        );
+
+        const result = lastResult(messages);
+        assert.ok(result);
+        assert.strictEqual(result.success, true);
+        panel.dispose();
+    });
+
+    test('resource.navigateTree posts failure when resource not found', async () => {
+        const dispatch = loadDispatch();
+        const panel = vscode.window.createWebviewPanel(
+            'kube9.argocdApplication',
+            'test',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+        const messages = capturePostMessages(panel);
+        const ctx = buildContext(panel);
+        (ctx.treeProvider as unknown as { revealTreeResource: () => Promise<boolean> }).revealTreeResource =
+            async () => false;
+
+        await dispatch(
+            ctx,
+            resourceActionMessage({
+                actionId: ACTION_RESOURCE_NAVIGATE_TREE,
+                kind: 'Deployment'
+            })
+        );
+
+        const result = lastResult(messages);
+        assert.ok(result);
+        assert.strictEqual(result.success, false);
+        assert.match(result.message, /not found in cluster tree/);
+        panel.dispose();
+    });
+});

--- a/src/tree/ClusterTreeProvider.ts
+++ b/src/tree/ClusterTreeProvider.ts
@@ -1947,9 +1947,9 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
         clusterItem: ClusterTreeItem,
         podName: string,
         namespace: string
-    ): Promise<void> {
+    ): Promise<boolean> {
         if (!this.treeView || !clusterItem.resourceData) {
-            return;
+            return false;
         }
 
         try {
@@ -1959,7 +1959,7 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
             
             if (!workloadsCategory) {
                 vscode.window.showInformationMessage(`Pod '${podName}' not found in tree view (Workloads category not found)`);
-                return;
+                return false;
             }
 
             // Get workload subcategories (Deployments, StatefulSets, DaemonSets, CronJobs)
@@ -1993,17 +1993,19 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
                         
                         // Focus the tree view
                         await vscode.commands.executeCommand('kube9ClusterView.focus');
-                        return;
+                        return true;
                     }
                 }
             }
-
+            
             // Pod not found
             vscode.window.showInformationMessage(`Pod '${podName}' not found in tree view`);
+            return false;
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             console.error('Error finding pod:', errorMessage);
             vscode.window.showInformationMessage(`Pod '${podName}' not found in tree view`);
+            return false;
         }
     }
 
@@ -2151,6 +2153,155 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
             vscode.window.showInformationMessage(
                 `ReplicaSet '${replicaSetName}' not found in tree view`
             );
+        }
+    }
+
+    /**
+     * Returns true when the tree provider's active kubectl context matches the given name.
+     */
+    public async isCurrentContext(contextName: string): Promise<boolean> {
+        if (!this.kubeconfig?.currentContext) {
+            return false;
+        }
+        return this.kubeconfig.currentContext === contextName;
+    }
+
+    /**
+     * Reveal a resource in the cluster tree by kind, name, and namespace.
+     *
+     * @returns true when the resource was found and revealed.
+     */
+    public async revealTreeResource(kind: string, name: string, namespace: string): Promise<boolean> {
+        if (!this.treeView) {
+            return false;
+        }
+
+        if (!this.kubeconfig) {
+            return false;
+        }
+
+        const clusterItem = await this.resolveClusterItemForReveal();
+        if (!clusterItem) {
+            return false;
+        }
+
+        if (kind === 'Pod') {
+            return this.findAndRevealPod(clusterItem, name, namespace);
+        }
+
+        const workloadKindToSubcategory: Record<string, TreeItemType> = {
+            Deployment: 'deployments',
+            StatefulSet: 'statefulsets',
+            DaemonSet: 'daemonsets',
+            CronJob: 'cronjobs'
+        };
+        const workloadSubcategory = workloadKindToSubcategory[kind];
+        if (workloadSubcategory) {
+            return this.findAndRevealNamedResource(
+                clusterItem,
+                'workloads',
+                workloadSubcategory,
+                name,
+                namespace
+            );
+        }
+
+        const topLevelCategoryByKind: Record<string, { category: TreeItemType; subcategory: TreeItemType }> = {
+            Service: { category: 'networking', subcategory: 'services' },
+            ConfigMap: { category: 'configuration', subcategory: 'configmaps' },
+            Secret: { category: 'configuration', subcategory: 'secrets' }
+        };
+        const categoryMapping = topLevelCategoryByKind[kind];
+        if (categoryMapping) {
+            return this.findAndRevealNamedResource(
+                clusterItem,
+                categoryMapping.category,
+                categoryMapping.subcategory,
+                name,
+                namespace
+            );
+        }
+
+        return false;
+    }
+
+    private async resolveClusterItemForReveal(): Promise<ClusterTreeItem | undefined> {
+        const currentContext = this.kubeconfig?.currentContext;
+        if (!currentContext) {
+            return undefined;
+        }
+
+        const clusterItem = this.clusterItemsCache.get(currentContext);
+        if (clusterItem) {
+            return clusterItem;
+        }
+
+        const rootItems = await this.getClusters();
+        return rootItems.find(
+            (item) =>
+                item.type === 'cluster' && item.resourceData?.context?.name === currentContext
+        );
+    }
+
+    private itemMatchesResource(
+        item: ClusterTreeItem,
+        resourceName: string,
+        namespace: string
+    ): boolean {
+        const itemName =
+            item.resourceData?.resourceName ||
+            (typeof item.label === 'string' ? item.label : item.label?.toString() || '');
+        const itemNamespace = item.resourceData?.namespace || '';
+        return itemName === resourceName && itemNamespace === namespace;
+    }
+
+    private async findAndRevealNamedResource(
+        clusterItem: ClusterTreeItem,
+        categoryType: TreeItemType,
+        subcategoryType: TreeItemType,
+        resourceName: string,
+        namespace: string
+    ): Promise<boolean> {
+        if (!this.treeView || !clusterItem.resourceData) {
+            return false;
+        }
+
+        try {
+            const categories = this.getCategories(clusterItem);
+            const category = categories.find((cat) => cat.type === categoryType);
+            if (!category) {
+                return false;
+            }
+
+            const subcategories = await this.getCategoryChildren(category);
+            const subcategory = subcategories.find((sub) => sub.type === subcategoryType);
+            if (!subcategory) {
+                return false;
+            }
+
+            const resources = await this.getCategoryChildren(subcategory);
+            const matchingResource = resources.find((resource) =>
+                this.itemMatchesResource(resource, resourceName, namespace)
+            );
+
+            if (!matchingResource) {
+                return false;
+            }
+
+            await this.treeView.reveal(matchingResource, {
+                select: true,
+                focus: true,
+                expand: true
+            });
+            await vscode.commands.executeCommand('kube9ClusterView.focus');
+            return true;
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.error(
+                `Error revealing ${subcategoryType} resource ${resourceName}:`,
+                errorMessage
+            );
+            return false;
         }
     }
 

--- a/src/webview/ArgoCDApplicationWebviewProvider.ts
+++ b/src/webview/ArgoCDApplicationWebviewProvider.ts
@@ -18,6 +18,7 @@ import {
     type ResourceActionWebviewMessage,
     type WebviewToExtensionMessage
 } from '../types/argocdWebviewProtocol';
+import { dispatchResourceAction } from '../services/KindCapabilityRegistry';
 
 /**
  * Information stored with each webview panel.
@@ -680,6 +681,8 @@ export class ArgoCDApplicationWebviewProvider {
                     case 'resourceAction':
                         await ArgoCDApplicationWebviewProvider.handleResourceAction(
                             panel,
+                            treeProvider,
+                            context,
                             message
                         );
                         break;
@@ -780,25 +783,23 @@ export class ArgoCDApplicationWebviewProvider {
     }
 
     /**
-     * Handle resource graph tile actions until #160 implements the action registry.
+     * Dispatch resource graph tile actions through the kind capability registry.
      */
     private static async handleResourceAction(
         panel: vscode.WebviewPanel,
+        treeProvider: ClusterTreeProvider,
+        context: string,
         message: ResourceActionWebviewMessage
     ): Promise<void> {
-        panel.webview.postMessage({
-            type: 'resourceActionResult',
-            actionId: message.actionId,
-            success: false,
-            message: 'Not implemented',
-            nodeRef: {
-                kind: message.kind,
-                name: message.name,
-                namespace: message.namespace,
-                ...(message.group !== undefined ? { group: message.group } : {}),
-                ...(message.version !== undefined ? { version: message.version } : {})
-            }
-        } satisfies ExtensionToWebviewMessage);
+        await dispatchResourceAction(
+            {
+                panel,
+                treeProvider,
+                context,
+                kubeconfigPath: treeProvider.getKubeconfigPath() ?? ''
+            },
+            message
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add `KindCapabilityRegistry` to dispatch `deployment.restartRollout` and `resource.navigateTree` from Argo CD graph `resourceAction` messages.
- Replace the #157 stub in `ArgoCDApplicationWebviewProvider` with registry dispatch that always posts terminal `resourceActionProgress` / `resourceActionResult` payloads.
- Extend `ClusterTreeProvider` with `revealTreeResource` and context checks for best-effort tree focus/reveal.

Fixes #160

## Test plan

- [x] `npm run test:unit`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual: F5 extension, post `resourceAction` from Argo CD application webview devtools for navigate and restart (see issue #160)