### PR TITLE
feat(argocd): REST API auth path (token, base URL, port-forward) (#168)

### DIFF
--- a/docs/argocd-integration.md
+++ b/docs/argocd-integration.md
@@ -211,6 +211,62 @@ Right-click any application in the tree view or use buttons in the webview to:
 **Copy Name / Copy Namespace**
 - Quick clipboard actions for application metadata
 
+## REST API enrichment (resource graph)
+
+By default, the application **resource graph** uses Kubernetes Application CRD data only (`topologySource: crd_flat`). Optional **Tier B** enrichment calls the Argo CD REST API (`GET /api/v1/applications/{name}/resource-tree`) for native parent/child topology when you enable REST access separately from CRD RBAC.
+
+### Kubernetes RBAC vs Argo CD API RBAC
+
+These are **independent** trust boundaries:
+
+| Concern | Identity | Typical permissions |
+|---------|----------|---------------------|
+| **Application CRD** (baseline) | kubeconfig user | `applications` get, list, patch on `argoproj.io` |
+| **Resource graph (CRD-flat)** | kubeconfig user | Same as Application CRD |
+| **Resource graph (owner-ref fallback)** | kubeconfig user | Additional get/list on managed workload kinds in destination namespaces |
+| **Resource graph (REST resource-tree)** | Argo CD API bearer token | Argo CD project/RBAC allowing application get and resource-tree for the app |
+
+Your kubeconfig can read Application CRDs while REST enrichment still fails with 401/403 if the Argo CD token or URL is wrong. The extension logs host-side, skips Tier B, and keeps the Application panel usable on CRD data.
+
+### Enable REST enrichment
+
+1. Open VS Code settings and set **`kube9.argocd.restEnabled`** to `true` for the workspace or user scope.
+2. Choose an access mode with **`kube9.argocd.accessMode`**:
+   - **`direct`** — set **`kube9.argocd.serverUrl`** to the HTTPS API base (ingress URL or in-cluster URL reachable from your workstation). Use a string for all contexts or an object keyed by kubeconfig context name (same pattern as `kube9.operatorNamespace`).
+   - **`portForward`** — Kube9 starts or reuses a host-managed `kubectl port-forward` to the detected **`argocd-server`** Service. The API base becomes `http://127.0.0.1:{localPort}`. Optional **`kube9.argocd.portForwardLocalPort`** sets the preferred local bind port (default `8443`).
+3. Run **Kube9: Set Argo CD API Token** from the Command Palette for the active kubectl context. Tokens are stored in VS Code **SecretStorage** only (`kube9.argocd.bearerToken.{context}`), never in `settings.json` or webview payloads.
+4. Run **Kube9: Test Argo CD API Connection** to verify reachability. Success and failure messages are redacted (no token values, kubeconfig paths, or raw Authorization headers).
+5. Open an Application graph. When REST is disabled or misconfigured, topology stays on CRD tiers only.
+
+### Token creation
+
+Create an Argo CD API token with permissions to list applications and read resource-tree for your target apps. Common approaches:
+
+- Argo CD UI: **User Info → Generate New Token** (admin or project-scoped user)
+- CLI: `argocd account generate-token` (when you already have CLI access)
+
+Store the token with **Kube9: Set Argo CD API Token**. Use **Kube9: Clear Argo CD API Token** to remove it from SecretStorage for the active context.
+
+### TLS settings
+
+**`kube9.argocd.tlsInsecure`** skips TLS certificate verification for HTTPS API bases. Default is `false`. Use only for local labs or trusted port-forward setups. Do not enable for production ingress URLs.
+
+### Settings reference
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `kube9.argocd.restEnabled` | `false` | Opt-in gate for Tier B REST calls |
+| `kube9.argocd.serverUrl` | unset | Direct API base URL (string or per-context object) |
+| `kube9.argocd.accessMode` | `direct` | `direct` or `portForward` |
+| `kube9.argocd.tlsInsecure` | `false` | Skip TLS verification (non-production) |
+| `kube9.argocd.portForwardLocalPort` | `8443` | Preferred local port for port-forward mode |
+
+Commands (Command Palette → **Kube9**):
+
+- **Set Argo CD API Token**
+- **Clear Argo CD API Token**
+- **Test Argo CD API Connection**
+
 ## Usage Guide
 
 ### Viewing Applications

--- a/package.json
+++ b/package.json
@@ -181,6 +181,21 @@
         "category": "Kube9"
       },
       {
+        "command": "kube9.argocd.setApiToken",
+        "title": "Set Argo CD API Token",
+        "category": "Kube9"
+      },
+      {
+        "command": "kube9.argocd.clearApiToken",
+        "title": "Clear Argo CD API Token",
+        "category": "Kube9"
+      },
+      {
+        "command": "kube9.argocd.testApiConnection",
+        "title": "Test Argo CD API Connection",
+        "category": "Kube9"
+      },
+      {
         "command": "kube9.showCacheStats",
         "title": "Show Cache Statistics",
         "category": "Kube9"

--- a/src/commands/ArgoCDRestAuthCommands.ts
+++ b/src/commands/ArgoCDRestAuthCommands.ts
@@ -1,0 +1,128 @@
+import * as vscode from 'vscode';
+import { getExtensionContext, getClusterTreeProvider } from '../extension';
+import { ArgoCDRestAuthResolver, bearerTokenSecretKey } from '../services/ArgoCDRestAuthResolver';
+import { ArgoCDRestClientError, testArgoCDRestConnection } from '../services/ArgoCDRestClient';
+import { ArgoCDService } from '../services/ArgoCDService';
+import { OperatorStatusClient } from '../services/OperatorStatusClient';
+import { getContextInfo } from '../utils/kubectlContext';
+
+function getArgoCDService(): ArgoCDService | undefined {
+    const treeProvider = getClusterTreeProvider();
+    const kubeconfigPath = treeProvider.getKubeconfigPath();
+
+    if (!kubeconfigPath) {
+        return undefined;
+    }
+
+    const operatorStatusClient = new OperatorStatusClient();
+    return new ArgoCDService(operatorStatusClient, kubeconfigPath);
+}
+
+async function getActiveContextName(): Promise<string> {
+    const contextInfo = await getContextInfo();
+    return contextInfo.contextName;
+}
+
+export async function setArgoCDApiTokenCommand(): Promise<void> {
+    try {
+        const contextName = await getActiveContextName();
+        const token = await vscode.window.showInputBox({
+            title: 'Set Argo CD API Token',
+            prompt: `Enter a bearer token for kubectl context "${contextName}"`,
+            password: true,
+            ignoreFocusOut: true,
+            validateInput: (value) => (value.trim() === '' ? 'Token cannot be empty' : undefined)
+        });
+
+        if (token === undefined) {
+            return;
+        }
+
+        await getExtensionContext().secrets.store(bearerTokenSecretKey(contextName), token.trim());
+        vscode.window.showInformationMessage(
+            `Argo CD API token saved for context "${contextName}".`
+        );
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error('Failed to set Argo CD API token:', message);
+        vscode.window.showErrorMessage(`Failed to set Argo CD API token: ${message}`);
+    }
+}
+
+export async function clearArgoCDApiTokenCommand(): Promise<void> {
+    try {
+        const contextName = await getActiveContextName();
+        const secretKey = bearerTokenSecretKey(contextName);
+        const existing = await getExtensionContext().secrets.get(secretKey);
+
+        if (!existing) {
+            vscode.window.showInformationMessage(
+                `No Argo CD API token is configured for context "${contextName}".`
+            );
+            return;
+        }
+
+        const confirmation = await vscode.window.showWarningMessage(
+            `Clear the Argo CD API token for context "${contextName}"?`,
+            { modal: true },
+            'Clear',
+            'Cancel'
+        );
+
+        if (confirmation !== 'Clear') {
+            return;
+        }
+
+        await getExtensionContext().secrets.delete(secretKey);
+        vscode.window.showInformationMessage(
+            `Argo CD API token cleared for context "${contextName}".`
+        );
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error('Failed to clear Argo CD API token:', message);
+        vscode.window.showErrorMessage(`Failed to clear Argo CD API token: ${message}`);
+    }
+}
+
+export async function testArgoCDApiConnectionCommand(): Promise<void> {
+    try {
+        const contextName = await getActiveContextName();
+        const argoCDService = getArgoCDService();
+        if (!argoCDService) {
+            vscode.window.showErrorMessage('Unable to test connection: Kubeconfig not available');
+            return;
+        }
+
+        const authResolver = new ArgoCDRestAuthResolver(getExtensionContext(), argoCDService);
+        const auth = await authResolver.resolve(contextName);
+
+        if (!auth.available) {
+            vscode.window.showErrorMessage(
+                auth.reason || 'Argo CD REST credentials are not configured for this context'
+            );
+            return;
+        }
+
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: 'Testing Argo CD API connection...',
+                cancellable: false
+            },
+            async () => {
+                await testArgoCDRestConnection(auth);
+            }
+        );
+
+        vscode.window.showInformationMessage(
+            `Argo CD API connection succeeded for context "${contextName}".`
+        );
+    } catch (error) {
+        const message =
+            error instanceof ArgoCDRestClientError || error instanceof Error
+                ? error.message
+                : String(error);
+        console.error('Argo CD API connection test failed:', message);
+        vscode.window.showErrorMessage(`Argo CD API connection test failed: ${message}`);
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,6 +46,11 @@ import {
     copyNameCommand,
     copyNamespaceCommand
 } from './commands/ArgoCDCommands';
+import {
+    setArgoCDApiTokenCommand,
+    clearArgoCDApiTokenCommand,
+    testArgoCDApiConnectionCommand
+} from './commands/ArgoCDRestAuthCommands';
 import { showCacheStatsCommand } from './commands/cacheStats';
 import { EventsCommands } from './commands/EventsCommands';
 import { EventViewerPanel } from './webview/EventViewerPanel';
@@ -1442,6 +1447,27 @@ function registerCommands(): void {
     );
     context.subscriptions.push(copyNamespaceCmd);
     disposables.push(copyNamespaceCmd);
+
+    const setArgoCDApiTokenCmd = registerInstrumentedKube9Command(
+        'kube9.argocd.setApiToken',
+        setArgoCDApiTokenCommand
+    );
+    context.subscriptions.push(setArgoCDApiTokenCmd);
+    disposables.push(setArgoCDApiTokenCmd);
+
+    const clearArgoCDApiTokenCmd = registerInstrumentedKube9Command(
+        'kube9.argocd.clearApiToken',
+        clearArgoCDApiTokenCommand
+    );
+    context.subscriptions.push(clearArgoCDApiTokenCmd);
+    disposables.push(clearArgoCDApiTokenCmd);
+
+    const testArgoCDApiConnectionCmd = registerInstrumentedKube9Command(
+        'kube9.argocd.testApiConnection',
+        testArgoCDApiConnectionCommand
+    );
+    context.subscriptions.push(testArgoCDApiConnectionCmd);
+    disposables.push(testArgoCDApiConnectionCmd);
     
     // Register cache statistics command
     const showCacheStatsCmd = registerInstrumentedKube9Command(

--- a/src/services/ArgoCDRestClient.ts
+++ b/src/services/ArgoCDRestClient.ts
@@ -80,6 +80,33 @@ function requestJson(url: string, auth: ArgoCDRestAuthContext, timeoutMs: number
     });
 }
 
