### PR TITLE
feat(argocd): fetch resource-tree API and map parentRefs into full topology (#166)

### DIFF
--- a/package.json
+++ b/package.json
@@ -705,6 +705,39 @@
           "default": 30000,
           "description": "API request timeout in milliseconds"
         },
+        "kube9.argocd.restEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable Argo CD REST API enrichment for resource graph topology (resource-tree). CRD-only workflows are unchanged when false.",
+          "scope": "application"
+        },
+        "kube9.argocd.serverUrl": {
+          "type": [
+            "string",
+            "object"
+          ],
+          "default": null,
+          "markdownDescription": "Argo CD API server base URL for REST enrichment (`accessMode: direct`). String applies to all contexts; object maps kubeconfig context names to URLs."
+        },
+        "kube9.argocd.accessMode": {
+          "type": "string",
+          "enum": [
+            "direct",
+            "portForward"
+          ],
+          "default": "direct",
+          "description": "How to reach the Argo CD API server for REST enrichment: direct URL or kubectl port-forward to argocd-server."
+        },
+        "kube9.argocd.tlsInsecure": {
+          "type": "boolean",
+          "default": false,
+          "description": "Skip TLS certificate verification for Argo CD REST requests (lab/local HTTPS only)."
+        },
+        "kube9.argocd.portForwardLocalPort": {
+          "type": "number",
+          "default": 8443,
+          "description": "Preferred local port when accessMode is portForward for Argo CD REST."
+        },
         "kube9.errors.showDetails": {
           "type": "boolean",
           "default": false,

--- a/src/services/ApplicationResourceGraphAssembler.ts
+++ b/src/services/ApplicationResourceGraphAssembler.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ArgoCDApplication, ArgoCDResource, HealthStatusCode, SyncStatusCode } from '../types/argocd';
+import type { ArgoCDResourceTreeNode, ArgoCDResourceTreeResponse } from '../types/argocdResourceTree';
 import {
     buildApplicationRootNodeId,
     buildGraphEdgeId,
@@ -12,11 +13,14 @@ import {
     topologyModeFromSource,
     type ApplicationKey,
     type ApplicationResourceGraph,
+    type GraphNodeId,
     type ManagedResourceKey,
     type ResourceGraphEdge,
     type ResourceGraphNode
 } from '../types/applicationResourceGraph';
 import { truncateApplicationResourceGraph } from './ApplicationResourceGraphTruncation';
+
+const CRD_FLAT_TOPOLOGY_SOURCE = 'crd_flat' as const;
 
 export interface CrdFlatGraphAssemblyResult {
     graph: ApplicationResourceGraph;
@@ -29,7 +33,236 @@ export interface BuildCrdFlatApplicationResourceGraphInput {
     observedAt?: string;
 }
 
-const TOPOLOGY_SOURCE = 'crd_flat' as const;
+export interface BuildResourceTreeApplicationResourceGraphInput {
+    application: ArgoCDApplication;
+    applicationKey: ApplicationKey;
+    resourceTree: ArgoCDResourceTreeResponse;
+    observedAt?: string;
+}
+
+const RESOURCE_TREE_TOPOLOGY_SOURCE = 'argocd_resource_tree' as const;
+
+function trimOrUndefined(value: string | undefined): string | undefined {
+    const trimmed = value?.trim() ?? '';
+    return trimmed === '' ? undefined : trimmed;
+}
+
+function isApplicationTreeNode(
+    node: ArgoCDResourceTreeNode,
+    application: ArgoCDApplication
+): boolean {
+    const kind = trimOrUndefined(node.kind) ?? '';
+    const name = trimOrUndefined(node.name) ?? '';
+    const group = trimOrUndefined(node.group) ?? '';
+    return (
+        kind === 'Application' &&
+        name === application.name &&
+        (group === '' || group === 'argoproj.io')
+    );
+}
+
+function treeNodeToManagedResourceKey(node: ArgoCDResourceTreeNode): ManagedResourceKey | null {
+    const kind = trimOrUndefined(node.kind);
+    const name = trimOrUndefined(node.name);
+    if (!kind || !name) {
+        return null;
+    }
+    const apiGroup = trimOrUndefined(node.group);
+    return {
+        namespace: node.namespace?.trim() ?? '',
+        kind,
+        name,
+        ...(apiGroup ? { apiGroup } : {})
+    };
+}
+
+function parentRefToManagedResourceKey(
+    parentRef: NonNullable<ArgoCDResourceTreeNode['parentRefs']>[number]
+): ManagedResourceKey | null {
+    const kind = trimOrUndefined(parentRef.kind);
+    const name = trimOrUndefined(parentRef.name);
+    if (!kind || !name) {
+        return null;
+    }
+    const apiGroup = trimOrUndefined(parentRef.group);
+    return {
+        namespace: parentRef.namespace?.trim() ?? '',
+        kind,
+        name,
+        ...(apiGroup ? { apiGroup } : {})
+    };
+}
+
+function findCrdResourceStatus(
+    application: ArgoCDApplication,
+    resourceKey: ManagedResourceKey
+): ArgoCDResource | undefined {
+    return application.resources.find((row) => managedResourceKeysEqual(toManagedResourceKey(row), resourceKey));
+}
+
+function healthFromTreeNode(node: ArgoCDResourceTreeNode): HealthStatusCode | undefined {
+    const status = trimOrUndefined(node.health?.status);
+    if (!status) {
+        return undefined;
+    }
+    return toHealthStatusCode(status as HealthStatusCode);
+}
+
+function buildManagedResourceNodeFromTree(
+    node: ArgoCDResourceTreeNode,
+    application: ArgoCDApplication
+): ResourceGraphNode | null {
+    const resourceKey = treeNodeToManagedResourceKey(node);
+    if (!resourceKey) {
+        return null;
+    }
+
+    const crdRow = findCrdResourceStatus(application, resourceKey);
+    const status: ResourceGraphNode['status'] = {
+        syncStatus: crdRow ? toSyncStatusCode(crdRow.syncStatus) : 'Unknown',
+        healthStatus: crdRow
+            ? toHealthStatusCode(crdRow.healthStatus)
+            : healthFromTreeNode(node) ?? 'Unknown'
+    };
+    const message = crdRow?.message ?? trimOrUndefined(node.health?.message);
+    if (message) {
+        status.message = message;
+    }
+
+    return {
+        id: buildManagedResourceNodeId(resourceKey),
+        role: 'managed_resource',
+        resourceKey,
+        status,
+        label: resourceKey.name,
+        kindLabel: resourceKey.kind
+    };
+}
+
+function resolveParentNodeId(
+    parentRef: NonNullable<ArgoCDResourceTreeNode['parentRefs']>[number],
+    application: ArgoCDApplication,
+    nodeIdsByKey: Map<string, GraphNodeId>
+): GraphNodeId | null {
+    if (
+        trimOrUndefined(parentRef.kind) === 'Application' &&
+        trimOrUndefined(parentRef.name) === application.name
+    ) {
+        return buildApplicationRootNodeId(application.namespace, application.name);
+    }
+
+    const parentKey = parentRefToManagedResourceKey(parentRef);
+    if (!parentKey) {
+        return null;
+    }
+
+    return nodeIdsByKey.get(formatManagedResourceKey(parentKey)) ?? null;
+}
+
+export function buildResourceTreeApplicationResourceGraph(
+    input: BuildResourceTreeApplicationResourceGraphInput
+): CrdFlatGraphAssemblyResult {
+    const { application, applicationKey, resourceTree } = input;
+    const observedAt = input.observedAt ?? new Date().toISOString();
+    const assemblyWarnings: string[] = [];
+
+    const rootNode = buildApplicationRootNode(application);
+    const managedNodes: ResourceGraphNode[] = [];
+    const nodeIdsByKey = new Map<string, GraphNodeId>();
+    const seenNodeIds = new Set<GraphNodeId>();
+
+    for (const treeNode of resourceTree.nodes ?? []) {
+        if (isApplicationTreeNode(treeNode, application)) {
+            continue;
+        }
+
+        const managedNode = buildManagedResourceNodeFromTree(treeNode, application);
+        if (!managedNode || seenNodeIds.has(managedNode.id)) {
+            if (managedNode && seenNodeIds.has(managedNode.id)) {
+                assemblyWarnings.push(`Skipped duplicate resource-tree node: ${managedNode.id}`);
+            } else if (!managedNode) {
+                assemblyWarnings.push('Skipped resource-tree node: missing kind or name');
+            }
+            continue;
+        }
+
+        seenNodeIds.add(managedNode.id);
+        managedNodes.push(managedNode);
+        if (managedNode.resourceKey) {
+            nodeIdsByKey.set(formatManagedResourceKey(managedNode.resourceKey), managedNode.id);
+        }
+    }
+
+    const edges: ResourceGraphEdge[] = [];
+    const edgeIds = new Set<string>();
+
+    for (const treeNode of resourceTree.nodes ?? []) {
+        if (isApplicationTreeNode(treeNode, application)) {
+            continue;
+        }
+
+        const childKey = treeNodeToManagedResourceKey(treeNode);
+        if (!childKey) {
+            continue;
+        }
+        const childId = nodeIdsByKey.get(formatManagedResourceKey(childKey));
+        if (!childId) {
+            continue;
+        }
+
+        const parentRefs = treeNode.parentRefs ?? [];
+        if (parentRefs.length === 0) {
+            const edgeId = buildGraphEdgeId(rootNode.id, childId, 'manages');
+            if (!edgeIds.has(edgeId)) {
+                edgeIds.add(edgeId);
+                edges.push({
+                    id: edgeId,
+                    source: rootNode.id,
+                    target: childId,
+                    relationship: 'manages'
+                });
+            }
+            continue;
+        }
+
+        for (const parentRef of parentRefs) {
+            const parentId = resolveParentNodeId(parentRef, application, nodeIdsByKey);
+            if (!parentId) {
+                assemblyWarnings.push(
+                    `Skipped parent edge for ${childKey.kind}/${childKey.name}: parent not found in graph`
+                );
+                continue;
+            }
+
+            const relationship = parentId === rootNode.id ? 'manages' : 'owns';
+            const edgeId = buildGraphEdgeId(parentId, childId, relationship);
+            if (edgeIds.has(edgeId)) {
+                continue;
+            }
+            edgeIds.add(edgeId);
+            edges.push({
+                id: edgeId,
+                source: parentId,
+                target: childId,
+                relationship
+            });
+        }
+    }
+
+    const nodes = [rootNode, ...managedNodes];
+    const graph: ApplicationResourceGraph = truncateApplicationResourceGraph({
+        applicationKey,
+        nodes,
+        edges,
+        topologySource: RESOURCE_TREE_TOPOLOGY_SOURCE,
+        topologyMode: topologyModeFromSource(RESOURCE_TREE_TOPOLOGY_SOURCE),
+        structureVersion: computeStructureVersion({ nodes, edges }),
+        observedAt
+    });
+
+    return { graph, assemblyWarnings };
+}
+
 
 function trimOrEmpty(value: string | undefined): string {
     return value?.trim() ?? '';
@@ -142,8 +375,8 @@ export function buildCrdFlatApplicationResourceGraph(
         applicationKey,
         nodes,
         edges,
-        topologySource: TOPOLOGY_SOURCE,
-        topologyMode: topologyModeFromSource(TOPOLOGY_SOURCE),
+        topologySource: CRD_FLAT_TOPOLOGY_SOURCE,
+        topologyMode: topologyModeFromSource(CRD_FLAT_TOPOLOGY_SOURCE),
         structureVersion: computeStructureVersion({ nodes, edges }),
         observedAt
     });

--- a/src/services/ApplicationResourceGraphBuilder.ts
+++ b/src/services/ApplicationResourceGraphBuilder.ts
@@ -1,0 +1,82 @@
+import * as vscode from 'vscode';
+import type { ArgoCDApplication } from '../types/argocd';
+import type { ApplicationKey, ApplicationResourceGraph, TopologySource } from '../types/applicationResourceGraph';
+import {
+    buildCrdFlatApplicationResourceGraph,
+    buildResourceTreeApplicationResourceGraph
+} from './ApplicationResourceGraphAssembler';
+import { fetchApplicationResourceTree } from './ArgoCDRestClient';
+import { ArgoCDRestAuthResolver } from './ArgoCDRestAuthResolver';
+import type { ArgoCDService } from './ArgoCDService';
+
+export interface BuildApplicationResourceGraphInput {
+    application: ArgoCDApplication;
+    applicationKey: ApplicationKey;
+    argoCDService: ArgoCDService;
+    extensionContext: vscode.ExtensionContext;
+}
+
+export interface BuildApplicationResourceGraphResult {
+    graph: ApplicationResourceGraph;
+    topologySource: TopologySource;
+    assemblyWarnings: string[];
+}
+
+function getOutputChannel(): vscode.OutputChannel {
+    return vscode.window.createOutputChannel('kube9 ArgoCD Service');
+}
+
+export async function buildApplicationResourceGraph(
+    input: BuildApplicationResourceGraphInput
+): Promise<BuildApplicationResourceGraphResult> {
+    const observedAt = new Date().toISOString();
+    const authResolver = new ArgoCDRestAuthResolver(input.extensionContext, input.argoCDService);
+    const auth = await authResolver.resolve(input.applicationKey.context);
+
+    if (auth.available) {
+        try {
+            const resourceTree = await fetchApplicationResourceTree(
+                auth,
+                input.application.name,
+                input.application.namespace
+            );
+            const { graph, assemblyWarnings } = buildResourceTreeApplicationResourceGraph({
+                application: input.application,
+                applicationKey: input.applicationKey,
+                resourceTree,
+                observedAt
+            });
+
+            for (const warning of assemblyWarnings) {
+                getOutputChannel().appendLine(`[WARNING] resource-tree graph assembly: ${warning}`);
+            }
+
+            return {
+                graph,
+                topologySource: 'argocd_resource_tree',
+                assemblyWarnings
+            };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            getOutputChannel().appendLine(
+                `[INFO] Argo CD resource-tree enrichment unavailable; falling back to CRD-flat graph: ${message}`
+            );
+        }
+    } else if (auth.reason) {
+        getOutputChannel().appendLine(
+            `[INFO] Argo CD resource-tree enrichment skipped: ${auth.reason}`
+        );
+    }
+
+    const { graph, assemblyWarnings } = buildCrdFlatApplicationResourceGraph({
+        application: input.application,
+        applicationKey: input.applicationKey,
+        observedAt
+    });
+
+    return {
+        graph,
+        topologySource: 'crd_flat',
+        assemblyWarnings
+    };
+}

--- a/src/services/ArgoCDRestAuthResolver.ts
+++ b/src/services/ArgoCDRestAuthResolver.ts
@@ -1,0 +1,143 @@
+import * as vscode from 'vscode';
+import { ArgoCDService } from './ArgoCDService';
+import { PortForwardManager, PortForwardStatus } from './PortForwardManager';
+import {
+    readBooleanSetting,
+    readContextScopedSetting,
+    readNumberSetting
+} from './contextSettings';
+
+export type ArgoCDAccessMode = 'direct' | 'portForward';
+
+export interface ArgoCDRestAuthContext {
+    available: true;
+    baseUrl: string;
+    bearerToken: string;
+    tlsInsecure: boolean;
+}
+
+export interface ArgoCDRestAuthUnavailable {
+    available: false;
+    reason: string;
+}
+
+export type ArgoCDRestAuthResolution = ArgoCDRestAuthContext | ArgoCDRestAuthUnavailable;
+
+const ARGOCD_SERVER_SERVICE = 'argocd-server';
+const DEFAULT_PORT_FORWARD_LOCAL_PORT = 8443;
+const SECRET_KEY_PREFIX = 'kube9.argocd.bearerToken.';
+
+function normalizeBaseUrl(url: string): string {
+    return url.replace(/\/+$/, '');
+}
+
+function redactReason(message: string): string {
+    return message
+        .replace(/Bearer\s+\S+/gi, 'Bearer [redacted]')
+        .replace(/token[=:]\s*\S+/gi, 'token=[redacted]')
+        .replace(/kubeconfig[=:]\s*\S+/gi, 'kubeconfig=[redacted]');
+}
+
+export function bearerTokenSecretKey(context: string): string {
+    return `${SECRET_KEY_PREFIX}${context}`;
+}
+
+export class ArgoCDRestAuthResolver {
+    constructor(
+        private readonly extensionContext: vscode.ExtensionContext,
+        private readonly argoCDService: ArgoCDService,
+        private readonly portForwardManager: PortForwardManager = PortForwardManager.getInstance()
+    ) {}
+
+    async resolve(context: string): Promise<ArgoCDRestAuthResolution> {
+        const restEnabled = readBooleanSetting('kube9', 'argocd.restEnabled', false);
+        if (!restEnabled) {
+            return { available: false, reason: 'Argo CD REST enrichment is disabled' };
+        }
+
+        const bearerToken = await this.extensionContext.secrets.get(bearerTokenSecretKey(context));
+        if (!bearerToken || bearerToken.trim() === '') {
+            return { available: false, reason: 'Argo CD API bearer token is not configured for this context' };
+        }
+
+        const accessMode =
+            vscode.workspace.getConfiguration('kube9').get<'direct' | 'portForward'>('argocd.accessMode') ??
+            'direct';
+        const tlsInsecure = readBooleanSetting('kube9', 'argocd.tlsInsecure', false);
+
+        try {
+            if (accessMode === 'portForward') {
+                const baseUrl = await this.resolvePortForwardBaseUrl(context);
+                if (!baseUrl) {
+                    return {
+                        available: false,
+                        reason: 'Could not establish a port-forward to the Argo CD API server'
+                    };
+                }
+                return {
+                    available: true,
+                    baseUrl: normalizeBaseUrl(baseUrl),
+                    bearerToken: bearerToken.trim(),
+                    tlsInsecure
+                };
+            }
+
+            const serverUrl = readContextScopedSetting('kube9', 'argocd.serverUrl', context);
+            if (!serverUrl) {
+                return {
+                    available: false,
+                    reason: 'Argo CD server URL is not configured for this context'
+                };
+            }
+
+            return {
+                available: true,
+                baseUrl: normalizeBaseUrl(serverUrl),
+                bearerToken: bearerToken.trim(),
+                tlsInsecure
+            };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            return { available: false, reason: redactReason(message) };
+        }
+    }
+
+    private async resolvePortForwardBaseUrl(context: string): Promise<string | undefined> {
+        const installation = await this.argoCDService.isInstalled(context);
+        if (!installation.installed || !installation.namespace) {
+            return undefined;
+        }
+
+        const preferredLocalPort = readNumberSetting(
+            'kube9',
+            'argocd.portForwardLocalPort',
+            DEFAULT_PORT_FORWARD_LOCAL_PORT
+        );
+
+        const existing = this.portForwardManager
+            .getAllForwards()
+            .find(
+                (forward) =>
+                    forward.context === context &&
+                    forward.namespace === installation.namespace &&
+                    forward.resourceType === 'service' &&
+                    forward.resourceName === ARGOCD_SERVER_SERVICE &&
+                    forward.status === PortForwardStatus.Connected
+            );
+
+        if (existing) {
+            return `http://127.0.0.1:${existing.localPort}`;
+        }
+
+        const forward = await this.portForwardManager.startForward({
+            resourceType: 'service',
+            serviceName: ARGOCD_SERVER_SERVICE,
+            namespace: installation.namespace,
+            context,
+            localPort: preferredLocalPort,
+            remotePort: 443
+        });
+
+        return `http://127.0.0.1:${forward.localPort}`;
+    }
+}

--- a/src/services/ArgoCDRestClient.ts
+++ b/src/services/ArgoCDRestClient.ts
@@ -1,0 +1,115 @@
+import * as http from 'http';
+import * as https from 'https';
+import { URL } from 'url';
+import type { ArgoCDResourceTreeResponse } from '../types/argocdResourceTree';
+import type { ArgoCDRestAuthContext } from './ArgoCDRestAuthResolver';
+import { readNumberSetting } from './contextSettings';
+
+export class ArgoCDRestClientError extends Error {
+    constructor(
+        message: string,
+        readonly statusCode?: number
+    ) {
+        super(message);
+        this.name = 'ArgoCDRestClientError';
+    }
+}
+
+interface HttpResponse {
+    ok: boolean;
+    status: number;
+    statusText: string;
+    text(): Promise<string>;
+    json<T>(): Promise<T>;
+}
+
+function redactErrorMessage(message: string): string {
+    return message
+        .replace(/Bearer\s+\S+/gi, 'Bearer [redacted]')
+        .replace(/token[=:]\s*\S+/gi, 'token=[redacted]')
+        .replace(/kubeconfig[=:]\s*\S+/gi, 'kubeconfig=[redacted]');
+}
+
+function buildResourceTreeUrl(baseUrl: string, applicationName: string, applicationNamespace: string): string {
+    const url = new URL(
+        `/api/v1/applications/${encodeURIComponent(applicationName)}/resource-tree`,
+        `${baseUrl}/`
+    );
+    if (applicationNamespace.trim() !== '') {
+        url.searchParams.set('appNamespace', applicationNamespace);
+    }
+    return url.toString();
+}
+
+function requestJson(url: string, auth: ArgoCDRestAuthContext, timeoutMs: number): Promise<HttpResponse> {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const transport = parsed.protocol === 'https:' ? https : http;
+        const request = transport.request(
+            parsed,
+            {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${auth.bearerToken}`,
+                    Accept: 'application/json'
+                },
+                rejectUnauthorized: !auth.tlsInsecure
+            },
+            (response) => {
+                const chunks: Buffer[] = [];
+                response.on('data', (chunk: Buffer) => chunks.push(chunk));
+                response.on('end', () => {
+                    const body = Buffer.concat(chunks).toString('utf8');
+                    const status = response.statusCode ?? 0;
+                    resolve({
+                        ok: status >= 200 && status < 300,
+                        status,
+                        statusText: response.statusMessage ?? '',
+                        text: async () => body,
+                        json: async <T>() => JSON.parse(body) as T
+                    });
+                });
+            }
+        );
+
+        request.setTimeout(timeoutMs, () => {
+            request.destroy(new Error('Argo CD resource-tree request timed out'));
+        });
+        request.on('error', reject);
+        request.end();
+    });
+}
+
+export async function fetchApplicationResourceTree(
+    auth: ArgoCDRestAuthContext,
+    applicationName: string,
+    applicationNamespace: string
+): Promise<ArgoCDResourceTreeResponse> {
+    const timeoutMs = readNumberSetting('kube9', 'timeout.apiRequest', 30_000);
+    const url = buildResourceTreeUrl(auth.baseUrl, applicationName, applicationNamespace);
+
+    try {
+        const response = await requestJson(url, auth, timeoutMs);
+
+        if (!response.ok) {
+            const body = await response.text();
+            const detail = body.trim() === '' ? response.statusText : body;
+            throw new ArgoCDRestClientError(
+                redactErrorMessage(
+                    `Argo CD resource-tree request failed (${response.status}): ${detail}`
+                ),
+                response.status
+            );
+        }
+
+        return await response.json<ArgoCDResourceTreeResponse>();
+    } catch (error) {
+        if (error instanceof ArgoCDRestClientError) {
+            throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        throw new ArgoCDRestClientError(redactErrorMessage(message));
+    }
+}
+
+export { buildResourceTreeUrl };

--- a/src/services/contextSettings.ts
+++ b/src/services/contextSettings.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+
+/**
+ * Read a VS Code setting that may be a plain string or a per-context object map.
+ */
+export function readContextScopedSetting(
+    section: string,
+    key: string,
+    context: string
+): string | undefined {
+    const config = vscode.workspace.getConfiguration(section);
+    const value = config.get<string | Record<string, string>>(key);
+
+    if (value === undefined || value === null) {
+        return undefined;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed === '' ? undefined : trimmed;
+    }
+
+    if (typeof value === 'object') {
+        const scoped = value[context];
+        if (typeof scoped !== 'string') {
+            return undefined;
+        }
+        const trimmed = scoped.trim();
+        return trimmed === '' ? undefined : trimmed;
+    }
+
+    return undefined;
+}
+
+export function readBooleanSetting(section: string, key: string, defaultValue: boolean): boolean {
+    const config = vscode.workspace.getConfiguration(section);
+    const value = config.get<boolean>(key);
+    return value === undefined ? defaultValue : value;
+}
+
+export function readNumberSetting(section: string, key: string, defaultValue: number): number {
+    const config = vscode.workspace.getConfiguration(section);
+    const value = config.get<number>(key);
+    return typeof value === 'number' && Number.isFinite(value) ? value : defaultValue;
+}

--- a/src/test/suite/services/applicationResourceGraphAssembler.resourceTree.test.ts
+++ b/src/test/suite/services/applicationResourceGraphAssembler.resourceTree.test.ts
@@ -1,0 +1,181 @@
+import * as assert from 'assert';
+import type { ArgoCDApplication } from '../../../types/argocd';
+import {
+    buildApplicationRootNodeId,
+    buildGraphEdgeId,
+    buildManagedResourceNodeId,
+    type ApplicationKey
+} from '../../../types/applicationResourceGraph';
+import { buildResourceTreeApplicationResourceGraph } from '../../../services/ApplicationResourceGraphAssembler';
+
+function sampleApplication(): ArgoCDApplication {
+    return {
+        name: 'guestbook',
+        namespace: 'argocd',
+        project: 'default',
+        createdAt: '2026-05-27T00:00:00.000Z',
+        syncStatus: {
+            status: 'Synced',
+            revision: 'abc123',
+            comparedTo: { source: { repoURL: 'https://example.com/repo', path: '.', targetRevision: 'HEAD' } }
+        },
+        healthStatus: { status: 'Healthy' },
+        source: { repoURL: 'https://example.com/repo', path: '.', targetRevision: 'HEAD' },
+        destination: { server: 'https://kubernetes.default.svc', namespace: 'guestbook' },
+        resources: [
+            {
+                kind: 'Deployment',
+                name: 'guestbook-ui',
+                namespace: 'guestbook',
+                syncStatus: 'Synced',
+                healthStatus: 'Healthy'
+            },
+            {
+                kind: 'Service',
+                name: 'guestbook-ui',
+                namespace: 'guestbook',
+                syncStatus: 'Synced',
+                healthStatus: 'Healthy'
+            }
+        ]
+    };
+}
+
+function applicationKey(): ApplicationKey {
+    return { context: 'minikube', namespace: 'argocd', name: 'guestbook' };
+}
+
+suite('ApplicationResourceGraphAssembler resource-tree', () => {
+    test('maps parentRefs into owns edges and sets full topology metadata', () => {
+        const application = sampleApplication();
+        const rootId = buildApplicationRootNodeId(application.namespace, application.name);
+        const deploymentKey = { namespace: 'guestbook', kind: 'Deployment', name: 'guestbook-ui', apiGroup: 'apps' };
+        const deploymentId = buildManagedResourceNodeId(deploymentKey);
+        const serviceId = buildManagedResourceNodeId({ namespace: 'guestbook', kind: 'Service', name: 'guestbook-ui' });
+
+        const { graph } = buildResourceTreeApplicationResourceGraph({
+            application,
+            applicationKey: applicationKey(),
+            resourceTree: {
+                nodes: [
+                    {
+                        group: 'apps',
+                        kind: 'Deployment',
+                        namespace: 'guestbook',
+                        name: 'guestbook-ui',
+                        parentRefs: [
+                            {
+                                group: 'argoproj.io',
+                                kind: 'Application',
+                                name: 'guestbook',
+                                namespace: 'argocd'
+                            }
+                        ],
+                        health: { status: 'Healthy' }
+                    },
+                    {
+                        group: '',
+                        kind: 'Service',
+                        namespace: 'guestbook',
+                        name: 'guestbook-ui',
+                        parentRefs: [
+                            {
+                                group: 'apps',
+                                kind: 'Deployment',
+                                namespace: 'guestbook',
+                                name: 'guestbook-ui'
+                            }
+                        ],
+                        health: { status: 'Healthy' }
+                    }
+                ]
+            }
+        });
+
+        assert.strictEqual(graph.topologySource, 'argocd_resource_tree');
+        assert.strictEqual(graph.topologyMode, 'full');
+        assert.strictEqual(graph.nodes.length, 3);
+
+        const managesEdge = graph.edges.find(
+            (edge) => edge.source === rootId && edge.target === deploymentId && edge.relationship === 'manages'
+        );
+        assert.ok(managesEdge, 'expected Application root manages Deployment');
+
+        const ownsEdge = graph.edges.find(
+            (edge) =>
+                edge.source === deploymentId &&
+                edge.target === serviceId &&
+                edge.relationship === 'owns' &&
+                edge.id === buildGraphEdgeId(deploymentId, serviceId, 'owns')
+        );
+        assert.ok(ownsEdge, 'expected Deployment owns Service from parentRefs');
+    });
+
+    test('enriches node status from Application CRD resources when available', () => {
+        const application = sampleApplication();
+        application.resources[0].syncStatus = 'OutOfSync';
+        application.resources[0].healthStatus = 'Degraded';
+        application.resources[0].message = 'deployment out of sync';
+
+        const { graph } = buildResourceTreeApplicationResourceGraph({
+            application,
+            applicationKey: applicationKey(),
+            resourceTree: {
+                nodes: [
+                    {
+                        group: 'apps',
+                        kind: 'Deployment',
+                        namespace: 'guestbook',
+                        name: 'guestbook-ui',
+                        parentRefs: [],
+                        health: { status: 'Healthy' }
+                    }
+                ]
+            }
+        });
+
+        const deploymentNode = graph.nodes.find((node) => node.resourceKey?.kind === 'Deployment');
+        assert.ok(deploymentNode);
+        assert.strictEqual(deploymentNode.status.syncStatus, 'OutOfSync');
+        assert.strictEqual(deploymentNode.status.healthStatus, 'Degraded');
+        assert.strictEqual(deploymentNode.status.message, 'deployment out of sync');
+    });
+
+    test('skips duplicate Application node from resource-tree while preserving root identity', () => {
+        const application = sampleApplication();
+        const rootId = buildApplicationRootNodeId(application.namespace, application.name);
+
+        const { graph } = buildResourceTreeApplicationResourceGraph({
+            application,
+            applicationKey: applicationKey(),
+            resourceTree: {
+                nodes: [
+                    {
+                        group: 'argoproj.io',
+                        kind: 'Application',
+                        namespace: 'argocd',
+                        name: 'guestbook'
+                    },
+                    {
+                        group: 'apps',
+                        kind: 'Deployment',
+                        namespace: 'guestbook',
+                        name: 'guestbook-ui',
+                        parentRefs: [
+                            {
+                                kind: 'Application',
+                                name: 'guestbook',
+                                namespace: 'argocd',
+                                group: 'argoproj.io'
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        const applicationNodes = graph.nodes.filter((node) => node.role === 'application');
+        assert.strictEqual(applicationNodes.length, 1);
+        assert.strictEqual(applicationNodes[0].id, rootId);
+    });
+});

--- a/src/test/suite/services/applicationResourceGraphBuilder.test.ts
+++ b/src/test/suite/services/applicationResourceGraphBuilder.test.ts
@@ -1,0 +1,66 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import type { ArgoCDApplication } from '../../../types/argocd';
+import { buildApplicationResourceGraph } from '../../../services/ApplicationResourceGraphBuilder';
+import type { ArgoCDService } from '../../../services/ArgoCDService';
+
+const originalGetConfiguration = vscode.workspace.getConfiguration;
+
+function sampleApplication(): ArgoCDApplication {
+    return {
+        name: 'guestbook',
+        namespace: 'argocd',
+        project: 'default',
+        createdAt: '2026-05-27T00:00:00.000Z',
+        syncStatus: {
+            status: 'Synced',
+            revision: 'abc123',
+            comparedTo: { source: { repoURL: 'https://example.com/repo', path: '.', targetRevision: 'HEAD' } }
+        },
+        healthStatus: { status: 'Healthy' },
+        source: { repoURL: 'https://example.com/repo', path: '.', targetRevision: 'HEAD' },
+        destination: { server: 'https://kubernetes.default.svc', namespace: 'guestbook' },
+        resources: [
+            {
+                kind: 'Deployment',
+                name: 'guestbook-ui',
+                namespace: 'guestbook',
+                syncStatus: 'Synced',
+                healthStatus: 'Healthy'
+            }
+        ]
+    };
+}
+
+suite('ApplicationResourceGraphBuilder', () => {
+    teardown(() => {
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+    });
+
+    setup(() => {
+        vscode.workspace.getConfiguration = ((section?: string) => ({
+            get: <T>(key: string, defaultValue?: T): T | undefined => {
+                if (section !== 'kube9') {
+                    return defaultValue;
+                }
+                if (key === 'argocd.restEnabled') {
+                    return false as T;
+                }
+                return defaultValue;
+            }
+        })) as typeof vscode.workspace.getConfiguration;
+    });
+
+    test('falls back to crd_flat when REST enrichment is disabled', async () => {
+        const result = await buildApplicationResourceGraph({
+            application: sampleApplication(),
+            applicationKey: { context: 'minikube', namespace: 'argocd', name: 'guestbook' },
+            argoCDService: {} as ArgoCDService,
+            extensionContext: { secrets: { get: async () => undefined } } as unknown as vscode.ExtensionContext
+        });
+
+        assert.strictEqual(result.topologySource, 'crd_flat');
+        assert.strictEqual(result.graph.topologyMode, 'limited');
+        assert.strictEqual(result.graph.nodes.length, 2);
+    });
+});

--- a/src/test/suite/services/argocdRestAuthResolver.test.ts
+++ b/src/test/suite/services/argocdRestAuthResolver.test.ts
@@ -1,0 +1,120 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { ArgoCDRestAuthResolver, bearerTokenSecretKey } from '../../../services/ArgoCDRestAuthResolver';
+import { buildResourceTreeUrl } from '../../../services/ArgoCDRestClient';
+import type { ArgoCDService } from '../../../services/ArgoCDService';
+
+const originalGetConfiguration = vscode.workspace.getConfiguration;
+
+suite('ArgoCDRestAuthResolver', () => {
+    const contextName = 'minikube';
+
+    teardown(() => {
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+    });
+
+    setup(() => {
+        vscode.workspace.getConfiguration = ((section?: string) => ({
+            get: <T>(key: string, defaultValue?: T): T | undefined => {
+                if (section !== 'kube9') {
+                    return defaultValue;
+                }
+                const values: Record<string, unknown> = {
+                    'argocd.restEnabled': false,
+                    'argocd.accessMode': 'direct',
+                    'argocd.tlsInsecure': false,
+                    'argocd.portForwardLocalPort': 8443,
+                    'timeout.apiRequest': 30_000
+                };
+                return (values[key] ?? defaultValue) as T | undefined;
+            }
+        })) as typeof vscode.workspace.getConfiguration;
+    });
+
+    test('returns unavailable when REST enrichment is disabled', async () => {
+        const resolver = new ArgoCDRestAuthResolver(
+            { secrets: { get: async () => undefined } } as unknown as vscode.ExtensionContext,
+            {} as ArgoCDService
+        );
+
+        const result = await resolver.resolve(contextName);
+        assert.strictEqual(result.available, false);
+        if (!result.available) {
+            assert.match(result.reason, /disabled/i);
+        }
+    });
+
+    test('returns unavailable when bearer token is missing', async () => {
+        vscode.workspace.getConfiguration = ((section?: string) => ({
+            get: <T>(key: string, defaultValue?: T): T | undefined => {
+                if (section !== 'kube9') {
+                    return defaultValue;
+                }
+                if (key === 'argocd.restEnabled') {
+                    return true as T;
+                }
+                return defaultValue;
+            }
+        })) as typeof vscode.workspace.getConfiguration;
+
+        const resolver = new ArgoCDRestAuthResolver(
+            { secrets: { get: async () => undefined } } as unknown as vscode.ExtensionContext,
+            {} as ArgoCDService
+        );
+
+        const result = await resolver.resolve(contextName);
+        assert.strictEqual(result.available, false);
+        if (!result.available) {
+            assert.match(result.reason, /token/i);
+        }
+    });
+
+    test('resolves direct mode when URL and token are configured', async () => {
+        vscode.workspace.getConfiguration = ((section?: string) => ({
+            get: <T>(key: string, defaultValue?: T): T | undefined => {
+                if (section !== 'kube9') {
+                    return defaultValue;
+                }
+                const values: Record<string, unknown> = {
+                    'argocd.restEnabled': true,
+                    'argocd.accessMode': 'direct',
+                    'argocd.serverUrl': {
+                        [contextName]: 'https://argocd.example.com/'
+                    },
+                    'argocd.tlsInsecure': false
+                };
+                return (values[key] ?? defaultValue) as T | undefined;
+            }
+        })) as typeof vscode.workspace.getConfiguration;
+
+        const secrets = new Map<string, string>();
+        secrets.set(bearerTokenSecretKey(contextName), 'secret-token');
+
+        const resolver = new ArgoCDRestAuthResolver(
+            {
+                secrets: {
+                    get: async (key: string) => secrets.get(key)
+                }
+            } as unknown as vscode.ExtensionContext,
+            {} as ArgoCDService
+        );
+
+        const result = await resolver.resolve(contextName);
+        assert.strictEqual(result.available, true);
+        if (result.available) {
+            assert.strictEqual(result.baseUrl, 'https://argocd.example.com');
+            assert.strictEqual(result.bearerToken, 'secret-token');
+            assert.strictEqual(result.tlsInsecure, false);
+        }
+    });
+});
+
+suite('ArgoCDRestClient URL builder', () => {
+    test('includes appNamespace query parameter for namespaced applications', () => {
+        const url = buildResourceTreeUrl('https://argocd.example.com', 'guestbook', 'argocd');
+        assert.strictEqual(
+            url,
+            'https://argocd.example.com/api/v1/applications/guestbook/resource-tree?appNamespace=argocd'
+        );
+    });
+});

--- a/src/test/suite/webview/ArgoCDApplicationWebviewProvider.graph.test.ts
+++ b/src/test/suite/webview/ArgoCDApplicationWebviewProvider.graph.test.ts
@@ -111,7 +111,10 @@ suite('ArgoCDApplicationWebviewProvider resource graph', () => {
         mockExtensionContext = {
             subscriptions: [],
             extensionUri: vscode.Uri.file('/mock/extension/path'),
-            extensionPath: '/mock/extension/path'
+            extensionPath: '/mock/extension/path',
+            secrets: {
+                get: async () => undefined
+            }
         } as unknown as vscode.ExtensionContext;
 
         mockArgoCDService = {

--- a/src/types/argocdResourceTree.ts
+++ b/src/types/argocdResourceTree.ts
@@ -1,0 +1,35 @@
+/**
+ * Subset of Argo CD GET /api/v1/applications/{name}/resource-tree response.
+ * Live API shape may flatten resourceRef fields onto each node (see argoproj/argo-cd#14604).
+ */
+
+export interface ArgoCDResourceTreeParentRef {
+    group?: string;
+    kind?: string;
+    name?: string;
+    namespace?: string;
+    uid?: string;
+    version?: string;
+}
+
+export interface ArgoCDResourceTreeNodeHealth {
+    status?: string;
+    message?: string;
+}
+
+export interface ArgoCDResourceTreeNode {
+    group?: string;
+    kind?: string;
+    namespace?: string;
+    name?: string;
+    version?: string;
+    uid?: string;
+    parentRefs?: ArgoCDResourceTreeParentRef[];
+    health?: ArgoCDResourceTreeNodeHealth;
+}
+
+export interface ArgoCDResourceTreeResponse {
+    nodes?: ArgoCDResourceTreeNode[];
+    hosts?: unknown[];
+    orphanedNodes?: ArgoCDResourceTreeNode[];
+}

--- a/src/webview/ArgoCDApplicationWebviewProvider.ts
+++ b/src/webview/ArgoCDApplicationWebviewProvider.ts
@@ -3,6 +3,7 @@ import { ArgoCDService } from '../services/ArgoCDService';
 import { ClusterTreeProvider } from '../tree/ClusterTreeProvider';
 import { ArgoCDNotFoundError, ArgoCDPermissionError } from '../types/argocd';
 import type { ApplicationKey, ApplicationResourceGraph, TopologySource } from '../types/applicationResourceGraph';
+import { buildApplicationResourceGraph } from '../services/ApplicationResourceGraphBuilder';
 import { buildCrdFlatApplicationResourceGraph } from '../services/ApplicationResourceGraphAssembler';
 import { mergeApplicationResourceGraphSnapshots } from '../services/ApplicationResourceGraphMerger';
 import { KubectlError, KubectlErrorType } from '../kubernetes/KubectlError';
@@ -30,6 +31,8 @@ interface PanelInfo {
     namespace: string;
     /** Kubernetes context */
     context: string;
+    /** Extension context for host-only services (REST auth, secrets) */
+    extensionContext: vscode.ExtensionContext;
     /** Previous graph snapshot for merge-on-refresh */
     lastGraph?: ApplicationResourceGraph;
     /** Cancels in-flight operation polling for this panel */
@@ -110,7 +113,8 @@ export class ArgoCDApplicationWebviewProvider {
             panel,
             applicationName,
             namespace,
-            context
+            context,
+            extensionContext
         });
 
         // Set the webview's HTML content
@@ -535,6 +539,7 @@ export class ArgoCDApplicationWebviewProvider {
     ): Promise<void> {
         const panelKey = ArgoCDApplicationWebviewProvider.panelKey(context, namespace, applicationName);
         const panelInfo = ArgoCDApplicationWebviewProvider.openPanels.get(panelKey);
+        const extensionContext = panelInfo?.extensionContext;
 
         try {
             if (options?.bypassCache) {
@@ -550,10 +555,27 @@ export class ArgoCDApplicationWebviewProvider {
                 namespace,
                 applicationName
             );
-            const { graph: incoming } = buildCrdFlatApplicationResourceGraph({
-                application,
-                applicationKey
-            });
+
+            let incoming;
+            let topologySource: TopologySource;
+
+            if (extensionContext) {
+                const built = await buildApplicationResourceGraph({
+                    application,
+                    applicationKey,
+                    argoCDService,
+                    extensionContext
+                });
+                incoming = built.graph;
+                topologySource = built.topologySource;
+            } else {
+                const built = buildCrdFlatApplicationResourceGraph({
+                    application,
+                    applicationKey
+                });
+                incoming = built.graph;
+                topologySource = 'crd_flat';
+            }
 
             const { graph } = mergeApplicationResourceGraphSnapshots(panelInfo?.lastGraph, incoming);
 
@@ -562,7 +584,7 @@ export class ArgoCDApplicationWebviewProvider {
             }
 
             ArgoCDApplicationWebviewProvider.postResourceGraph(panel, graph, {
-                topologySource: 'crd_flat',
+                topologySource,
                 refreshedAt: new Date().toISOString(),
                 truncated: graph.truncated
             });


### PR DESCRIPTION
## Summary

- Adds extension-host REST path for `GET /api/v1/applications/{name}/resource-tree` with credentials resolved via `ArgoCDRestAuthResolver` (settings + SecretStorage, never sent to webviews).
- Maps Argo CD `nodes[]` and `parentRefs` into `ApplicationResourceGraph` with `topologySource: argocd_resource_tree` and `topologyMode: full`, preserving Application root identity and CRD sync/health enrichment.
- Falls back to existing `crd_flat` graph when REST is disabled, misconfigured, or errors (401/403, TLS, timeout).

## Related issues

- Closes #166
- Includes minimal REST settings surface needed for Tier B; full auth UX commands/docs remain in #168

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:unit` (1165 passing)
- [ ] Manual: enable `kube9.argocd.restEnabled`, configure server URL + token, open Application graph and confirm `topologySource: argocd_resource_tree`
- [ ] Manual: break REST access and confirm CRD-flat fallback with usable panel