### PR TITLE
feat(describe): legacy workload shared header shell

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -165,6 +165,10 @@ export function getYAMLEditorManager(): YAMLEditorManager {
  * @returns The help controller
  * @throws Error if help controller has not been initialized
  */
+export function isHelpControllerReady(): boolean {
+    return helpController !== undefined;
+}
+
 export function getHelpController(): HelpController {
     if (!helpController) {
         throw new Error('HelpController not initialized');

--- a/src/test/suite/webview/legacyDescribeHeaderShell.test.ts
+++ b/src/test/suite/webview/legacyDescribeHeaderShell.test.ts
@@ -1,0 +1,72 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import {
+    buildLegacyDescribeDocumentShell,
+    buildLegacyDescribeHeadAssets,
+    buildLegacyHeaderActionScript,
+    buildLegacyHeaderFragment,
+    LEGACY_DESCRIBE_HELP_CONTEXT
+} from '../../../webview/legacyDescribeHeaderShell';
+
+suite('legacyDescribeHeaderShell @unit', () => {
+    const extensionUri = vscode.Uri.file('/tmp/kube9-extension');
+
+    test('buildLegacyHeaderFragment uses shared webview-header classes and codicons', () => {
+        const html = buildLegacyHeaderFragment({
+            titleInnerHtml: 'Deployment / <span id="deployment-name">app</span>'
+        });
+
+        assert.ok(html.includes('class="webview-header"'));
+        assert.ok(html.includes('codicon-refresh'));
+        assert.ok(html.includes('codicon-file-code'));
+        assert.ok(html.includes('codicon-question'));
+        assert.ok(html.includes('id="refresh-btn"'));
+        assert.ok(html.includes('id="view-yaml-btn"'));
+        assert.ok(html.includes('id="help-btn"'));
+    });
+
+    test('buildLegacyHeaderActionScript posts legacy openHelp command', () => {
+        const script = buildLegacyHeaderActionScript({
+            helpContext: LEGACY_DESCRIBE_HELP_CONTEXT,
+            showRefresh: false
+        });
+
+        assert.ok(script.includes("command: 'viewYaml'"));
+        assert.ok(script.includes("command: 'openHelp', context: \"describe-webview\""));
+        assert.ok(!script.includes("command: 'refresh'"));
+    });
+
+    test('buildLegacyDescribeDocumentShell links shipped header and codicon CSS', () => {
+        const webview = {
+            cspSource: 'vscode-webview://authority',
+            asWebviewUri: (uri: vscode.Uri) => uri
+        } as vscode.Webview;
+
+        const html = buildLegacyDescribeDocumentShell({
+            webview,
+            extensionUri,
+            pageTitle: 'Test',
+            bodyHtml: '<div class="container">body</div>',
+            panelCss: '.container { padding: 0; }',
+            script: '/* noop */',
+            wrapScript: false
+        });
+
+        assert.ok(html.includes('webview-header.css'));
+        assert.ok(html.includes('codicon.css'));
+        assert.ok(!html.includes('src/webview/styles/webview-header.css'));
+        assert.ok(html.includes('font-src vscode-webview://authority'));
+    });
+
+    test('buildLegacyDescribeHeadAssets matches document shell CSP profile', () => {
+        const webview = {
+            cspSource: 'vscode-webview://authority',
+            asWebviewUri: (uri: vscode.Uri) => uri
+        } as vscode.Webview;
+
+        const { csp, headerLink, codiconsLink } = buildLegacyDescribeHeadAssets(webview, extensionUri);
+        assert.ok(csp.includes("style-src vscode-webview://authority 'unsafe-inline'"));
+        assert.ok(headerLink.includes('webview-header.css'));
+        assert.ok(codiconsLink.includes('codicon.css'));
+    });
+});

--- a/src/webview/CronJobDescribeWebview.ts
+++ b/src/webview/CronJobDescribeWebview.ts
@@ -5,13 +5,20 @@ import { CronJobDescribeData } from '../providers/CronJobDescribeProvider';
 import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
 import { DescribeWebview } from './DescribeWebview';
 import { releaseExclusiveDescribePanelBindings } from './describeSharedPanelBindings';
+import {
+    buildLegacyDescribeHeadAssets,
+    buildLegacyHeaderActionScript,
+    buildLegacyHeaderFragment,
+    getLegacyDescribeWebviewPanelOptions,
+    setupLegacyDescribeHelpHandler
+} from './legacyDescribeHeaderShell';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 
 /**
  * Message sent from webview to extension.
  */
 interface WebviewMessage {
-    command: 'refresh' | 'navigateToJob' | 'copyValue';
+    command: 'refresh' | 'navigateToJob' | 'copyValue' | 'viewYaml';
     jobName?: string;
     name?: string;
     namespace?: string;
@@ -138,10 +145,7 @@ export class CronJobDescribeWebview {
             'kube9Describe',  // Use the shared panel ID
             title,
             vscode.ViewColumn.One,
-            {
-                enableScripts: true,
-                retainContextWhenHidden: true
-            }
+            getLegacyDescribeWebviewPanelOptions(context.extensionUri)
         );
 
         CronJobDescribeWebview.currentPanel = panel;
@@ -162,6 +166,7 @@ export class CronJobDescribeWebview {
     private static attachPanelBindings(panel: vscode.WebviewPanel): void {
         CronJobDescribeWebview.releaseMessageBindings();
         CronJobDescribeWebview.setupMessageHandlers(panel);
+        setupLegacyDescribeHelpHandler(panel.webview);
 
         CronJobDescribeWebview.panelDisposeSubscription = panel.onDidDispose(() => {
             if (CronJobDescribeWebview.currentPanel === panel) {
@@ -330,6 +335,31 @@ export class CronJobDescribeWebview {
                         }
                         break;
                     }
+
+                    case 'viewYaml': {
+                        const cronjobName = CronJobDescribeWebview.currentCronJobName;
+                        const namespace = CronJobDescribeWebview.currentNamespace;
+                        const cluster = CronJobDescribeWebview.contextName;
+                        if (!cronjobName || !namespace || !cluster) {
+                            vscode.window.showErrorMessage('CronJob context not available');
+                            break;
+                        }
+                        try {
+                            const { getYAMLEditorManager } = await import('../extension');
+                            const yamlEditorManager = getYAMLEditorManager();
+                            await yamlEditorManager.openYAMLEditor({
+                                kind: 'CronJob',
+                                name: cronjobName,
+                                namespace,
+                                apiVersion: 'batch/v1',
+                                cluster
+                            });
+                        } catch (error) {
+                            const errorMessage = error instanceof Error ? error.message : String(error);
+                            vscode.window.showErrorMessage(`Failed to open YAML: ${errorMessage}`);
+                        }
+                        break;
+                    }
                     
                     default: {
                         console.log('Unknown message command:', message.command);
@@ -349,76 +379,33 @@ export class CronJobDescribeWebview {
     private static getWebviewContent(
         webview: vscode.Webview
     ): string {
-        const cspSource = webview.cspSource;
+        const extensionUri = CronJobDescribeWebview.extensionContext?.extensionUri;
+        if (!extensionUri) {
+            throw new Error('CronJob describe requires extension context');
+        }
+        const { headerLink, codiconsLink, csp } = buildLegacyDescribeHeadAssets(webview, extensionUri);
+        const headerFragment = buildLegacyHeaderFragment({
+            titleInnerHtml: 'CronJob / <span class="cronjob-name" id="cronjob-name">Loading...</span>'
+        });
 
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src ${cspSource} 'unsafe-inline';">
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
+    ${headerLink}
+    ${codiconsLink}
     <title>CronJob Describe</title>
     <style>
-        body {
-            font-family: var(--vscode-font-family);
-            font-size: var(--vscode-font-size);
-            color: var(--vscode-foreground);
-            background-color: var(--vscode-editor-background);
-            padding: 0;
-            margin: 0;
-        }
-
         .container {
             max-width: 1400px;
             margin: 0 auto;
             padding: 20px;
         }
 
-        .cronjob-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            border-bottom: 1px solid var(--vscode-panel-border);
-            padding-bottom: 15px;
-            margin-bottom: 20px;
-        }
-
-        .cronjob-title {
-            margin: 0;
-            font-size: 24px;
-            font-weight: 600;
-            color: var(--vscode-foreground);
-        }
-
         .cronjob-name {
             color: var(--vscode-textLink-foreground);
-        }
-
-        .header-actions {
-            display: flex;
-            gap: 10px;
-        }
-
-        .action-btn {
-            display: flex;
-            align-items: center;
-            gap: 6px;
-            padding: 6px 12px;
-            background-color: var(--vscode-button-background);
-            color: var(--vscode-button-foreground);
-            border: none;
-            border-radius: 2px;
-            cursor: pointer;
-            font-size: var(--vscode-font-size);
-            font-family: var(--vscode-font-family);
-        }
-
-        .action-btn:hover {
-            background-color: var(--vscode-button-hoverBackground);
-        }
-
-        .btn-icon {
-            font-size: 14px;
         }
 
         .status-banner {
@@ -707,16 +694,7 @@ export class CronJobDescribeWebview {
 </head>
 <body>
     <div class="container">
-        <!-- Header -->
-        <div class="cronjob-header">
-            <h1 class="cronjob-title">CronJob / <span class="cronjob-name" id="cronjob-name">Loading...</span></h1>
-            <div class="header-actions">
-                <button id="refresh-btn" class="action-btn">
-                    <span class="btn-icon">🔄</span>
-                    <span class="btn-text">Refresh</span>
-                </button>
-            </div>
-        </div>
+        ${headerFragment}
 
         <!-- Loading Indicator -->
         <div id="loading" class="loading">Loading CronJob details...</div>
@@ -1307,6 +1285,7 @@ export class CronJobDescribeWebview {
                     showLoading();
                 });
             }
+${buildLegacyHeaderActionScript({ showRefresh: false })}
         })();
     </script>
 </body>

--- a/src/webview/DaemonSetDescribeWebview.ts
+++ b/src/webview/DaemonSetDescribeWebview.ts
@@ -1,11 +1,18 @@
 import * as vscode from 'vscode';
+import { getYAMLEditorManager } from '../extension';
 import { WorkloadCommands } from '../kubectl/WorkloadCommands';
 import { transformDaemonSetData, DaemonSetDescribeData } from './daemonSetDataTransformer';
 import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
 import { DescribeWebview } from './DescribeWebview';
 import { releaseExclusiveDescribePanelBindings } from './describeSharedPanelBindings';
+import {
+    buildLegacyDescribeDocumentShell,
+    buildLegacyHeaderActionScript,
+    buildLegacyHeaderFragment,
+    getLegacyDescribeWebviewPanelOptions,
+    setupLegacyDescribeHelpHandler
+} from './legacyDescribeHeaderShell';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
-import { getYAMLEditorManager } from '../extension';
 
 interface WebviewMessage {
     command: 'refresh' | 'copyValue' | 'viewYaml' | 'navigateToPod';
@@ -19,6 +26,7 @@ interface WebviewMessage {
  * Structured describe panel for namespaced DaemonSet resources.
  */
 export class DaemonSetDescribeWebview {
+    private static extensionUri: vscode.Uri | undefined;
     private static currentPanel: vscode.WebviewPanel | undefined;
     private static currentDaemonSetName: string | undefined;
     private static currentNamespace: string | undefined;
@@ -37,6 +45,7 @@ export class DaemonSetDescribeWebview {
         contextName: string
     ): Promise<void> {
         releaseExclusiveDescribePanelBindings();
+        DaemonSetDescribeWebview.extensionUri = context.extensionUri;
         DaemonSetDescribeWebview.currentDaemonSetName = daemonSetName;
         DaemonSetDescribeWebview.currentNamespace = namespace;
         DaemonSetDescribeWebview.kubeconfigPath = kubeconfigPath;
@@ -76,10 +85,12 @@ export class DaemonSetDescribeWebview {
         }
 
         notifyMajorWebviewOpened('resource_describe');
-        const panel = vscode.window.createWebviewPanel('kube9Describe', `DaemonSet / ${daemonSetName}`, vscode.ViewColumn.One, {
-            enableScripts: true,
-            retainContextWhenHidden: true
-        });
+        const panel = vscode.window.createWebviewPanel(
+            'kube9Describe',
+            `DaemonSet / ${daemonSetName}`,
+            vscode.ViewColumn.One,
+            getLegacyDescribeWebviewPanelOptions(context.extensionUri)
+        );
 
         DaemonSetDescribeWebview.currentPanel = panel;
         DescribeWebview.setSharedPanel(panel);
@@ -109,6 +120,7 @@ export class DaemonSetDescribeWebview {
     private static attachPanelBindings(panel: vscode.WebviewPanel): void {
         DaemonSetDescribeWebview.detachPanelSubscriptions();
         DaemonSetDescribeWebview.setupMessageHandlers(panel);
+        setupLegacyDescribeHelpHandler(panel.webview);
 
         DaemonSetDescribeWebview.panelDisposeSubscription = panel.onDidDispose(() => {
             if (DaemonSetDescribeWebview.currentPanel === panel) {
@@ -308,22 +320,16 @@ export class DaemonSetDescribeWebview {
     }
 
     private static getWebviewContent(webview: vscode.Webview): string {
-        const csp = webview.cspSource;
-        return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src ${csp} 'unsafe-inline';" />
-  <title>DaemonSet Describe</title>
-  <style>
-    body { font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); color: var(--vscode-foreground); background: var(--vscode-editor-background); margin: 0; padding: 0; }
-    .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
-    .hdr { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 12px; margin-bottom: 16px; }
-    .hdr h1 { margin: 0; font-size: 22px; font-weight: 600; }
-    .actions { display: flex; gap: 8px; flex-wrap: wrap; }
-    .action-btn { padding: 6px 12px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 2px; cursor: pointer; font: inherit; }
-    .action-btn:hover { background: var(--vscode-button-hoverBackground); }
+        const extensionUri = DaemonSetDescribeWebview.extensionUri;
+        if (!extensionUri) {
+            throw new Error('DaemonSet describe requires extension context');
+        }
+
+        const headerFragment = buildLegacyHeaderFragment({
+            titleInnerHtml: 'DaemonSet / <span id="ds-name">…</span>'
+        });
+
+        const panelCss = `    .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
     .section { margin-bottom: 28px; }
     .section h2 { margin: 0 0 10px; font-size: 17px; border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 6px; }
     .info-grid { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 12px; }
@@ -355,18 +361,10 @@ export class DaemonSetDescribeWebview {
     .status-bad { color: var(--vscode-errorForeground); }
     .annotation-item { padding: 10px 0; border-bottom: 1px solid var(--vscode-panel-border); }
     .annotation-key { font-weight: 600; margin-bottom: 4px; }
-    .annotation-val { font-family: var(--vscode-editor-font-family); white-space: pre-wrap; word-break: break-all; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="hdr">
-      <h1>DaemonSet / <span id="ds-name">…</span></h1>
-      <div class="actions">
-        <button class="action-btn" id="btn-refresh">Refresh</button>
-        <button class="action-btn" id="btn-yaml">View YAML</button>
-      </div>
-    </div>
+    .annotation-val { font-family: var(--vscode-editor-font-family); white-space: pre-wrap; word-break: break-all; }`;
+
+        const bodyHtml = `  <div class="container">
+    ${headerFragment}
     <div id="loading" class="loading">Loading DaemonSet…</div>
     <div id="err" class="error-message"></div>
     <div id="main" class="hidden">
@@ -381,11 +379,9 @@ export class DaemonSetDescribeWebview {
       <div class="section" id="sec-events"><h2>Events</h2><div id="events-banner"></div><table><thead><tr><th>Type</th><th>Reason</th><th>Message</th><th>Age</th><th>From</th><th>Count</th></tr></thead><tbody id="events-body"></tbody></table></div>
       <div class="section" id="sec-annotations"><h2>Annotations</h2><div id="ann-body"></div></div>
     </div>
-  </div>
-  <script>
-  (function(){
-    const vscode = acquireVsCodeApi();
-    const $ = id => document.getElementById(id);
+  </div>`;
+
+        const script = `    const $ = id => document.getElementById(id);
     function esc(s){ if(s==null) return ''; return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
     window.addEventListener('message', ev => {
       const m = ev.data;
@@ -512,11 +508,16 @@ export class DaemonSetDescribeWebview {
         : '<div class="empty-state">No annotations</div>';
       ab.querySelectorAll('.copy-btn').forEach(b => b.addEventListener('click', () => vscode.postMessage({ command:'copyValue', value: b.getAttribute('data-copy') })));
     }
-    $('btn-refresh').addEventListener('click', () => { $('loading').classList.remove('hidden'); vscode.postMessage({ command:'refresh' }); });
-    $('btn-yaml').addEventListener('click', () => vscode.postMessage({ command:'viewYaml' }));
-  })();
-  </script>
-</body>
-</html>`;
+    $('refresh-btn').addEventListener('click', () => { $('loading').classList.remove('hidden'); vscode.postMessage({ command:'refresh' }); });
+${buildLegacyHeaderActionScript({ showRefresh: false })}`;
+
+        return buildLegacyDescribeDocumentShell({
+            webview,
+            extensionUri,
+            pageTitle: 'DaemonSet Describe',
+            bodyHtml,
+            panelCss,
+            script
+        });
     }
 }

--- a/src/webview/DeploymentDescribeWebview.ts
+++ b/src/webview/DeploymentDescribeWebview.ts
@@ -4,13 +4,20 @@ import { transformDeploymentData, DeploymentDescribeData } from './deploymentDat
 import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
 import { DescribeWebview } from './DescribeWebview';
 import { releaseExclusiveDescribePanelBindings } from './describeSharedPanelBindings';
+import {
+    buildLegacyDescribeHeadAssets,
+    buildLegacyHeaderActionScript,
+    buildLegacyHeaderFragment,
+    getLegacyDescribeWebviewPanelOptions,
+    setupLegacyDescribeHelpHandler
+} from './legacyDescribeHeaderShell';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 
 /**
  * Message sent from webview to extension.
  */
 interface WebviewMessage {
-    command: 'refresh' | 'navigateToReplicaSet' | 'copyValue';
+    command: 'refresh' | 'navigateToReplicaSet' | 'copyValue' | 'viewYaml';
     replicaSetName?: string;
     name?: string;
     namespace?: string;
@@ -140,10 +147,7 @@ export class DeploymentDescribeWebview {
             'kube9Describe',  // Use the shared panel ID
             title,
             vscode.ViewColumn.One,
-            {
-                enableScripts: true,
-                retainContextWhenHidden: true
-            }
+            getLegacyDescribeWebviewPanelOptions(context.extensionUri)
         );
 
         DeploymentDescribeWebview.currentPanel = panel;
@@ -164,6 +168,7 @@ export class DeploymentDescribeWebview {
     private static attachPanelBindings(panel: vscode.WebviewPanel): void {
         DeploymentDescribeWebview.releaseMessageBindings();
         DeploymentDescribeWebview.setupMessageHandlers(panel);
+        setupLegacyDescribeHelpHandler(panel.webview);
 
         DeploymentDescribeWebview.panelDisposeSubscription = panel.onDidDispose(() => {
             if (DeploymentDescribeWebview.currentPanel === panel) {
@@ -381,6 +386,31 @@ export class DeploymentDescribeWebview {
                         }
                         break;
                     }
+
+                    case 'viewYaml': {
+                        const deploymentName = DeploymentDescribeWebview.currentDeploymentName;
+                        const namespace = DeploymentDescribeWebview.currentNamespace;
+                        const cluster = DeploymentDescribeWebview.contextName;
+                        if (!deploymentName || !namespace || !cluster) {
+                            vscode.window.showErrorMessage('Deployment context not available');
+                            break;
+                        }
+                        try {
+                            const { getYAMLEditorManager } = await import('../extension');
+                            const yamlEditorManager = getYAMLEditorManager();
+                            await yamlEditorManager.openYAMLEditor({
+                                kind: 'Deployment',
+                                name: deploymentName,
+                                namespace,
+                                apiVersion: 'apps/v1',
+                                cluster
+                            });
+                        } catch (error) {
+                            const errorMessage = error instanceof Error ? error.message : String(error);
+                            vscode.window.showErrorMessage(`Failed to open YAML: ${errorMessage}`);
+                        }
+                        break;
+                    }
                     
                     default: {
                         console.log('Unknown message command:', message.command);
@@ -400,76 +430,34 @@ export class DeploymentDescribeWebview {
     private static getWebviewContent(
         webview: vscode.Webview
     ): string {
-        const cspSource = webview.cspSource;
+        const extensionUri = DeploymentDescribeWebview.extensionContext?.extensionUri;
+        if (!extensionUri) {
+            throw new Error('Deployment describe requires extension context');
+        }
+        const { headerLink, codiconsLink, csp } = buildLegacyDescribeHeadAssets(webview, extensionUri);
+        const headerFragment = buildLegacyHeaderFragment({
+            titleInnerHtml:
+                'Deployment / <span class="deployment-name" id="deployment-name">Loading...</span>'
+        });
 
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src ${cspSource} 'unsafe-inline';">
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
+    ${headerLink}
+    ${codiconsLink}
     <title>Deployment Describe</title>
     <style>
-        body {
-            font-family: var(--vscode-font-family);
-            font-size: var(--vscode-font-size);
-            color: var(--vscode-foreground);
-            background-color: var(--vscode-editor-background);
-            padding: 0;
-            margin: 0;
-        }
-
         .container {
             max-width: 1400px;
             margin: 0 auto;
             padding: 20px;
         }
 
-        .deployment-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            border-bottom: 1px solid var(--vscode-panel-border);
-            padding-bottom: 15px;
-            margin-bottom: 20px;
-        }
-
-        .deployment-title {
-            margin: 0;
-            font-size: 24px;
-            font-weight: 600;
-            color: var(--vscode-foreground);
-        }
-
         .deployment-name {
             color: var(--vscode-textLink-foreground);
-        }
-
-        .header-actions {
-            display: flex;
-            gap: 10px;
-        }
-
-        .action-btn {
-            display: flex;
-            align-items: center;
-            gap: 6px;
-            padding: 6px 12px;
-            background-color: var(--vscode-button-background);
-            color: var(--vscode-button-foreground);
-            border: none;
-            border-radius: 2px;
-            cursor: pointer;
-            font-size: var(--vscode-font-size);
-            font-family: var(--vscode-font-family);
-        }
-
-        .action-btn:hover {
-            background-color: var(--vscode-button-hoverBackground);
-        }
-
-        .btn-icon {
-            font-size: 14px;
         }
 
         .section {
@@ -816,16 +804,7 @@ export class DeploymentDescribeWebview {
 </head>
 <body>
     <div class="container">
-        <!-- Header -->
-        <div class="deployment-header">
-            <h1 class="deployment-title">Deployment / <span class="deployment-name" id="deployment-name">Loading...</span></h1>
-            <div class="header-actions">
-                <button id="refresh-btn" class="action-btn">
-                    <span class="btn-icon">🔄</span>
-                    <span class="btn-text">Refresh</span>
-                </button>
-            </div>
-        </div>
+        ${headerFragment}
 
         <!-- Loading Indicator -->
         <div id="loading" class="loading">Loading deployment details...</div>
@@ -1585,6 +1564,7 @@ export class DeploymentDescribeWebview {
                     showLoading();
                 });
             }
+${buildLegacyHeaderActionScript({ showRefresh: false })}
         })();
     </script>
 </body>

--- a/src/webview/DescribeWebview.ts
+++ b/src/webview/DescribeWebview.ts
@@ -23,7 +23,12 @@ import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 import { NamespaceTreeItemConfig } from '../tree/items/NamespaceTreeItem';
 import { setNamespace } from '../utils/kubectlContext';
 import { resolveSpecializedDescribeFromTreeItem } from './describeTreeRouting';
-import { getWebviewHeaderStyleUri } from './webviewHeaderStyles';
+import {
+    buildLegacyDescribeHeadAssets,
+    buildLegacyHeaderFragment,
+    getLegacyDescribeWebviewPanelOptions,
+    setupLegacyDescribeHelpHandler
+} from './legacyDescribeHeaderShell';
 import { getWebviewShellHtml } from './webviewShellHtml';
 
 /**
@@ -293,16 +298,15 @@ export class DescribeWebview {
             'kube9Describe',
             title,
             vscode.ViewColumn.One,
-            {
-                enableScripts: true,
-                retainContextWhenHidden: true
-            }
+            getLegacyDescribeWebviewPanelOptions(context.extensionUri)
         );
 
         DescribeWebview.currentPanel = panel;
 
         // Set the webview's HTML content
         panel.webview.html = DescribeWebview.getWebviewContent(resourceInfo, panel.webview);
+
+        setupLegacyDescribeHelpHandler(panel.webview);
 
         // Handle panel disposal - clear shared state
         panel.onDidDispose(
@@ -365,45 +369,32 @@ export class DescribeWebview {
             ? `${resourceInfo.kind} "${resourceInfo.name}" in namespace "${resourceInfo.namespace}"`
             : `${resourceInfo.kind} "${resourceInfo.name}"`;
 
-        const cspSource = webview.cspSource;
-        let headerStyleUri = '';
-        let nonce = '';
-
-        if (DescribeWebview.extensionContext) {
-            headerStyleUri = getWebviewHeaderStyleUri(
-                DescribeWebview.extensionContext.extensionUri,
-                webview
-            ).toString();
-            nonce = getNonce();
+        const extensionUri = DescribeWebview.extensionContext?.extensionUri;
+        if (!extensionUri) {
+            throw new Error('Describe webview requires extension context');
         }
 
-        const headerStyleLink = headerStyleUri ? `<link href="${headerStyleUri}" rel="stylesheet">` : '';
-        const cspScriptSrc = nonce ? `script-src 'nonce-${nonce}';` : '';
+        const { headerLink, codiconsLink, csp } = buildLegacyDescribeHeadAssets(webview, extensionUri);
+        const headerFragment = buildLegacyHeaderFragment({
+            titleInnerHtml: `${DescribeWebview.escapeHtml(resourceInfo.kind)} / ${DescribeWebview.escapeHtml(resourceInfo.name)}`,
+            showRefresh: false,
+            showViewYaml: false
+        });
 
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline' ${cspSource}; ${cspScriptSrc}">
-    ${headerStyleLink}
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
+    ${headerLink}
+    ${codiconsLink}
     <title>Describe: ${DescribeWebview.escapeHtml(resourceInfo.kind)} / ${DescribeWebview.escapeHtml(resourceInfo.name)}</title>
     <style>
-        body {
-            font-family: var(--vscode-font-family);
-            color: var(--vscode-foreground);
-            background-color: var(--vscode-editor-background);
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
             padding: 20px;
-            margin: 0;
-        }
-        h1 {
-            margin-top: 0;
-            font-size: 1.5em;
-            font-weight: 600;
-            color: var(--vscode-foreground);
-            border-bottom: 2px solid var(--vscode-panel-border);
-            padding-bottom: 10px;
-            margin-bottom: 20px;
         }
         .coming-soon {
             text-align: center;
@@ -422,11 +413,24 @@ export class DescribeWebview {
     </style>
 </head>
 <body>
-    <h1>${DescribeWebview.escapeHtml(resourceInfo.kind)} / ${DescribeWebview.escapeHtml(resourceInfo.name)}</h1>
-    <div class="coming-soon">
-        <div class="coming-soon-message">Coming soon</div>
-        <div class="resource-info">Resource: ${DescribeWebview.escapeHtml(resourceDisplay)}</div>
+    <div class="container">
+        ${headerFragment}
+        <div class="coming-soon">
+            <div class="coming-soon-message">Coming soon</div>
+            <div class="resource-info">Resource: ${DescribeWebview.escapeHtml(resourceDisplay)}</div>
+        </div>
     </div>
+    <script>
+    (function() {
+        var vscode = acquireVsCodeApi();
+        var helpBtn = document.getElementById('help-btn');
+        if (helpBtn) {
+            helpBtn.addEventListener('click', function() {
+                vscode.postMessage({ command: 'openHelp', context: 'describe-webview' });
+            });
+        }
+    })();
+    </script>
 </body>
 </html>`;
     }

--- a/src/webview/NodeDescribeWebview.ts
+++ b/src/webview/NodeDescribeWebview.ts
@@ -5,13 +5,20 @@ import { transformNodeData, NodeDescribeData } from './nodeDescribeTransformer';
 import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
 import { DescribeWebview } from './DescribeWebview';
 import { releaseExclusiveDescribePanelBindings } from './describeSharedPanelBindings';
+import {
+    buildLegacyDescribeHeadAssets,
+    buildLegacyHeaderActionScript,
+    buildLegacyHeaderFragment,
+    getLegacyDescribeWebviewPanelOptions,
+    setupLegacyDescribeHelpHandler
+} from './legacyDescribeHeaderShell';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 
 /**
  * Message sent from webview to extension.
  */
 interface WebviewMessage {
-    command: 'refresh' | 'navigateToPod' | 'copyValue';
+    command: 'refresh' | 'navigateToPod' | 'copyValue' | 'viewYaml';
     podName?: string;
     name?: string;
     namespace?: string;
@@ -129,10 +136,7 @@ export class NodeDescribeWebview {
             'kube9Describe',  // Use the shared panel ID
             title,
             vscode.ViewColumn.One,
-            {
-                enableScripts: true,
-                retainContextWhenHidden: true
-            }
+            getLegacyDescribeWebviewPanelOptions(context.extensionUri)
         );
 
         NodeDescribeWebview.currentPanel = panel;
@@ -153,6 +157,7 @@ export class NodeDescribeWebview {
     private static attachPanelBindings(panel: vscode.WebviewPanel): void {
         NodeDescribeWebview.releaseMessageBindings();
         NodeDescribeWebview.setupMessageHandlers(panel);
+        setupLegacyDescribeHelpHandler(panel.webview);
 
         NodeDescribeWebview.panelDisposeSubscription = panel.onDidDispose(() => {
             if (NodeDescribeWebview.currentPanel === panel) {
@@ -312,6 +317,29 @@ export class NodeDescribeWebview {
                         }
                         break;
                     }
+
+                    case 'viewYaml': {
+                        const nodeName = NodeDescribeWebview.currentNodeName;
+                        const cluster = NodeDescribeWebview.contextName;
+                        if (!nodeName || !cluster) {
+                            vscode.window.showErrorMessage('Node context not available');
+                            break;
+                        }
+                        try {
+                            const { getYAMLEditorManager } = await import('../extension');
+                            const yamlEditorManager = getYAMLEditorManager();
+                            await yamlEditorManager.openYAMLEditor({
+                                kind: 'Node',
+                                name: nodeName,
+                                apiVersion: 'v1',
+                                cluster
+                            });
+                        } catch (error) {
+                            const errorMessage = error instanceof Error ? error.message : String(error);
+                            vscode.window.showErrorMessage(`Failed to open YAML: ${errorMessage}`);
+                        }
+                        break;
+                    }
                     
                     default: {
                         console.log('Unknown message command:', message.command);
@@ -331,76 +359,33 @@ export class NodeDescribeWebview {
     private static getWebviewContent(
         webview: vscode.Webview
     ): string {
-        const cspSource = webview.cspSource;
+        const extensionUri = NodeDescribeWebview.extensionContext?.extensionUri;
+        if (!extensionUri) {
+            throw new Error('Node describe requires extension context');
+        }
+        const { headerLink, codiconsLink, csp } = buildLegacyDescribeHeadAssets(webview, extensionUri);
+        const headerFragment = buildLegacyHeaderFragment({
+            titleInnerHtml: 'Node / <span class="node-name" id="node-name">Loading...</span>'
+        });
 
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src ${cspSource} 'unsafe-inline';">
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
+    ${headerLink}
+    ${codiconsLink}
     <title>Node Describe</title>
     <style>
-        body {
-            font-family: var(--vscode-font-family);
-            font-size: var(--vscode-font-size);
-            color: var(--vscode-foreground);
-            background-color: var(--vscode-editor-background);
-            padding: 0;
-            margin: 0;
-        }
-
         .container {
             max-width: 1400px;
             margin: 0 auto;
             padding: 20px;
         }
 
-        .node-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            border-bottom: 1px solid var(--vscode-panel-border);
-            padding-bottom: 15px;
-            margin-bottom: 20px;
-        }
-
-        .node-title {
-            margin: 0;
-            font-size: 24px;
-            font-weight: 600;
-            color: var(--vscode-foreground);
-        }
-
         .node-name {
             color: var(--vscode-textLink-foreground);
-        }
-
-        .header-actions {
-            display: flex;
-            gap: 10px;
-        }
-
-        .action-btn {
-            display: flex;
-            align-items: center;
-            gap: 6px;
-            padding: 6px 12px;
-            background-color: var(--vscode-button-background);
-            color: var(--vscode-button-foreground);
-            border: none;
-            border-radius: 2px;
-            cursor: pointer;
-            font-size: var(--vscode-font-size);
-            font-family: var(--vscode-font-family);
-        }
-
-        .action-btn:hover {
-            background-color: var(--vscode-button-hoverBackground);
-        }
-
-        .btn-icon {
-            font-size: 14px;
         }
 
         .status-banner {
@@ -688,16 +673,7 @@ export class NodeDescribeWebview {
 </head>
 <body>
     <div class="container">
-        <!-- Header -->
-        <div class="node-header">
-            <h1 class="node-title">Node / <span class="node-name" id="node-name">Loading...</span></h1>
-            <div class="header-actions">
-                <button id="refresh-btn" class="action-btn">
-                    <span class="btn-icon">🔄</span>
-                    <span class="btn-text">Refresh</span>
-                </button>
-            </div>
-        </div>
+        ${headerFragment}
 
         <!-- Status Banner -->
         <div class="status-banner" id="status-banner">
@@ -1209,6 +1185,7 @@ export class NodeDescribeWebview {
         document.getElementById('refresh-btn').addEventListener('click', () => {
             vscode.postMessage({ command: 'refresh' });
         });
+${buildLegacyHeaderActionScript({ showRefresh: false })}
     </script>
 </body>
 </html>`;

--- a/src/webview/StatefulSetDescribeWebview.ts
+++ b/src/webview/StatefulSetDescribeWebview.ts
@@ -4,6 +4,13 @@ import { transformStatefulSetData, StatefulSetDescribeData } from './statefulSet
 import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
 import { DescribeWebview } from './DescribeWebview';
 import { releaseExclusiveDescribePanelBindings } from './describeSharedPanelBindings';
+import {
+    buildLegacyDescribeDocumentShell,
+    buildLegacyHeaderActionScript,
+    buildLegacyHeaderFragment,
+    getLegacyDescribeWebviewPanelOptions,
+    setupLegacyDescribeHelpHandler
+} from './legacyDescribeHeaderShell';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 
 interface WebviewMessage {
@@ -19,6 +26,7 @@ interface WebviewMessage {
  * Mirrors {@link DeploymentDescribeWebview} patterns (shared panel, cache, messages).
  */
 export class StatefulSetDescribeWebview {
+    private static extensionUri: vscode.Uri | undefined;
     private static currentPanel: vscode.WebviewPanel | undefined;
     private static currentName: string | undefined;
     private static currentNamespace: string | undefined;
@@ -37,6 +45,7 @@ export class StatefulSetDescribeWebview {
         contextName: string
     ): Promise<void> {
         releaseExclusiveDescribePanelBindings();
+        StatefulSetDescribeWebview.extensionUri = context.extensionUri;
         StatefulSetDescribeWebview.currentName = statefulSetName;
         StatefulSetDescribeWebview.currentNamespace = namespace;
         StatefulSetDescribeWebview.kubeconfigPath = kubeconfigPath;
@@ -78,10 +87,12 @@ export class StatefulSetDescribeWebview {
 
         const title = `StatefulSet / ${statefulSetName}`;
         notifyMajorWebviewOpened('resource_describe');
-        const panel = vscode.window.createWebviewPanel('kube9Describe', title, vscode.ViewColumn.One, {
-            enableScripts: true,
-            retainContextWhenHidden: true
-        });
+        const panel = vscode.window.createWebviewPanel(
+            'kube9Describe',
+            title,
+            vscode.ViewColumn.One,
+            getLegacyDescribeWebviewPanelOptions(context.extensionUri)
+        );
 
         StatefulSetDescribeWebview.currentPanel = panel;
         DescribeWebview.setSharedPanel(panel);
@@ -98,6 +109,7 @@ export class StatefulSetDescribeWebview {
     private static attachPanelBindings(panel: vscode.WebviewPanel): void {
         StatefulSetDescribeWebview.detachPanelSubscriptions();
         StatefulSetDescribeWebview.setupMessageHandlers(panel);
+        setupLegacyDescribeHelpHandler(panel.webview);
 
         StatefulSetDescribeWebview.panelDisposeSubscription = panel.onDidDispose(() => {
             if (StatefulSetDescribeWebview.currentPanel === panel) {
@@ -304,26 +316,16 @@ export class StatefulSetDescribeWebview {
     }
 
     private static getWebviewContent(webview: vscode.Webview): string {
-        const cspSource = webview.cspSource;
-        return `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src ${cspSource} 'unsafe-inline';">
-    <title>StatefulSet Describe</title>
-    <style>
-        body { font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); color: var(--vscode-foreground);
-            background-color: var(--vscode-editor-background); padding: 0; margin: 0; }
-        .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
-        .resource-header { display: flex; justify-content: space-between; align-items: center;
-            border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 15px; margin-bottom: 20px; flex-wrap: wrap; gap: 10px; }
-        .resource-title { margin: 0; font-size: 24px; font-weight: 600; }
-        .header-actions { display: flex; gap: 10px; flex-wrap: wrap; }
-        .action-btn { display: flex; align-items: center; gap: 6px; padding: 6px 12px;
-            background-color: var(--vscode-button-background); color: var(--vscode-button-foreground);
-            border: none; border-radius: 2px; cursor: pointer; font-family: inherit; }
-        .action-btn:hover { background-color: var(--vscode-button-hoverBackground); }
+        const extensionUri = StatefulSetDescribeWebview.extensionUri;
+        if (!extensionUri) {
+            throw new Error('StatefulSet describe requires extension context');
+        }
+
+        const headerFragment = buildLegacyHeaderFragment({
+            titleInnerHtml: 'StatefulSet / <span id="sts-name">Loading…</span>'
+        });
+
+        const panelCss = `        .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
         .section { margin-bottom: 28px; }
         .section h2 { margin: 0 0 12px 0; font-size: 18px; font-weight: 600;
             border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 8px; }
@@ -348,18 +350,10 @@ export class StatefulSetDescribeWebview {
         .loading { text-align: center; padding: 40px; color: var(--vscode-descriptionForeground); }
         .hidden { display: none; }
         .label-list { list-style: none; padding: 0; margin: 0; }
-        .label-item { display: flex; align-items: center; gap: 10px; padding: 6px 0; border-bottom: 1px solid var(--vscode-panel-border); }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="resource-header">
-            <h1 class="resource-title">StatefulSet / <span id="sts-name">Loading…</span></h1>
-            <div class="header-actions">
-                <button id="yaml-btn" class="action-btn">View YAML</button>
-                <button id="refresh-btn" class="action-btn">Refresh</button>
-            </div>
-        </div>
+        .label-item { display: flex; align-items: center; gap: 10px; padding: 6px 0; border-bottom: 1px solid var(--vscode-panel-border); }`;
+
+        const bodyHtml = `    <div class="container">
+            ${headerFragment}
         <div id="loading" class="loading">Loading StatefulSet…</div>
         <div id="page-error" class="error-banner hidden"></div>
         <div id="warnings" class="hidden"></div>
@@ -383,11 +377,9 @@ export class StatefulSetDescribeWebview {
                 <th>Type</th><th>Reason</th><th>Message</th><th>Age</th><th>From</th><th>Count</th>
             </tr></thead><tbody id="events-body"></tbody></table></div>
         </div>
-    </div>
-    <script>
-    (function() {
-        var vscode = acquireVsCodeApi();
-        window.addEventListener('message', function(event) {
+    </div>`;
+
+        const script = `        window.addEventListener('message', function(event) {
             var message = event.data;
             if (message.command === 'updateStatefulSetData') {
                 hideError();
@@ -570,12 +562,15 @@ export class StatefulSetDescribeWebview {
             document.getElementById('content').classList.add('hidden');
             vscode.postMessage({ command: 'refresh' });
         });
-        document.getElementById('yaml-btn').addEventListener('click', function() {
-            vscode.postMessage({ command: 'viewYaml' });
+${buildLegacyHeaderActionScript({ showRefresh: false })}`;
+
+        return buildLegacyDescribeDocumentShell({
+            webview,
+            extensionUri,
+            pageTitle: 'StatefulSet Describe',
+            bodyHtml,
+            panelCss,
+            script
         });
-    })();
-    </script>
-</body>
-</html>`;
     }
 }

--- a/src/webview/WebviewHelpHandler.ts
+++ b/src/webview/WebviewHelpHandler.ts
@@ -16,14 +16,18 @@ export class WebviewHelpHandler {
      */
     public setupHelpMessageHandler(webview: vscode.Webview): void {
         webview.onDidReceiveMessage(async (message) => {
-            if (message.type === 'openHelp') {
-                try {
-                    await this.helpController.openContextualHelp(message.context);
-                } catch (error) {
-                    const errorMessage = error instanceof Error ? error.message : String(error);
-                    console.error('Error handling help message:', errorMessage);
-                    // Don't show error to user - help failures shouldn't break webview functionality
-                }
+            const isReactHelp = message?.type === 'openHelp' && message.context;
+            const isLegacyHelp = message?.command === 'openHelp' && message.context;
+            if (!isReactHelp && !isLegacyHelp) {
+                return;
+            }
+
+            try {
+                await this.helpController.openContextualHelp(message.context);
+            } catch (error) {
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                console.error('Error handling help message:', errorMessage);
+                // Don't show error to user - help failures shouldn't break webview functionality
             }
         });
     }

--- a/src/webview/legacyDescribeHeaderShell.ts
+++ b/src/webview/legacyDescribeHeaderShell.ts
@@ -1,0 +1,253 @@
+import * as vscode from 'vscode';
+import { getHelpController, isHelpControllerReady } from '../extension';
+import { WebviewHelpHandler } from './WebviewHelpHandler';
+import { getCodiconsStyleUri } from './webviewShellHtml';
+import { getWebviewHeaderStyleUri } from './webviewHeaderStyles';
+
+/** Default help topic for legacy workload describe panels. */
+export const LEGACY_DESCRIBE_HELP_CONTEXT = 'describe-webview';
+
+export interface LegacyDescribeHeaderActionOptions {
+    /** When false, omit View YAML (e.g. coming-soon stub). Default true. */
+    showViewYaml?: boolean;
+    /** When false, omit Refresh. Default true. */
+    showRefresh?: boolean;
+    /** When set, renders Help and wires `openHelp` via legacy header script. */
+    helpContext?: string;
+    refreshButtonId?: string;
+    viewYamlButtonId?: string;
+    helpButtonId?: string;
+}
+
+export interface LegacyDescribeHeaderOptions extends LegacyDescribeHeaderActionOptions {
+    /** Inner HTML for the h1 (caller escapes untrusted values). */
+    titleInnerHtml: string;
+}
+
+export interface LegacyDescribeDocumentShellOptions {
+    webview: vscode.Webview;
+    extensionUri: vscode.Uri;
+    pageTitle: string;
+    /** Full body markup (embed {@link buildLegacyHeaderFragment} inside `.container` when needed). */
+    bodyHtml: string;
+    /** Panel-specific CSS (exclude header chrome; use shipped webview-header.css). */
+    panelCss?: string;
+    /** Script body placed before closing `</body>` (wrapped in IIFE when `wrapScript` is true). */
+    script?: string;
+    /** When true (default), wraps `script` in an IIFE. */
+    wrapScript?: boolean;
+}
+
+/** Registers legacy `{ command: 'openHelp' }` help handling when the extension host initialized HelpController. */
+export function setupLegacyDescribeHelpHandler(webview: vscode.Webview): void {
+    if (!isHelpControllerReady()) {
+        return;
+    }
+    const helpHandler = new WebviewHelpHandler(getHelpController());
+    helpHandler.setupHelpMessageHandler(webview);
+}
+
+/** `localResourceRoots` for legacy describe panels (shipped header + codicons). */
+export function getLegacyDescribeLocalResourceRoots(extensionUri: vscode.Uri): vscode.Uri[] {
+    return [vscode.Uri.joinPath(extensionUri, 'media')];
+}
+
+/** Linked stylesheet tags and CSP for legacy panels not yet on {@link buildLegacyDescribeDocumentShell}. */
+export function buildLegacyDescribeHeadAssets(
+    webview: vscode.Webview,
+    extensionUri: vscode.Uri
+): { headerLink: string; codiconsLink: string; csp: string } {
+    const cspSource = webview.cspSource;
+    const headerUri = getWebviewHeaderStyleUri(extensionUri, webview).toString();
+    const codiconsUri = getCodiconsStyleUri(extensionUri, webview).toString();
+    return {
+        headerLink: `<link href="${headerUri}" rel="stylesheet">`,
+        codiconsLink: `<link href="${codiconsUri}" rel="stylesheet">`,
+        csp: `default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src ${cspSource} 'unsafe-inline'; font-src ${cspSource};`
+    };
+}
+
+/** Webview panel options shared by legacy workload describe generators. */
+export function getLegacyDescribeWebviewPanelOptions(
+    extensionUri: vscode.Uri
+): vscode.WebviewPanelOptions & vscode.WebviewOptions {
+    return {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: getLegacyDescribeLocalResourceRoots(extensionUri)
+    };
+}
+
+function codiconClass(icon: string): string {
+    return icon.startsWith('codicon-') ? icon : `codicon-${icon}`;
+}
+
+function renderHeaderActionButton(
+    id: string,
+    label: string,
+    icon: string,
+    extraClass = ''
+): string {
+    const className = ['webview-header-action-btn', extraClass].filter(Boolean).join(' ');
+    return `<button type="button" id="${id}" class="${className}" aria-label="${label}">
+                <span class="codicon ${codiconClass(icon)}" aria-hidden="true"></span>
+                <span class="webview-header-action-label">${label}</span>
+            </button>`;
+}
+
+/**
+ * Markup aligned with React {@link WebviewHeader} (`.webview-header` + action buttons).
+ */
+export function buildLegacyHeaderFragment(options: LegacyDescribeHeaderOptions): string {
+    const {
+        titleInnerHtml,
+        showViewYaml = true,
+        showRefresh = true,
+        helpContext = LEGACY_DESCRIBE_HELP_CONTEXT,
+        refreshButtonId = 'refresh-btn',
+        viewYamlButtonId = 'view-yaml-btn',
+        helpButtonId = 'help-btn'
+    } = options;
+
+    const actions: string[] = [];
+    if (showRefresh) {
+        actions.push(renderHeaderActionButton(refreshButtonId, 'Refresh', 'refresh'));
+    }
+    if (showViewYaml) {
+        actions.push(renderHeaderActionButton(viewYamlButtonId, 'View YAML', 'file-code'));
+    }
+    if (helpContext) {
+        actions.push(
+            renderHeaderActionButton(
+                helpButtonId,
+                'Help',
+                'question',
+                'webview-header-help-btn'
+            )
+        );
+    }
+
+    const actionsHtml = actions.length ? actions.join('\n                ') : '';
+
+    return `<header class="webview-header">
+            <div class="webview-header-title">
+                <h1>${titleInnerHtml}</h1>
+            </div>
+            <div class="webview-header-actions">
+                ${actionsHtml}
+            </div>
+        </header>`;
+}
+
+/**
+ * Inline listeners for legacy header buttons (Refresh, View YAML, Help).
+ */
+export function buildLegacyHeaderActionScript(options: LegacyDescribeHeaderActionOptions = {}): string {
+    const {
+        showViewYaml = true,
+        showRefresh = true,
+        helpContext = LEGACY_DESCRIBE_HELP_CONTEXT,
+        refreshButtonId = 'refresh-btn',
+        viewYamlButtonId = 'view-yaml-btn',
+        helpButtonId = 'help-btn'
+    } = options;
+
+    const blocks: string[] = [];
+    if (showRefresh) {
+        blocks.push(`        var refreshBtn = document.getElementById('${refreshButtonId}');
+        if (refreshBtn) {
+            refreshBtn.addEventListener('click', function() {
+                vscode.postMessage({ command: 'refresh' });
+            });
+        }`);
+    }
+    if (showViewYaml) {
+        blocks.push(`        var yamlBtn = document.getElementById('${viewYamlButtonId}');
+        if (yamlBtn) {
+            yamlBtn.addEventListener('click', function() {
+                vscode.postMessage({ command: 'viewYaml' });
+            });
+        }`);
+    }
+    if (helpContext) {
+        const contextJson = JSON.stringify(helpContext);
+        blocks.push(`        var helpBtn = document.getElementById('${helpButtonId}');
+        if (helpBtn) {
+            helpBtn.addEventListener('click', function() {
+                vscode.postMessage({ command: 'openHelp', context: ${contextJson} });
+            });
+        }`);
+    }
+
+    return blocks.join('\n');
+}
+
+const LEGACY_SHELL_LAYOUT_CSS = `
+        body {
+            font-family: var(--vscode-font-family);
+            font-size: var(--vscode-font-size);
+            color: var(--vscode-foreground);
+            background-color: var(--vscode-editor-background);
+            padding: 0;
+            margin: 0;
+        }
+        .legacy-describe-shell {
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+        .legacy-describe-shell > .webview-header {
+            flex-shrink: 0;
+        }
+        .legacy-describe-body {
+            flex: 1 1 auto;
+        }
+`;
+
+/**
+ * Full HTML document for legacy describe generators: CSP, shipped header CSS, codicons, shared header.
+ */
+export function buildLegacyDescribeDocumentShell(options: LegacyDescribeDocumentShellOptions): string {
+    const { webview, extensionUri, pageTitle, bodyHtml, panelCss = '', script = '', wrapScript = true } =
+        options;
+
+    const cspSource = webview.cspSource;
+    const headerUri = getWebviewHeaderStyleUri(extensionUri, webview);
+    const codiconsUri = getCodiconsStyleUri(extensionUri, webview);
+
+    const scriptBlock =
+        script.trim().length > 0
+            ? wrapScript
+                ? `<script>
+    (function() {
+        var vscode = acquireVsCodeApi();
+${script}
+    })();
+    </script>`
+                : `<script>${script}</script>`
+            : '';
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src ${cspSource} 'unsafe-inline'; font-src ${cspSource};">
+    <link href="${headerUri.toString()}" rel="stylesheet">
+    <link href="${codiconsUri.toString()}" rel="stylesheet">
+    <title>${pageTitle}</title>
+    <style>
+${LEGACY_SHELL_LAYOUT_CSS}
+${panelCss}
+    </style>
+</head>
+<body>
+    <div class="legacy-describe-shell">
+        <div class="legacy-describe-body">
+${bodyHtml}
+        </div>
+    </div>
+    ${scriptBlock}
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary

- Adds `legacyDescribeHeaderShell.ts` to generate React-aligned `.webview-header` markup, link shipped `media/styles/webview-header.css` and codicons, and wire Refresh / View YAML / Help actions.
- Migrates Deployment, Node, CronJob, StatefulSet, and DaemonSet legacy describe generators to the shared shell; adds View YAML handlers where missing (Deployment, Node, CronJob).
- Updates the generic `DescribeWebview` coming-soon stub to use the same header chrome; extends `WebviewHelpHandler` to accept legacy `{ command: 'openHelp' }` messages.

Closes #198

## Test plan

- [x] `npm run lint`
- [x] `npm run test:unit`
- [ ] Install VSIX and open each workload describe (Deployment, Node, CronJob, StatefulSet, DaemonSet): header uses themed buttons, Refresh works, View YAML opens editor, Help opens describe docs
- [ ] Open an unsupported kind (coming-soon stub): shared header styling, no broken CSS in packaged VSIX

## Notes

Help uses legacy `{ command: 'openHelp', context: 'describe-webview' }` from inline HTML (React panels continue to use `{ type: 'openHelp' }`).