### PR TITLE
fix(kubernetes): use strategic merge PATCH for workload mutations (#217)

### DIFF
--- a/src/commands/applyYAML.ts
+++ b/src/commands/applyYAML.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs/promises';
 import { KubectlError } from '../kubernetes/KubectlError';
 import { getContextInfo } from '../utils/kubectlContext';
 import { getKubernetesApiClient } from '../kubernetes/apiClient';
+import { strategicMergePatch } from '../kubernetes/strategicMergePatch';
 import * as yaml from 'js-yaml';
 import * as k8s from '@kubernetes/client-node';
 
@@ -12,6 +13,14 @@ export interface ApplyYAMLResult {
   success: boolean;
   output: string;
   resourcesAffected: string[];
+}
+
+async function patchExistingResource(
+    resource: Record<string, unknown>,
+    contextName: string,
+    dryRun?: string
+): Promise<void> {
+    await strategicMergePatch(resource as k8s.KubernetesObject, contextName, dryRun);
 }
 
 /**
@@ -59,12 +68,7 @@ async function applyResource(
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
                         // Resource exists, use strategic merge patch
-                        await apiClient.core.patchNamespacedPod({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -80,12 +84,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.core.patchNamespacedService({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -101,12 +100,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.core.patchNamespacedConfigMap({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -122,12 +116,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.core.patchNamespacedSecret({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -143,12 +132,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.apps.patchNamespacedDeployment({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -164,12 +148,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.apps.patchNamespacedStatefulSet({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -185,12 +164,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.apps.patchNamespacedDaemonSet({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -206,12 +180,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.apps.patchNamespacedReplicaSet({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -227,12 +196,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.batch.patchNamespacedJob({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -248,12 +212,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.batch.patchNamespacedCronJob({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -269,12 +228,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.core.patchNamespacedPersistentVolumeClaim({
-                            name,
-                            namespace,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -297,11 +251,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.core.patchNamespace({
-                            name,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -316,11 +266,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.core.patchPersistentVolume({
-                            name,
-                            body: resource,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;
@@ -335,11 +281,7 @@ async function applyResource(
                 } catch (error: unknown) {
                     const apiError = error as { statusCode?: number };
                     if (apiError.statusCode === 409) {
-                        await apiClient.storage.patchStorageClass({
-                            name,
-                            body: resource as unknown as k8s.V1StorageClass,
-                            dryRun
-                        });
+                        await patchExistingResource(resource, contextName, dryRun);
                         return mode !== 'apply' ? `${kind}/${name} validated (dry-run)` : `${kind}/${name} configured`;
                     }
                     throw error;

--- a/src/commands/restartWorkload.ts
+++ b/src/commands/restartWorkload.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import { KubectlError } from '../kubernetes/KubectlError';
 import { getKubernetesApiClient } from '../kubernetes/apiClient';
+import { strategicMergePatch } from '../kubernetes/strategicMergePatch';
+import * as k8s from '@kubernetes/client-node';
 
 
 /**
@@ -85,10 +87,6 @@ export async function applyRestartAnnotation(
     // Create annotation key
     const annotationKey = 'kubectl.kubernetes.io/restartedAt';
     
-    // Set context on API client
-    const apiClient = getKubernetesApiClient();
-    apiClient.setContext(contextName);
-    
     // Use strategic merge patch - this automatically creates nested objects if they don't exist
     // and merges the annotation into existing annotations
     const mergePatch = {
@@ -104,37 +102,21 @@ export async function applyRestartAnnotation(
     };
     
     try {
-        // Route to appropriate patch method based on workload type
         if (!namespace) {
             throw new Error('Workload resources must have a namespace');
         }
-        
-        switch (kind) {
-            case 'Deployment':
-                await apiClient.apps.patchNamespacedDeployment({
-                    name,
-                    namespace,
-                    body: mergePatch
-                });
-                break;
-            case 'StatefulSet':
-                await apiClient.apps.patchNamespacedStatefulSet({
-                    name,
-                    namespace,
-                    body: mergePatch
-                });
-                break;
-            case 'DaemonSet':
-                await apiClient.apps.patchNamespacedDaemonSet({
-                    name,
-                    namespace,
-                    body: mergePatch
-                });
-                break;
-            default:
-                throw new Error(`Unsupported workload kind: ${kind}`);
+
+        if (kind !== 'Deployment' && kind !== 'StatefulSet' && kind !== 'DaemonSet') {
+            throw new Error(`Unsupported workload kind: ${kind}`);
         }
-        
+
+        await strategicMergePatch({
+            apiVersion: 'apps/v1',
+            kind,
+            metadata: { name, namespace },
+            ...mergePatch
+        } as k8s.KubernetesObject, contextName);
+
         console.log(`Successfully applied restart annotation to ${kind}/${name}`);
     } catch (error: unknown) {
         // Convert execution error to structured KubectlError

--- a/src/kubectl/WorkloadCommands.ts
+++ b/src/kubectl/WorkloadCommands.ts
@@ -6,6 +6,7 @@ import { WorkloadEntry, WorkloadHealth } from '../types/workloadData';
 import { fetchPods, fetchDeployments } from '../kubernetes/resourceFetchers';
 import { getResourceCache, CACHE_TTL } from '../kubernetes/cache';
 import { getKubernetesApiClient } from '../kubernetes/apiClient';
+import { strategicMergePatch } from '../kubernetes/strategicMergePatch';
 
 /**
  * Timeout for kubectl commands in milliseconds.
@@ -2172,39 +2173,12 @@ export class WorkloadCommands {
         replicas: number
     ): Promise<ScaleResult> {
         try {
-            // Set context on API client
-            const apiClient = getKubernetesApiClient();
-            apiClient.setContext(contextName);
-            
-            // Prepare patch body with replicas update
-            const patchBody = {
-                spec: {
-                    replicas: replicas
-                }
-            };
-            
-            // Use appropriate API based on workload kind
-            if (kind === 'Deployment') {
-                await apiClient.apps.patchNamespacedDeployment({
-                    name,
-                    namespace,
-                    body: patchBody
-                });
-            } else if (kind === 'StatefulSet') {
-                await apiClient.apps.patchNamespacedStatefulSet({
-                    name,
-                    namespace,
-                    body: patchBody
-                });
-            } else if (kind === 'ReplicaSet') {
-                await apiClient.apps.patchNamespacedReplicaSet({
-                    name,
-                    namespace,
-                    body: patchBody
-                });
-            } else {
-                throw new Error(`Unsupported workload kind: ${kind}`);
-            }
+            await strategicMergePatch({
+                apiVersion: 'apps/v1',
+                kind,
+                metadata: { name, namespace },
+                spec: { replicas }
+            } as k8s.KubernetesObject, contextName);
 
             // Scale operation succeeded
             return { success: true };

--- a/src/kubernetes/strategicMergePatch.ts
+++ b/src/kubernetes/strategicMergePatch.ts
@@ -1,0 +1,25 @@
+import * as k8s from '@kubernetes/client-node';
+import { getKubernetesApiClient } from './apiClient';
+
+/**
+ * Applies a strategic merge patch to a Kubernetes resource.
+ * Uses KubernetesObjectApi so Content-Type is application/strategic-merge-patch+json,
+ * unlike generated patchNamespaced* methods that send application/json-patch+json.
+ */
+export async function strategicMergePatch<T extends k8s.KubernetesObject>(
+    resource: k8s.KubernetesObject,
+    contextName: string,
+    dryRun?: string
+): Promise<T> {
+    const apiClient = getKubernetesApiClient();
+    apiClient.setContext(contextName);
+    const objectApi = k8s.KubernetesObjectApi.makeApiClient(apiClient.getKubeConfig());
+    return objectApi.patch(
+        resource,
+        undefined,
+        dryRun,
+        undefined,
+        undefined,
+        k8s.PatchStrategy.StrategicMergePatch
+    ) as Promise<T>;
+}

--- a/src/test/suite/commands/applyYAML.test.ts
+++ b/src/test/suite/commands/applyYAML.test.ts
@@ -16,11 +16,9 @@ let isProxyActive = false;
 
 // Track API client calls
 let createPodCalls: Array<{ namespace: string; body: unknown }> = [];
-let patchPodCalls: Array<{ name: string; namespace: string; body: unknown }> = [];
 let createServiceCalls: Array<{ namespace: string; body: unknown }> = [];
-let patchServiceCalls: Array<{ name: string; namespace: string; body: unknown }> = [];
 let createDeploymentCalls: Array<{ namespace: string; body: unknown }> = [];
-let patchDeploymentCalls: Array<{ name: string; namespace: string; body: unknown }> = [];
+let strategicMergePatchCalls: Array<{ resource: k8s.KubernetesObject; contextName: string; dryRun?: string }> = [];
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let mockApiResponse: { type: 'success'; resource?: unknown } | { type: 'error'; error: unknown } | null = null;
 
@@ -67,11 +65,9 @@ suite('applyYAML Command Tests', () => {
         
         // Reset API client call tracking
         createPodCalls = [];
-        patchPodCalls = [];
+        strategicMergePatchCalls = [];
         createServiceCalls = [];
-        patchServiceCalls = [];
         createDeploymentCalls = [];
-        patchDeploymentCalls = [];
         mockApiResponse = null;
         
         // Reset and mock API client
@@ -94,13 +90,6 @@ suite('applyYAML Command Tests', () => {
                 }
                 return { metadata: { name: 'test-pod', namespace: options.namespace } } as k8s.V1Pod;
             },
-            patchNamespacedPod: async (options: { name: string; namespace: string; body: unknown }) => {
-                patchPodCalls.push(options);
-                if (mockApiResponse && mockApiResponse.type === 'error') {
-                    throw mockApiResponse.error;
-                }
-                return { metadata: { name: options.name, namespace: options.namespace } } as k8s.V1Pod;
-            },
             createNamespacedService: async (options: { namespace: string; body: unknown }) => {
                 createServiceCalls.push(options);
                 if (mockApiResponse && mockApiResponse.type === 'error') {
@@ -112,13 +101,6 @@ suite('applyYAML Command Tests', () => {
                 }
                 return { metadata: { name: 'test-service', namespace: options.namespace } } as k8s.V1Service;
             },
-            patchNamespacedService: async (options: { name: string; namespace: string; body: unknown }) => {
-                patchServiceCalls.push(options);
-                if (mockApiResponse && mockApiResponse.type === 'error') {
-                    throw mockApiResponse.error;
-                }
-                return { metadata: { name: options.name, namespace: options.namespace } } as k8s.V1Service;
-            },
             createNamespacedConfigMap: async (options: { namespace: string; body: unknown }) => {
                 if (mockApiResponse && mockApiResponse.type === 'error') {
                     const apiError = mockApiResponse.error as { statusCode?: number };
@@ -129,12 +111,6 @@ suite('applyYAML Command Tests', () => {
                 }
                 return { metadata: { name: 'test-configmap', namespace: options.namespace } } as k8s.V1ConfigMap;
             },
-            patchNamespacedConfigMap: async (options: { name: string; namespace: string; body: unknown }) => {
-                if (mockApiResponse && mockApiResponse.type === 'error') {
-                    throw mockApiResponse.error;
-                }
-                return { metadata: { name: options.name, namespace: options.namespace } } as k8s.V1ConfigMap;
-            },
             createNamespacedSecret: async (options: { namespace: string; body: unknown }) => {
                 if (mockApiResponse && mockApiResponse.type === 'error') {
                     const apiError = mockApiResponse.error as { statusCode?: number };
@@ -144,12 +120,6 @@ suite('applyYAML Command Tests', () => {
                     throw mockApiResponse.error;
                 }
                 return { metadata: { name: 'test-secret', namespace: options.namespace } } as k8s.V1Secret;
-            },
-            patchNamespacedSecret: async (options: { name: string; namespace: string; body: unknown }) => {
-                if (mockApiResponse && mockApiResponse.type === 'error') {
-                    throw mockApiResponse.error;
-                }
-                return { metadata: { name: options.name, namespace: options.namespace } } as k8s.V1Secret;
             }
         };
         
@@ -165,13 +135,6 @@ suite('applyYAML Command Tests', () => {
                     throw mockApiResponse.error;
                 }
                 return { metadata: { name: 'test-deployment', namespace: options.namespace } } as k8s.V1Deployment;
-            },
-            patchNamespacedDeployment: async (options: { name: string; namespace: string; body: unknown }) => {
-                patchDeploymentCalls.push(options);
-                if (mockApiResponse && mockApiResponse.type === 'error') {
-                    throw mockApiResponse.error;
-                }
-                return { metadata: { name: options.name, namespace: options.namespace } } as k8s.V1Deployment;
             }
         };
         
@@ -354,6 +317,22 @@ suite('applyYAML Command Tests', () => {
         (vscode.window as any)._clearMessages();
 
         // Clear module cache to force reload with mocked execFile AND mocked window
+        const strategicMergePatchPath = require.resolve('../../../kubernetes/strategicMergePatch');
+        delete require.cache[strategicMergePatchPath];
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+        const strategicMergePatchModule = require('../../../kubernetes/strategicMergePatch');
+        strategicMergePatchModule.strategicMergePatch = async (
+            resource: k8s.KubernetesObject,
+            contextName: string,
+            dryRun?: string
+        ) => {
+            strategicMergePatchCalls.push({ resource, contextName, dryRun });
+            if (mockApiResponse && mockApiResponse.type === 'error') {
+                throw mockApiResponse.error;
+            }
+            return resource;
+        };
+
         const applyYAMLPath = require.resolve('../../../commands/applyYAML');
         delete require.cache[applyYAMLPath];
         
@@ -459,7 +438,7 @@ suite('applyYAML Command Tests', () => {
             // Should show quick pick for mode selection
             assert.strictEqual(quickPickCalls.length, 1, 'Should show quick pick for mode selection');
             // Should call API to create deployment
-            assert.ok(createDeploymentCalls.length > 0 || patchDeploymentCalls.length > 0, 'Should call API to create or patch deployment');
+            assert.ok(createDeploymentCalls.length > 0 || strategicMergePatchCalls.length > 0, 'Should call API to create or patch deployment');
         });
 
         test('uses active editor when no URI and YAML file open', async () => {
@@ -487,7 +466,7 @@ suite('applyYAML Command Tests', () => {
             // Should not show file picker
             assert.strictEqual(openDialogCalls.length, 0, 'Should not show file picker when YAML file is open');
             // Should call API to create service
-            assert.ok(createServiceCalls.length > 0 || patchServiceCalls.length > 0, 'Should call API to create or patch service');
+            assert.ok(createServiceCalls.length > 0 || strategicMergePatchCalls.length > 0, 'Should call API to create or patch service');
         });
 
         test('shows file picker when no URI and no YAML file', async () => {
@@ -507,7 +486,7 @@ suite('applyYAML Command Tests', () => {
             assert.strictEqual(openDialogCalls.length, 1, 'Should show file picker when no URI and no YAML file');
             assert.deepStrictEqual(openDialogCalls[0].filters?.['YAML files'], ['yaml', 'yml'], 'Should filter for YAML files');
             // Should call API (checking for Pod creation since the YAML is for a Pod)
-            assert.ok(createPodCalls.length > 0 || patchPodCalls.length > 0, 'Should call API');
+            assert.ok(createPodCalls.length > 0 || strategicMergePatchCalls.length > 0, 'Should call API');
         });
 
         test('cancels when file picker dismissed', async () => {
@@ -566,7 +545,7 @@ suite('applyYAML Command Tests', () => {
             await applyYAMLCommand(testUri);
 
             // Should call API to create deployment (apply mode)
-            assert.ok(createDeploymentCalls.length > 0 || patchDeploymentCalls.length > 0, 'Should call API to create or patch deployment');
+            assert.ok(createDeploymentCalls.length > 0 || strategicMergePatchCalls.length > 0, 'Should call API to create or patch deployment');
         });
 
         test('executes with --dry-run=server for server mode', async () => {

--- a/src/test/suite/commands/restartWorkload.test.ts
+++ b/src/test/suite/commands/restartWorkload.test.ts
@@ -25,10 +25,9 @@ let mockTreeProviderRefreshCalled = false;
 let mockNamespaceWebviewRefreshCalled = false;
 let mockNamespaceWebviewRefreshNamespace: string | undefined = undefined;
 
-// Track API client calls
-let patchDeploymentCalls: Array<{ name: string; namespace: string; body: unknown }> = [];
-let patchStatefulSetCalls: Array<{ name: string; namespace: string; body: unknown }> = [];
-let patchDaemonSetCalls: Array<{ name: string; namespace: string; body: unknown }> = [];
+// Track strategic merge patch calls
+let strategicMergePatchCalls: Array<{ resource: k8s.KubernetesObject; contextName: string }> = [];
+let strategicMergePatchError: unknown = null;
 let readDeploymentCalls: Array<{ name: string; namespace: string }> = [];
 let readStatefulSetCalls: Array<{ name: string; namespace: string }> = [];
 let readDaemonSetCalls: Array<{ name: string; namespace: string }> = [];
@@ -66,10 +65,9 @@ suite('restartWorkload Command Tests', () => {
         mockNamespaceWebviewRefreshNamespace = undefined;
         mockExecFileResponse = null;
         
-        // Reset API client call tracking
-        patchDeploymentCalls = [];
-        patchStatefulSetCalls = [];
-        patchDaemonSetCalls = [];
+        // Reset strategic merge patch call tracking
+        strategicMergePatchCalls = [];
+        strategicMergePatchError = null;
         readDeploymentCalls = [];
         readStatefulSetCalls = [];
         readDaemonSetCalls = [];
@@ -82,42 +80,6 @@ suite('restartWorkload Command Tests', () => {
         
         // Create mock Apps API
         mockAppsApi = {
-            patchNamespacedDeployment: async (options: { name: string; namespace: string; body: unknown }) => {
-                patchDeploymentCalls.push(options);
-                if (mockApiResponse && !Array.isArray(mockApiResponse)) {
-                    if (mockApiResponse.type === 'error') {
-                        throw mockApiResponse.error;
-                    }
-                    if (mockApiResponse.type === 'success' && mockApiResponse.resource) {
-                        return mockApiResponse.resource as k8s.V1Deployment;
-                    }
-                }
-                return { metadata: { name: options.name, namespace: options.namespace } } as k8s.V1Deployment;
-            },
-            patchNamespacedStatefulSet: async (options: { name: string; namespace: string; body: unknown }) => {
-                patchStatefulSetCalls.push(options);
-                if (mockApiResponse && !Array.isArray(mockApiResponse)) {
-                    if (mockApiResponse.type === 'error') {
-                        throw mockApiResponse.error;
-                    }
-                    if (mockApiResponse.type === 'success' && mockApiResponse.resource) {
-                        return mockApiResponse.resource as k8s.V1StatefulSet;
-                    }
-                }
-                return { metadata: { name: options.name, namespace: options.namespace } } as k8s.V1StatefulSet;
-            },
-            patchNamespacedDaemonSet: async (options: { name: string; namespace: string; body: unknown }) => {
-                patchDaemonSetCalls.push(options);
-                if (mockApiResponse && !Array.isArray(mockApiResponse)) {
-                    if (mockApiResponse.type === 'error') {
-                        throw mockApiResponse.error;
-                    }
-                    if (mockApiResponse.type === 'success' && mockApiResponse.resource) {
-                        return mockApiResponse.resource as k8s.V1DaemonSet;
-                    }
-                }
-                return { metadata: { name: options.name, namespace: options.namespace } } as k8s.V1DaemonSet;
-            },
             readNamespacedDeployment: async (options: { name: string; namespace: string }) => {
                 readDeploymentCalls.push(options);
                 // Support sequential responses for rollout watch tests
@@ -368,6 +330,21 @@ suite('restartWorkload Command Tests', () => {
         (vscode.window as any)._clearMessages();
 
         // Clear module cache for restartWorkload to ensure it uses mocked execFile
+        const strategicMergePatchPath = require.resolve('../../../kubernetes/strategicMergePatch');
+        delete require.cache[strategicMergePatchPath];
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+        const strategicMergePatchModule = require('../../../kubernetes/strategicMergePatch');
+        strategicMergePatchModule.strategicMergePatch = async (
+            resource: k8s.KubernetesObject,
+            contextName: string
+        ) => {
+            strategicMergePatchCalls.push({ resource, contextName });
+            if (strategicMergePatchError) {
+                throw strategicMergePatchError;
+            }
+            return resource;
+        };
+
         const restartWorkloadPath = require.resolve('../../../commands/restartWorkload');
         delete require.cache[restartWorkloadPath];
         
@@ -432,6 +409,7 @@ suite('restartWorkload Command Tests', () => {
      */
     function mockApiSuccess(resource?: unknown): void {
         mockApiResponse = { type: 'success', resource };
+        strategicMergePatchError = null;
     }
     
     /**
@@ -439,6 +417,7 @@ suite('restartWorkload Command Tests', () => {
      */
     function mockApiError(error: unknown): void {
         mockApiResponse = { type: 'error', error };
+        strategicMergePatchError = error;
     }
     
     /**
@@ -555,12 +534,13 @@ suite('restartWorkload Command Tests', () => {
                 '/test/kubeconfig'
             );
 
-            assert.strictEqual(patchDeploymentCalls.length, 1, 'Should call patchNamespacedDeployment');
-            const call = patchDeploymentCalls[0];
-            assert.strictEqual(call.name, 'my-deployment', 'Should include resource name');
-            assert.strictEqual(call.namespace, 'default', 'Should include namespace');
-            assert.ok(call.body, 'Should have patch body');
-            const patchBody = call.body as { spec?: { template?: { metadata?: { annotations?: Record<string, string> } } } };
+            assert.strictEqual(strategicMergePatchCalls.length, 1, 'Should call strategicMergePatch');
+            const call = strategicMergePatchCalls[0];
+            assert.strictEqual(call.resource.metadata?.name, 'my-deployment', 'Should include resource name');
+            assert.strictEqual(call.resource.metadata?.namespace, 'default', 'Should include namespace');
+            assert.strictEqual(call.resource.apiVersion, 'apps/v1', 'Should include apiVersion');
+            assert.strictEqual(call.resource.kind, 'Deployment', 'Should include kind');
+            const patchBody = call.resource as { spec?: { template?: { metadata?: { annotations?: Record<string, string> } } } };
             assert.ok(patchBody.spec?.template?.metadata?.annotations, 'Should have annotations in patch');
             assert.ok(patchBody.spec.template.metadata.annotations!['kubectl.kubernetes.io/restartedAt'], 'Should have restart annotation');
             assert.ok(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(patchBody.spec.template.metadata.annotations!['kubectl.kubernetes.io/restartedAt']!), 'Should have ISO 8601 timestamp');
@@ -602,11 +582,11 @@ suite('restartWorkload Command Tests', () => {
             );
 
             // Should only make one patch call (merge patch handles missing annotations)
-            assert.strictEqual(patchDeploymentCalls.length, 1, 'Should make single patch call');
-            const call = patchDeploymentCalls[0];
+            assert.strictEqual(strategicMergePatchCalls.length, 1, 'Should make single patch call');
+            const call = strategicMergePatchCalls[0];
             
             // Verify patch structure includes nested path to annotations
-            const patchBody = call.body as { spec?: { template?: { metadata?: { annotations?: Record<string, string> } } } };
+            const patchBody = call.resource as { spec?: { template?: { metadata?: { annotations?: Record<string, string> } } } };
             assert.ok(patchBody.spec?.template?.metadata?.annotations, 'Should have full nested structure in patch');
         });
 
@@ -623,8 +603,8 @@ suite('restartWorkload Command Tests', () => {
             );
 
             const afterTime = new Date().toISOString();
-            const call = patchDeploymentCalls[0];
-            const patchBody = call.body as { spec?: { template?: { metadata?: { annotations?: Record<string, string> } } } };
+            const call = strategicMergePatchCalls[0];
+            const patchBody = call.resource as { spec?: { template?: { metadata?: { annotations?: Record<string, string> } } } };
             const timestamp = patchBody.spec?.template?.metadata?.annotations?.['kubectl.kubernetes.io/restartedAt'];
             
             assert.ok(timestamp, 'Should have timestamp');
@@ -646,10 +626,11 @@ suite('restartWorkload Command Tests', () => {
                 '/test/kubeconfig'
             );
 
-            assert.strictEqual(patchStatefulSetCalls.length, 1, 'Should call patchNamespacedStatefulSet');
-            const call = patchStatefulSetCalls[0];
-            assert.strictEqual(call.name, 'my-statefulset', 'Should include resource name');
-            assert.strictEqual(call.namespace, 'default', 'Should include namespace');
+            assert.strictEqual(strategicMergePatchCalls.length, 1, 'Should call strategicMergePatch');
+            const call = strategicMergePatchCalls[0];
+            assert.strictEqual(call.resource.metadata?.name, 'my-statefulset', 'Should include resource name');
+            assert.strictEqual(call.resource.metadata?.namespace, 'default', 'Should include namespace');
+            assert.strictEqual(call.resource.kind, 'StatefulSet', 'Should include kind');
         });
     });
 
@@ -665,10 +646,11 @@ suite('restartWorkload Command Tests', () => {
                 '/test/kubeconfig'
             );
 
-            assert.strictEqual(patchDaemonSetCalls.length, 1, 'Should call patchNamespacedDaemonSet');
-            const call = patchDaemonSetCalls[0];
-            assert.strictEqual(call.name, 'my-daemonset', 'Should include resource name');
-            assert.strictEqual(call.namespace, 'default', 'Should include namespace');
+            assert.strictEqual(strategicMergePatchCalls.length, 1, 'Should call strategicMergePatch');
+            const call = strategicMergePatchCalls[0];
+            assert.strictEqual(call.resource.metadata?.name, 'my-daemonset', 'Should include resource name');
+            assert.strictEqual(call.resource.metadata?.namespace, 'default', 'Should include namespace');
+            assert.strictEqual(call.resource.kind, 'DaemonSet', 'Should include kind');
         });
 
         test('extracts status using DaemonSet-specific fields', async () => {
@@ -909,7 +891,7 @@ suite('restartWorkload Command Tests', () => {
             }
             
             // Should only have patch call, no get status calls
-            assert.strictEqual(patchDeploymentCalls.length, 1, 'Should only call patchNamespacedDeployment');
+            assert.strictEqual(strategicMergePatchCalls.length, 1, 'Should only call strategicMergePatch');
             assert.strictEqual(readDeploymentCalls.length, 0, 'Should not call readNamespacedDeployment');
         });
 
@@ -1016,7 +998,7 @@ suite('restartWorkload Command Tests', () => {
             const confirmation = await restartWorkloadModule.showRestartConfirmationDialog('my-deployment');
             if (!confirmation) {
                 // Should return early, no API calls
-                assert.strictEqual(patchDeploymentCalls.length, 0, 'Should not call API when cancelled');
+                assert.strictEqual(strategicMergePatchCalls.length, 0, 'Should not call API when cancelled');
             }
         });
     });
@@ -1025,48 +1007,50 @@ suite('restartWorkload Command Tests', () => {
         test('updates annotation timestamp on multiple restarts', async () => {
             const timestamps: string[] = [];
             
-            // Override mock to capture timestamps
-            const originalPatch = mockAppsApi.patchNamespacedDeployment;
-            mockAppsApi.patchNamespacedDeployment = async (options: { name: string; namespace: string; body: unknown }) => {
-                patchDeploymentCalls.push(options);
-                const patchBody = options.body as { spec?: { template?: { metadata?: { annotations?: Record<string, string> } } } };
+            const strategicMergePatchPath = require.resolve('../../../kubernetes/strategicMergePatch');
+            delete require.cache[strategicMergePatchPath];
+            // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+            const strategicMergePatchModule = require('../../../kubernetes/strategicMergePatch');
+            strategicMergePatchModule.strategicMergePatch = async (resource: k8s.KubernetesObject, contextName: string) => {
+                strategicMergePatchCalls.push({ resource, contextName });
+                const patchBody = resource as { spec?: { template?: { metadata?: { annotations?: Record<string, string> } } } };
                 const timestamp = patchBody.spec?.template?.metadata?.annotations?.['kubectl.kubernetes.io/restartedAt'];
                 if (timestamp) {
                     timestamps.push(timestamp);
                 }
-                return { metadata: { name: options.name, namespace: options.namespace } } as k8s.V1Deployment;
+                return resource;
             };
+
+            const restartWorkloadPath = require.resolve('../../../commands/restartWorkload');
+            delete require.cache[restartWorkloadPath];
+            // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+            restartWorkloadModule = require('../../../commands/restartWorkload');
+
+            // First restart
+            await restartWorkloadModule.applyRestartAnnotation(
+                'my-deployment',
+                'default',
+                'Deployment',
+                'test-context',
+                '/test/kubeconfig'
+            );
             
-            try {
-                // First restart
-                await restartWorkloadModule.applyRestartAnnotation(
-                    'my-deployment',
-                    'default',
-                    'Deployment',
-                    'test-context',
-                    '/test/kubeconfig'
-                );
-                
-                // Wait a bit to ensure different timestamp
-                await new Promise(resolve => setTimeout(resolve, 10));
-                
-                // Second restart
-                await restartWorkloadModule.applyRestartAnnotation(
-                    'my-deployment',
-                    'default',
-                    'Deployment',
-                    'test-context',
-                    '/test/kubeconfig'
-                );
-                
-                // Should have two timestamps
-                assert.strictEqual(timestamps.length, 2, 'Should have two timestamps');
-                assert.notStrictEqual(timestamps[0], timestamps[1], 'Timestamps should be different');
-                assert.ok(timestamps[0] < timestamps[1], 'Second timestamp should be later');
-            } finally {
-                // Restore original mock
-                mockAppsApi.patchNamespacedDeployment = originalPatch;
-            }
+            // Wait a bit to ensure different timestamp
+            await new Promise(resolve => setTimeout(resolve, 10));
+            
+            // Second restart
+            await restartWorkloadModule.applyRestartAnnotation(
+                'my-deployment',
+                'default',
+                'Deployment',
+                'test-context',
+                '/test/kubeconfig'
+            );
+            
+            // Should have two timestamps
+            assert.strictEqual(timestamps.length, 2, 'Should have two timestamps');
+            assert.notStrictEqual(timestamps[0], timestamps[1], 'Timestamps should be different');
+            assert.ok(timestamps[0] < timestamps[1], 'Second timestamp should be later');
         });
     });
 

--- a/src/test/suite/kubernetes/strategicMergePatch.test.ts
+++ b/src/test/suite/kubernetes/strategicMergePatch.test.ts
@@ -1,0 +1,95 @@
+import * as assert from 'assert';
+import * as k8s from '@kubernetes/client-node';
+import { getKubernetesApiClient, resetKubernetesApiClient } from '../../../kubernetes/apiClient';
+
+interface PatchCall {
+    resource: k8s.KubernetesObject;
+    dryRun?: string;
+    patchStrategy?: k8s.PatchStrategy;
+}
+
+let patchCalls: PatchCall[] = [];
+const originalMakeApiClient = k8s.KubernetesObjectApi.makeApiClient;
+
+suite('strategicMergePatch', () => {
+    setup(() => {
+        patchCalls = [];
+        resetKubernetesApiClient();
+
+        k8s.KubernetesObjectApi.makeApiClient = (() => ({
+            patch: async (
+                spec: k8s.KubernetesObject,
+                _pretty?: string,
+                dryRun?: string,
+                _fieldManager?: string,
+                _force?: boolean,
+                patchStrategy?: k8s.PatchStrategy
+            ) => {
+                patchCalls.push({ resource: spec, dryRun, patchStrategy });
+                return spec;
+            }
+        })) as unknown as typeof k8s.KubernetesObjectApi.makeApiClient;
+
+        const apiClient = getKubernetesApiClient();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (apiClient as any).setContext = () => {
+            // strategicMergePatch calls setContext; no cluster needed in unit tests
+        };
+    });
+
+    teardown(() => {
+        k8s.KubernetesObjectApi.makeApiClient = originalMakeApiClient;
+        resetKubernetesApiClient();
+    });
+
+    test('uses StrategicMergePatch Content-Type strategy and merge object body', async () => {
+        const modulePath = require.resolve('../../../kubernetes/strategicMergePatch');
+        delete require.cache[modulePath];
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+        const { strategicMergePatch } = require('../../../kubernetes/strategicMergePatch');
+
+        const resource = {
+            apiVersion: 'apps/v1',
+            kind: 'Deployment',
+            metadata: { name: 'test-deploy', namespace: 'kube9-system' },
+            spec: {
+                template: {
+                    metadata: {
+                        annotations: {
+                            'kubectl.kubernetes.io/restartedAt': '2026-07-09T12:00:00.000Z'
+                        }
+                    }
+                }
+            }
+        } as k8s.KubernetesObject;
+
+        await strategicMergePatch(resource, 'test-context');
+
+        assert.strictEqual(patchCalls.length, 1, 'Should invoke KubernetesObjectApi.patch once');
+        assert.strictEqual(
+            patchCalls[0].patchStrategy,
+            k8s.PatchStrategy.StrategicMergePatch,
+            'Should use application/strategic-merge-patch+json'
+        );
+        assert.deepStrictEqual(patchCalls[0].resource, resource, 'Should send merge object body');
+    });
+
+    test('forwards dryRun query parameter', async () => {
+        const modulePath = require.resolve('../../../kubernetes/strategicMergePatch');
+        delete require.cache[modulePath];
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+        const { strategicMergePatch } = require('../../../kubernetes/strategicMergePatch');
+
+        const resource = {
+            apiVersion: 'apps/v1',
+            kind: 'Deployment',
+            metadata: { name: 'test-deploy', namespace: 'default' },
+            spec: { replicas: 3 }
+        } as k8s.KubernetesObject;
+
+        await strategicMergePatch(resource, 'test-context', 'All');
+
+        assert.strictEqual(patchCalls.length, 1);
+        assert.strictEqual(patchCalls[0].dryRun, 'All');
+    });
+});


### PR DESCRIPTION
## Description

Fixes HTTP 400 patch decode errors when restarting, scaling, or applying existing YAML resources. Generated `@kubernetes/client-node` 1.4.x `patchNamespaced*` methods send `application/json-patch+json` while callers supply strategic merge objects.

## Motivation and Context

Restarting Deployments (including from the Argo CD graph) failed with:

```
error decoding patch: json: cannot unmarshal object into Go value of type []handlers.jsonPatchOp
```

Fixes #217

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] All new and existing tests pass (`npm test:unit`)
- [x] Linter passes (`npm run lint`)

## Summary

- Add `src/kubernetes/strategicMergePatch.ts` using `KubernetesObjectApi.patch(..., PatchStrategy.StrategicMergePatch)`
- Route restart annotation, scale, and apply-YAML 409 conflict patches through the helper
- Add unit tests asserting `application/strategic-merge-patch+json` strategy and merge object body

## How to Test this Work

1. Connect to a cluster with a Deployment (e.g. `kube9-operator` in `kube9-system`).
2. Tree: right-click Deployment → **Restart** → confirm. Expect success toast and pod rollout.
3. Repeat with **Restart and Wait**; expect progress notification until replicas ready.
4. Restart StatefulSet and DaemonSet if present.
5. Argo CD: Application graph → Deployment overflow → **Restart rollout**.
6. Optional: scale a Deployment; apply YAML that already exists (409 path).