### PR TITLE
feat(webview): namespace explorer header and M15 visual acceptance

### DIFF
--- a/src/test/suite/webview/namespaceExplorerHeader.test.ts
+++ b/src/test/suite/webview/namespaceExplorerHeader.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const WEBVIEW_SRC = path.join(process.cwd(), 'src', 'webview');
+
+suite('namespaceExplorerHeader @unit', () => {
+    test('namespace.html uses single webview-header row without duplicate title band', () => {
+        const html = fs.readFileSync(path.join(WEBVIEW_SRC, 'namespace.html'), 'utf8');
+
+        assert.ok(html.includes('webview-header namespace-explorer-header'));
+        assert.ok(html.includes('id="namespace-header-title"'));
+        assert.ok(html.includes('codicon-file-code'));
+        assert.ok(html.includes('webview-header-action-btn'));
+        assert.ok(!html.includes('class="namespace-header"'));
+        assert.ok(!html.includes('class="namespace-title"'));
+        assert.ok(!html.includes('id="namespace-title"'));
+        assert.ok(!html.includes('class="namespace-header"'));
+        assert.ok(html.includes('<h2>Workloads</h2>'));
+    });
+
+    test('NamespaceWebview injects shipped header assets and media roots', () => {
+        const source = fs.readFileSync(path.join(WEBVIEW_SRC, 'NamespaceWebview.ts'), 'utf8');
+
+        assert.ok(source.includes('buildLegacyDescribeHeadAssets'));
+        assert.ok(source.includes('getLegacyDescribeLocalResourceRoots'));
+        assert.ok(source.includes('NAMESPACE_ACTIONS_CLASS'));
+        assert.ok(!source.includes('{{CSP_SOURCE}}'));
+    });
+});

--- a/src/test/suite/webview/webviewHeaderParityAudit.test.ts
+++ b/src/test/suite/webview/webviewHeaderParityAudit.test.ts
@@ -76,4 +76,14 @@ suite('webviewHeaderParityAudit @unit', () => {
         assert.ok(source.includes('getWebviewShellHtml'));
         assert.ok(!source.includes('src/webview/styles/webview-header'));
     });
+
+    test('namespace explorer links shipped header CSS and codicons', () => {
+        const html = fs.readFileSync(path.join(WEBVIEW_SRC, 'namespace.html'), 'utf8');
+        assert.ok(html.includes('{{HEADER_LINK}}'));
+        assert.ok(html.includes('codicon-file-code'));
+
+        const panelSource = readWebviewSource('NamespaceWebview.ts');
+        assert.ok(panelSource.includes('buildLegacyDescribeHeadAssets'));
+        assert.ok(panelSource.includes('getLegacyDescribeLocalResourceRoots'));
+    });
 });

--- a/src/webview/NamespaceWebview.ts
+++ b/src/webview/NamespaceWebview.ts
@@ -11,6 +11,11 @@ import { PodHealthAnalyzer } from '../kubernetes/PodHealthAnalyzer';
 import { notifyMajorWebviewOpened } from '../telemetry/webviewTelemetryOpen';
 import { calculateHealthStatus } from '../kubernetes/HealthCalculator';
 import { WorkloadType, WorkloadEntry } from '../types/workloadData';