+export async function testArgoCDRestConnection(auth: ArgoCDRestAuthContext): Promise<void> {
+    const timeoutMs = readNumberSetting('kube9', 'timeout.apiRequest', 30_000);
+    const url = new URL('/api/v1/applications', `${auth.baseUrl}/`);
+    url.searchParams.set('limit', '1');
+
+    try {
+        const response = await requestJson(url.toString(), auth, timeoutMs);
+
+        if (!response.ok) {
+            const body = await response.text();
+            const detail = body.trim() === '' ? response.statusText : body;
+            throw new ArgoCDRestClientError(
+                redactErrorMessage(
+                    `Argo CD API connection test failed (${response.status}): ${detail}`
+                ),
+                response.status
+            );
+        }
+    } catch (error) {
+        if (error instanceof ArgoCDRestClientError) {
+            throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        throw new ArgoCDRestClientError(redactErrorMessage(message));
+    }
+}
+
 export async function fetchApplicationResourceTree(
     auth: ArgoCDRestAuthContext,
     applicationName: string,

--- a/src/test/suite/services/argocdRestAuthResolver.test.ts
+++ b/src/test/suite/services/argocdRestAuthResolver.test.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { ArgoCDRestAuthResolver, bearerTokenSecretKey } from '../../../services/ArgoCDRestAuthResolver';
 import { buildResourceTreeUrl } from '../../../services/ArgoCDRestClient';
 import type { ArgoCDService } from '../../../services/ArgoCDService';
+import { PortForwardStatus } from '../../../services/PortForwardManager';
 
 const originalGetConfiguration = vscode.workspace.getConfiguration;
 
@@ -105,6 +106,139 @@ suite('ArgoCDRestAuthResolver', () => {
             assert.strictEqual(result.baseUrl, 'https://argocd.example.com');
             assert.strictEqual(result.bearerToken, 'secret-token');
             assert.strictEqual(result.tlsInsecure, false);
+        }
+    });
+
+    test('returns unavailable when direct mode lacks server URL', async () => {
+        vscode.workspace.getConfiguration = ((section?: string) => ({
+            get: <T>(key: string, defaultValue?: T): T | undefined => {
+                if (section !== 'kube9') {
+                    return defaultValue;
+                }
+                const values: Record<string, unknown> = {
+                    'argocd.restEnabled': true,
+                    'argocd.accessMode': 'direct',
+                    'argocd.tlsInsecure': false
+                };
+                return (values[key] ?? defaultValue) as T | undefined;
+            }
+        })) as typeof vscode.workspace.getConfiguration;
+
+        const secrets = new Map<string, string>();
+        secrets.set(bearerTokenSecretKey(contextName), 'secret-token');
+
+        const resolver = new ArgoCDRestAuthResolver(
+            {
+                secrets: {
+                    get: async (key: string) => secrets.get(key)
+                }
+            } as unknown as vscode.ExtensionContext,
+            {} as ArgoCDService
+        );
+
+        const result = await resolver.resolve(contextName);
+        assert.strictEqual(result.available, false);
+        if (!result.available) {
+            assert.match(result.reason, /server url/i);
+        }
+    });
+
+    test('resolves port-forward mode base URL from connected forward', async () => {
+        vscode.workspace.getConfiguration = ((section?: string) => ({
+            get: <T>(key: string, defaultValue?: T): T | undefined => {
+                if (section !== 'kube9') {
+                    return defaultValue;
+                }
+                const values: Record<string, unknown> = {
+                    'argocd.restEnabled': true,
+                    'argocd.accessMode': 'portForward',
+                    'argocd.tlsInsecure': false,
+                    'argocd.portForwardLocalPort': 8443
+                };
+                return (values[key] ?? defaultValue) as T | undefined;
+            }
+        })) as typeof vscode.workspace.getConfiguration;
+
+        const secrets = new Map<string, string>();
+        secrets.set(bearerTokenSecretKey(contextName), 'secret-token');
+
+        const argoCDService = {
+            isInstalled: async () => ({ installed: true, namespace: 'argocd' })
+        } as unknown as ArgoCDService;
+
+        const portForwardManager = {
+            getAllForwards: () => [
+                {
+                    context: contextName,
+                    namespace: 'argocd',
+                    resourceType: 'service' as const,
+                    resourceName: 'argocd-server',
+                    status: PortForwardStatus.Connected,
+                    localPort: 9443
+                }
+            ],
+            startForward: async () => {
+                throw new Error('startForward should not be called when a connected forward exists');
+            }
+        };
+
+        const resolver = new ArgoCDRestAuthResolver(
+            {
+                secrets: {
+                    get: async (key: string) => secrets.get(key)
+                }
+            } as unknown as vscode.ExtensionContext,
+            argoCDService,
+            portForwardManager as never
+        );
+
+        const result = await resolver.resolve(contextName);
+        assert.strictEqual(result.available, true);
+        if (result.available) {
+            assert.strictEqual(result.baseUrl, 'http://127.0.0.1:9443');
+        }
+    });
+
+    test('redacts sensitive details from resolver errors', async () => {
+        vscode.workspace.getConfiguration = ((section?: string) => ({
+            get: <T>(key: string, defaultValue?: T): T | undefined => {
+                if (section !== 'kube9') {
+                    return defaultValue;
+                }
+                const values: Record<string, unknown> = {
+                    'argocd.restEnabled': true,
+                    'argocd.accessMode': 'portForward',
+                    'argocd.tlsInsecure': false,
+                    'argocd.portForwardLocalPort': 8443
+                };
+                return (values[key] ?? defaultValue) as T | undefined;
+            }
+        })) as typeof vscode.workspace.getConfiguration;
+
+        const secrets = new Map<string, string>();
+        secrets.set(bearerTokenSecretKey(contextName), 'secret-token');
+
+        const argoCDService = {
+            isInstalled: async () => {
+                throw new Error('Bearer super-secret-token kubeconfig=/home/user/.kube/config');
+            }
+        } as unknown as ArgoCDService;
+
+        const resolver = new ArgoCDRestAuthResolver(
+            {
+                secrets: {
+                    get: async (key: string) => secrets.get(key)
+                }
+            } as unknown as vscode.ExtensionContext,
+            argoCDService
+        );
+
+        const result = await resolver.resolve(contextName);
+        assert.strictEqual(result.available, false);
+        if (!result.available) {
+            assert.ok(!result.reason.includes('super-secret-token'));
+            assert.ok(!result.reason.includes('/home/user/.kube/config'));
+            assert.match(result.reason, /Bearer \[redacted\]/i);
         }
     });
 });


### PR DESCRIPTION
## Summary

- Adds Command Palette commands to set, clear, and test Argo CD REST API credentials per kubeconfig context (SecretStorage-backed bearer token).
- Adds `testArgoCDRestConnection` to verify reachability via `GET /api/v1/applications?limit=1` with redacted errors.
- Documents REST enrichment setup in `docs/argocd-integration.md` (Kubernetes vs Argo CD RBAC, direct vs port-forward, TLS warning).
- Expands `ArgoCDRestAuthResolver` unit tests for missing URL, port-forward base URL, and redacted failure messages.

Builds on existing `ArgoCDRestAuthResolver`, settings (`kube9.argocd.*`), and Tier B integration from #166.

Closes #168

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:unit` (1176 passing)
- [ ] Manual: enable `kube9.argocd.restEnabled`, set token via **Kube9: Set Argo CD API Token**, run **Test Argo CD API Connection**
- [ ] Manual: verify token is not present in `settings.json` or webview payloads
- [ ] Manual: `accessMode: portForward` resolves localhost base URL when `argocd-server` forward is active