+import {
+    buildLegacyDescribeHeadAssets,
+    getLegacyDescribeLocalResourceRoots,
+    getLegacyDescribeWebviewPanelOptions
+} from './legacyDescribeHeaderShell';
 
 /**
  * Context information for namespace webviews.
@@ -106,9 +111,9 @@ export class NamespaceWebview {
             title,
             vscode.ViewColumn.One,
             {
-                enableScripts: true,
-                retainContextWhenHidden: true,
+                ...getLegacyDescribeWebviewPanelOptions(context.extensionUri),
                 localResourceRoots: [
+                    ...getLegacyDescribeLocalResourceRoots(context.extensionUri),
                     vscode.Uri.joinPath(context.extensionUri, 'src', 'webview')
                 ]
             }
@@ -319,9 +324,17 @@ export class NamespaceWebview {
             // Get the URI for the main.js script file
             const scriptPath = vscode.Uri.joinPath(context.extensionUri, 'src', 'webview', 'main.js');
             const scriptUri = webview.asWebviewUri(scriptPath);
-            
+            const { csp, headerLink, codiconsLink } = buildLegacyDescribeHeadAssets(
+                webview,
+                context.extensionUri
+            );
+
             // Read the HTML file
             let htmlContent = fs.readFileSync(htmlPath, 'utf8');
+
+            htmlContent = htmlContent.replace(/\{\{CSP\}\}/g, csp);
+            htmlContent = htmlContent.replace(/\{\{HEADER_LINK\}\}/g, headerLink);
+            htmlContent = htmlContent.replace(/\{\{CODICONS_LINK\}\}/g, codiconsLink);
             
             // Replace placeholders with actual context data (using regex with global flag for all occurrences)
             htmlContent = htmlContent.replace(/\{\{CLUSTER_NAME\}\}/g, this.escapeHtml(namespaceContext.clusterName));
@@ -332,16 +345,20 @@ export class NamespaceWebview {
             if (namespaceContext.namespace) {
                 htmlContent = htmlContent.replace(/\{\{NAMESPACE_NAME\}\}/g, this.escapeHtml(namespaceContext.namespace));
                 htmlContent = htmlContent.replace(/\{\{IS_ALL_NAMESPACES\}\}/g, 'false');
+                htmlContent = htmlContent.replace(/\{\{NAMESPACE_ACTIONS_CLASS\}\}/g, '');
+                htmlContent = htmlContent.replace(/\{\{SCOPE_BADGE_TEXT\}\}/g, 'NAMESPACE');
             } else {
                 htmlContent = htmlContent.replace(/\{\{NAMESPACE_NAME\}\}/g, 'All Namespaces');
                 htmlContent = htmlContent.replace(/\{\{IS_ALL_NAMESPACES\}\}/g, 'true');
+                htmlContent = htmlContent.replace(
+                    /\{\{NAMESPACE_ACTIONS_CLASS\}\}/g,
+                    'namespace-header-actions--hidden'
+                );
+                htmlContent = htmlContent.replace(/\{\{SCOPE_BADGE_TEXT\}\}/g, 'CLUSTER-WIDE');
             }
             
             // Replace script URI placeholder
             htmlContent = htmlContent.replace(/\{\{SCRIPT_URI\}\}/g, scriptUri.toString());
-            
-            // Replace CSP source placeholder
-            htmlContent = htmlContent.replace(/\{\{CSP_SOURCE\}\}/g, webview.cspSource);
             
             return htmlContent;
         } catch (error) {

--- a/src/webview/main.js
+++ b/src/webview/main.js
@@ -8,28 +8,15 @@
 
     // Update UI based on whether this is "All Namespaces" view
     const isAllNamespaces = window.initialIsAllNamespaces || false;
-    
-    if (isAllNamespaces) {
-        const icon = document.getElementById('namespace-icon');
-        const badge = document.getElementById('scope-badge');
-        
-        if (icon) {
-            icon.classList.add('all-namespaces');
-        }
-        
-        if (badge) {
-            badge.textContent = 'CLUSTER-WIDE';
-        }
-    }
 
     // Set up message passing for communication with extension
     const vscode = acquireVsCodeApi();
 
     // Get button elements
     const setDefaultNamespaceButton = document.getElementById('set-default-namespace');
-    const btnIcon = setDefaultNamespaceButton?.querySelector('.btn-icon');
-    const btnText = setDefaultNamespaceButton?.querySelector('.btn-text');
-    const namespaceTitle = document.querySelector('h1.namespace-title');
+    const defaultIndicator = setDefaultNamespaceButton?.querySelector('.namespace-default-indicator');
+    const defaultActionLabel = setDefaultNamespaceButton?.querySelector('.webview-header-action-label');
+    const namespaceTitle = document.getElementById('namespace-header-title');
 
     /**
      * Update the button state based on whether the namespace is active.
@@ -38,7 +25,7 @@
      * @param {string} namespaceName - The namespace name (for validation/logging)
      */
     function updateButtonState(isActive, namespaceName) {
-        if (!setDefaultNamespaceButton || !btnIcon || !btnText) {
+        if (!setDefaultNamespaceButton || !defaultActionLabel) {
             console.warn('Button elements not found, cannot update state');
             return;
         }
@@ -46,15 +33,17 @@
         if (isActive) {
             // Namespace is active - show disabled/selected state
             setDefaultNamespaceButton.disabled = true;
-            btnIcon.style.display = 'inline';
-            btnIcon.classList.remove('hidden');
-            btnText.textContent = 'Default Namespace';
+            if (defaultIndicator) {
+                defaultIndicator.hidden = false;
+            }
+            defaultActionLabel.textContent = 'Default Namespace';
         } else {
             // Namespace is not active - show enabled state
             setDefaultNamespaceButton.disabled = false;
-            btnIcon.style.display = 'none';
-            btnIcon.classList.add('hidden');
-            btnText.textContent = 'Set as Default Namespace';
+            if (defaultIndicator) {
+                defaultIndicator.hidden = true;
+            }
+            defaultActionLabel.textContent = 'Set as Default Namespace';
         }
     }
 
@@ -459,17 +448,7 @@
     // For "All Namespaces" view, disable the button
     // For regular namespace view, start with disabled state (will be updated when first message arrives)
     if (isAllNamespaces) {
-        // Disable button for "All Namespaces" view
-        if (setDefaultNamespaceButton) {
-            setDefaultNamespaceButton.disabled = true;
-            if (btnIcon) {
-                btnIcon.style.display = 'none';
-                btnIcon.classList.add('hidden');
-            }
-            if (btnText) {
-                btnText.textContent = 'Set as Default Namespace';
-            }
-        }
+        // Primary actions are hidden in markup for cluster-wide view
     } else {
         // Initialize with inactive state (will be updated by first namespaceContextChanged message)
         const initialNamespaceName = namespaceTitle?.textContent?.trim();

--- a/src/webview/namespace.html
+++ b/src/webview/namespace.html
@@ -3,9 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src {{CSP_SOURCE}} 'unsafe-inline';">
+    <meta http-equiv="Content-Security-Policy" content="{{CSP}}">
+    {{HEADER_LINK}}
+    {{CODICONS_LINK}}
     <title>Namespace: {{NAMESPACE_NAME}}</title>
     <style>
+        /* Namespace explorer scrolls; override shipped header shell overflow defaults */
+        html, body {
+            overflow: auto;
+            height: auto;
+        }
+
         body {
             font-family: var(--vscode-font-family);
             font-size: var(--vscode-font-size);
@@ -21,34 +29,19 @@
             padding: 20px;
         }
 
-        .header {
-            border-bottom: 1px solid var(--vscode-panel-border);
-            padding-bottom: 20px;
-            margin-bottom: 30px;
-        }
-
-        .header h2 {
-            margin: 0 0 10px 0;
-            font-size: 24px;
-            font-weight: 600;
+        .namespace-metadata {
             display: flex;
             align-items: center;
-            gap: 10px;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 12px;
+            padding: 12px 16px;
+            border-bottom: 1px solid var(--vscode-panel-border);
+            margin-bottom: 24px;
         }
 
-        .icon {
-            display: inline-block;
-            width: 24px;
-            height: 24px;
-            background-color: var(--vscode-symbolIcon-namespaceForeground);
-            mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle cx="8" cy="8" r="6" fill="currentColor"/></svg>');
-            -webkit-mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle cx="8" cy="8" r="6" fill="currentColor"/></svg>');
-        }
-
-        .icon.all-namespaces {
-            background-color: var(--vscode-symbolIcon-classForeground);
-            mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7" stroke="currentColor" fill="none" stroke-width="1.5"/><circle cx="8" cy="8" r="1.5" fill="currentColor"/></svg>');
-            -webkit-mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7" stroke="currentColor" fill="none" stroke-width="1.5"/><circle cx="8" cy="8" r="1.5" fill="currentColor"/></svg>');
+        .namespace-header-actions--hidden {
+            display: none !important;
         }
 
         .metadata {
@@ -110,74 +103,12 @@
             letter-spacing: 0.5px;
         }
 
-        .namespace-header {
-            display: flex;
-            align-items: center;
-            gap: 15px;
-            padding: 15px;
-            background-color: var(--vscode-editor-background);
-            border-bottom: 2px solid var(--vscode-panel-border);
-        }
-
-        .namespace-title {
-            flex: 1;
-            margin: 0;
-            font-size: 1.5em;
-            font-weight: 600;
-            color: var(--vscode-foreground);
-        }
-
-        .default-namespace-btn {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            padding: 8px 16px;
-            background-color: var(--vscode-button-background);
-            color: var(--vscode-button-foreground);
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 0.95em;
-        }
-
-        .default-namespace-btn:hover:not(:disabled) {
-            background-color: var(--vscode-button-hoverBackground);
-        }
-
-        .default-namespace-btn:disabled {
-            background-color: var(--vscode-button-secondaryBackground);
-            color: var(--vscode-button-secondaryForeground);
-            cursor: default;
-            opacity: 0.8;
-        }
-
-        .default-namespace-btn .btn-icon {
-            font-size: 1.1em;
-        }
-
-        .default-namespace-btn:not(:disabled) .btn-icon {
+        #set-default-namespace .namespace-default-indicator[hidden] {
             display: none;
         }
 
-        .view-yaml-btn {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            padding: 8px 16px;
-            background-color: var(--vscode-button-secondaryBackground);
-            color: var(--vscode-button-secondaryForeground);
-            border: 1px solid var(--vscode-button-border);
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 0.95em;
-        }
-
-        .view-yaml-btn:hover {
-            background-color: var(--vscode-button-secondaryHoverBackground);
-        }
-
-        .view-yaml-btn .btn-icon {
-            font-size: 1.1em;
+        #set-default-namespace .namespace-default-indicator:not([hidden]) {
+            display: inline-flex;
         }
 
         /* Notification banner styles */
@@ -402,24 +333,23 @@
     </div>
 
     <div class="container">
-        <div class="namespace-header">
-            <h1 class="namespace-title">{{NAMESPACE_NAME}}</h1>
-            <button id="view-namespace-yaml" class="view-yaml-btn" data-namespace="{{NAMESPACE_NAME}}">
-                <span class="btn-icon">📄</span>
-                <span class="btn-text">View YAML</span>
-            </button>
-            <button id="set-default-namespace" class="default-namespace-btn">
-                <span class="btn-icon">✓</span>
-                <span class="btn-text">Set as Default Namespace</span>
-            </button>
-        </div>
+        <header class="webview-header namespace-explorer-header">
+            <div class="webview-header-title">
+                <h1 id="namespace-header-title">{{NAMESPACE_NAME}}</h1>
+            </div>
+            <div class="webview-header-actions {{NAMESPACE_ACTIONS_CLASS}}">
+                <button type="button" id="view-namespace-yaml" class="webview-header-action-btn" aria-label="View YAML" data-namespace="{{NAMESPACE_NAME}}">
+                    <span class="codicon codicon-file-code" aria-hidden="true"></span>
+                    <span class="webview-header-action-label">View YAML</span>
+                </button>
+                <button type="button" id="set-default-namespace" class="webview-header-action-btn" aria-label="Set as Default Namespace">
+                    <span class="codicon codicon-check namespace-default-indicator" aria-hidden="true" hidden></span>
+                    <span class="webview-header-action-label">Set as Default Namespace</span>
+                </button>
+            </div>
+        </header>
 
-        <div class="header">
-            <h2>
-                <span class="icon" id="namespace-icon"></span>
-                <span id="namespace-title">{{NAMESPACE_NAME}}</span>
-                <span class="badge" id="scope-badge">NAMESPACE</span>
-            </h2>
+        <div class="namespace-metadata">
             <div class="metadata">
                 <div class="metadata-item">
                     <span class="metadata-label">Cluster:</span>
@@ -430,6 +360,7 @@
                     <span>{{CONTEXT_NAME}}</span>
                 </div>
             </div>
+            <span class="badge" id="scope-badge">{{SCOPE_BADGE_TEXT}}</span>
         </div>
 
         <div class="workloads-section">


### PR DESCRIPTION
## Summary

- Migrates the legacy Namespace explorer (`namespace.html` / `NamespaceWebview.ts` / `main.js`) to the shared `webview-header` contract with shipped `media/styles/webview-header.css` and codicons in the VSIX.
- Removes duplicate in-webview title bands; namespace name (or **All Namespaces**) appears once in the header; cluster/context/scope badge live in a metadata row below.
- Preserves View YAML, Set as Default Namespace, and All Namespaces behavior (primary actions hidden for cluster-wide view).

Closes #199

## Test plan

- [x] `npm run lint`
- [x] `npm run test:unit`
- [ ] Packaged VSIX manual sign-off (Part B) — run after merge of dependent M15 surface PRs when validating the full milestone bar

### M15 visual acceptance (Part B — packaged VSIX)

Record **Pass/Fail** after `npm run package` → install VSIX. Dependent surface issues (#195–#198) should be merged before claiming full milestone pass.

| Panel | How to open | Pass criteria | Result |
|-------|-------------|---------------|--------|
| Helm Package Manager | Tree / command | Title left; Help only in header | _pending_ |
| Argo CD Application | Open app from tree | Primary cap; sub-header + graph toolbar below header | _pending_ |
| Events Viewer | Events command | Primary cap; sub-header Export/Search | _pending_ |
| Pod describe | Pod → Describe | `Pod / {name}`; Refresh + View YAML | _pending_ |
| **Namespace explorer** | Namespace → Open | Name only in header; metadata below; YAML + Set Default | _pending QA_ |
| Legacy workload describe | e.g. Deployment describe | Shared header shell; themed actions | _pending_ |

**Cross-cutting:** themed `--vscode-button-*` actions; no duplicate title bands on Namespace explorer; no Help on Namespace explorer.