### PR TITLE
docs(ai): argocd diagram interface contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -54,7 +54,7 @@ Dependency accuracy follows a **tiered topology** model:
 ### Graph structure
 
 - The **root node** is always the Application itself.
-- **Child nodes** represent managed resources and reflect dependency topology (not a flat inventory table).
+- **Child nodes** represent every returned managed resource for the Application. When full topology is available they reflect dependency topology; when only CRD data is available they still render as complete managed-resource nodes with limited edge accuracy.
 - **Edges** express parent/child or dependency relationships between nodes; direction flows left to right in the layout.
 - Each node has a **stable identity** within an Application (kind, API group/version, namespace when namespaced, name) so status refreshes and in-flight operations can merge updates without reordering unrelated nodes.
 
@@ -90,6 +90,7 @@ The registry is extensible: new kinds add capability entries without changing th
 - Mutating actions (sync, restart rollout) require **explicit user intent** via menu or command invocation.
 - Actions target the **specific node** the user selected; they do not implicitly cascade to unrelated nodes unless the underlying operation naturally affects dependents (for example, sync at Application root).
 - Read-only or insufficient RBAC must block write actions while preserving read-only graph inspection where permitted.
+- **View In Tree** from a managed-resource graph node resolves that node's `ManagedResourceKey` to the existing Kubernetes tree navigation path when a tree item can be mapped. Failure to map a node is a navigation limitation, not permission to mutate or invent resource identity.
 
 ## Webview page-level actions
 
@@ -160,3 +161,13 @@ Rules below are the **kube9-vscode reference baseline** for built-in Kubernetes 
 7. Application-level sync, refresh, hard refresh, and view-in-tree flows remain available from the webview header/sub-header and Application root overflow; they are not replaced by the graph canvas toolbar.
 8. Graph presentation and actions must not require the user to leave VS Code or open the native Argo CD server UI.
 9. **Extension-local graph assembly** for the first delivery: the extension owns graph DTO assembly and refresh paths; kube9-operator does not supply resource-tree snapshots today and is **not** required for this capability set. A future operator-mediated snapshot may align later without changing Kind Capability Registry rules stated here.
+
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### ArgoCD diagram interface
+- Define how selected graph nodes visually distinguish focus, selection, and open overflow states without changing the selected resource action scope.
+- Decide whether unsupported or non-navigable resource nodes hide the overflow menu or show disabled explanatory entries.
+- Specify how progressive disclosure for very large Applications preserves access to every returned managed resource.
+- Align final action labels and disabled-state copy for Application root overflow versus managed-resource overflow menus.

--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -15,9 +15,12 @@
 - As a GitOps engineer, when **resource-tree** topology is unavailable, I still get a **limited topology** graph from Application CR data with clear indication that dependency edges may be incomplete.
 - As a GitOps engineer, I can read **sync status** and **health status** on every graph tile at a glance, using the same status semantics as elsewhere in the extension's ArgoCD surfaces.
 - As a GitOps engineer, I can pan and zoom the graph and fit the view so I can explore large applications without losing context.
+- As a GitOps engineer, I can see every returned managed resource for the Application represented in the graph experience, even when large-application grouping or limited topology affects how relationships are displayed.
+- As a GitOps engineer, I can select a graph resource tile and keep that selection across refreshes while the same resource still exists.
+- As a GitOps engineer, I can open a three-dot actions menu on each eligible resource tile and only see actions that are valid for that resource kind and permission state.
 - As a GitOps engineer, I can run **application-level sync, refresh, and hard refresh** from the Application root node using the same flows already available for ArgoCD applications.
 - As a GitOps engineer, I can **restart rollout** on a Deployment node from the graph when I need to recycle pods without leaving the application detail panel.
-- As a GitOps engineer, I can **navigate to a managed resource in the cluster tree** or open its describe/detail surface from graph nodes where the extension supports that kind.
+- As a GitOps engineer, I can use **View In Tree** or resource navigation from a selected graph node to reveal the corresponding Kubernetes tree resource where the extension can map that resource identity.
 - As a GitOps engineer, after I sync or refresh an application, the graph **updates in place** with refreshed sync and health on affected nodes without requiring me to close and reopen the panel.
 - As a GitOps engineer working on a large application, I can still use the graph when node count is high because the experience avoids unusable clutter through progressive disclosure or grouping rather than failing silently.
 

--- a/.ai/data/consistency.md
+++ b/.ai/data/consistency.md
@@ -86,3 +86,11 @@ While `operationState.phase` is `Running` or `Terminating`:
 - Avoid full graph object replacement when a shallow status patch on existing node ids suffices (same topology, same node set).
 - Cap layout recomputation: run dagre (or equivalent) on initial load, topology change, and explicit user re-layout — not on every 30s status tick.
 - Large applications: node count limits and grouping are presentation/runtime concerns; data layer still treats each included node as a distinct `GraphNodeId`.
+
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### ArgoCD large graph consistency
+- Specify how grouping or progressive disclosure preserves access to every returned `ArgoCDResource` while keeping `crd_flat` count checks meaningful.
+- Define the refresh behavior for selected nodes when grouping, expansion, or topology upgrades change the visible tile set.

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -120,7 +120,7 @@ The **Application resource graph** is a derived, directed view model for React F
 | `structureVersion` | string | Fingerprint that changes when the **set of node ids** or **edge endpoints** changes. Used with polling merge (see [consistency.md](./consistency.md)). Attribute-only sync/health updates do not bump it. |
 | `layoutHint` | optional object | Non-authoritative hints from the assembler (for example `{ "algorithm": "dagre-lr", "version": "1" }`). Webview ignores when `structureVersion` changes or may omit hints entirely. |
 | `observedAt` | ISO 8601 string | When this graph snapshot was assembled |
-| `truncated` | boolean (optional) | `true` when the host omitted managed nodes because the application exceeded the product node cap; Application root is always present. Omitted or `false` when the full managed set is included. |
+| `truncated` | boolean (optional) | `true` when the delivered graph is presentation-limited for a large application. The Application root is always present, and the interface must still preserve a path to every returned managed resource through grouping, expansion, Details, or tree navigation rather than silently losing resources. Omitted or `false` when the full managed set is directly visible. |
 
 ### ResourceGraphNode
 
@@ -202,7 +202,7 @@ ArgoCDApplication
 Rules:
 
 1. **`ArgoCDApplication.resources` remains the sync/health authority** for every managed resource that appears in `status.resources` when using CRD-only ingestion.
-2. In **`crd_flat`** mode, graph nodes for managed resources are in **1:1 correspondence** with `resources[]`; edges are only Application → resource (`manages`).
+2. In **`crd_flat`** mode, graph nodes for managed resources are in **1:1 correspondence** with `resources[]`; edges are only Application → resource (`manages`). If the UI groups or collapses nodes for large applications, that grouping is a presentation layer over the same returned resources, not a data-layer reduction.
 3. When a **topology source** adds nodes not present in `status.resources` (e.g. ReplicaSet from resource-tree), those nodes use status from the topology payload where available; sync/health may be partial or `Unknown` until reconciled with CRD rows sharing the same `ManagedResourceKey`.
 4. **Matching** a graph node to a flat-list row uses `ManagedResourceKey` equality, not display label or React Flow internal id.
 5. The flat list is **unordered**; graph layout order is computed (e.g. dagre) and is not stored in the Application CR.

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -69,16 +69,13 @@ The webview posts `{ "command": "refresh" }` for explicit refresh. The host hand
 
 Graph delivery should use **JSON-safe DTOs** derived from [data_model.md](./data_model.md), not live React Flow class instances.
 
-### Recommended payload shape
+### Canonical graph message
 
-Either extend the existing application message or add a dedicated graph message. Minimal contract:
-
-**Option A — bundled (preferred for single refresh tick):**
+The canonical host-to-webview graph update is `resourceGraph`. It may be emitted in the same refresh tick as `applicationData`, but it remains a graph-specific message so selection, layout, and action state can be merged independently.
 
 ```json
 {
-  "type": "applicationGraph",
-  "application": { "...": "ArgoCDApplication" },
+  "type": "resourceGraph",
   "graph": {
     "applicationKey": { "context": "...", "namespace": "...", "name": "..." },
     "nodes": [ "..." ],
@@ -94,10 +91,7 @@ Either extend the existing application message or add a dedicated graph message.
 
 `topologyMode`, `structureVersion`, and `layoutHint` follow [data_model.md](./data_model.md). Omit `layoutHint` when absent. Webviews MUST tolerate missing `structureVersion` (treat whole snapshot as structural) until producers always send it.
 
-**Option B — graph-only delta after initial load:**
-
-- Initial open: full `application` + `graph` as above.
-- Subsequent polls: `graph` with the same node ids where entities unchanged; webview merges status fields and layout.
+Initial open sends full `applicationData` plus full `resourceGraph`. Subsequent polls send complete `resourceGraph` snapshots with the same node ids where entities are unchanged; the webview merges status fields, selection, viewport, and layout.
 
 ### ResourceGraphNode JSON
 
@@ -116,7 +110,7 @@ Do not serialize React Flow internal fields (`position`, `data.measured`, handle
 
 ### Webview → extension (unchanged identifiers)
 
-Actions that target a resource continue to send `kind`, `name`, `namespace` (and add `apiGroup` only when product requires it). Graph node selection resolves to `ManagedResourceKey` before posting messages such as `navigateToResource`.
+Actions that target a resource continue to send `kind`, `name`, `namespace` (and add `apiGroup` only when product requires it). Graph node selection resolves to `ManagedResourceKey` before posting messages such as `navigateToResource` or `resourceAction`.
 
 ## Topology from non-CRD sources
 
@@ -134,3 +128,12 @@ Raw upstream JSON must not leak into the webview bundle; normalize in the extens
 - **`topologyMode`**, **`layoutHint`**, and **`structureVersion`** are additive; older webviews SHOULD ignore unknown fields and degrade merge behavior when `structureVersion` is absent.
 - Changing `GraphNodeId` derivation is **breaking** for layout cache merge; avoid without migration logic.
 - Webview should tolerate unknown `topologySource` values by rendering nodes and ignoring unrecognized edge semantics while still honoring `topologyMode` when present.
+
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### ArgoCD graph DTO details
+- Define the exact `structureVersion` derivation in implementation and tests without binding the contract to one hash function.
+- Decide when `apiGroup` / `group` is required for tree navigation and action routing, and update `ManagedResourceKey` parsing and serialization together.
+- Define whether large-application grouping is represented in the DTO as grouped nodes or remains an interface-only transform over complete resource nodes.

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -80,8 +80,8 @@ Native Argo CD UI resource graphs use this API; kube9-vscode targets **visual pa
 ### Topology and refresh merge
 
 - **Stable node id**: deterministic string from `(group/,)kind/namespace/name` (and Application root id from app metadata).
-- **Incremental refresh**: new `resourceGraph` messages merge by node id; layout cache is a data/runtime concern but graph payloads must be complete snapshots for the host→webview contract.
-- **Caps**: when node count exceeds product limit, host sets `truncated: true` and omits or collapses nodes per data contract; never silently drop Application root.
+- **Incremental refresh**: new `resourceGraph` messages merge by node id; layout cache is a data/runtime concern, and graph payloads are complete snapshots for the host-to-webview contract unless a future patch message is explicitly added.
+- **Caps**: when node count exceeds product limit, host sets `truncated: true` and groups or collapses visible nodes per data/interface contracts; never silently drop Application root or remove the user's path to a returned managed resource.
 
 ### Status semantics (integration boundary)
 
@@ -127,7 +127,7 @@ JSON messages over `webview.postMessage` / `onDidReceiveMessage`. Types are stri
 | `applicationData` | `data: ArgoCDApplication` | Full CRD parse (existing) |
 | `updateStatus` | `syncStatus`, `healthStatus` | Partial status update |
 | `operationProgress` | `phase`, `message?` | Application-level sync/refresh |
-| `resourceGraph` | `graph`, `topologySource`, `refreshedAt`, optional `truncated` | Graph snapshot for React Flow |
+| `resourceGraph` | `graph`, `topologySource`, `topologyMode`, `structureVersion`, `refreshedAt`, optional `truncated` | Complete graph snapshot for React Flow merge |
 | `resourceActionProgress` | `actionId`, `phase`, `message?`, optional node ref | Tile action in flight |
 | `resourceActionResult` | `actionId`, `success`, `message`, optional node ref | Tile action terminal state |
 | `error` | `message` | User-visible failure |
@@ -192,3 +192,12 @@ The report does not shell out beyond the existing operator status read path. It 
 | Resource-tree / owner-ref partial failure | `resourceGraph` with lower tier + optional banner in UI | Informational (implementation) |
 | Resource action denied | `resourceActionResult` success false | Error message |
 | Network / timeout on CRD get | `error` | Warning or error per severity |
+
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### ArgoCD resource graph integration
+- Define the final `resourceAction` payload shape for selected nodes, including whether both `group` and `apiGroup` appear or one canonical field is used across parser, tree reveal, and action routing.
+- Decide whether owner-reference topology enrichment belongs in the first implementation slice or remains a documented optional extension after CRD-flat completeness ships.
+- Specify the safe user-facing fallback message when optional resource-tree topology fails without exposing raw upstream errors, endpoints, or credentials.

--- a/.ai/integration/messaging_async.md
+++ b/.ai/integration/messaging_async.md
@@ -23,7 +23,7 @@ See [api_contracts.md](./api_contracts.md#argo-cd-application-webview-protocol) 
 | Direction | Type | Behavior |
 |-----------|------|----------|
 | Webview → host | `graphRefresh` | Host reloads Application CRD (and optional resource-tree / owner-ref pass), rebuilds graph DTO, posts `resourceGraph`. Optional `bypassCache` flag mirrors application list cache invalidation. |
-| Host → webview | `resourceGraph` | Pushes `ApplicationResourceGraph` plus `topologySource` and `refreshedAt` ISO timestamp. |
+| Host → webview | `resourceGraph` | Pushes `ApplicationResourceGraph` plus topology metadata, `structureVersion`, and `refreshedAt` ISO timestamp. |
 | Webview → host | `resourceAction` | Host runs registered action by `actionId` (see api_contracts). |
 | Host → webview | `resourceActionProgress`, `resourceActionResult` | Per-action progress and terminal outcome for tile menus. |
 

--- a/.ai/interface/accessibility.md
+++ b/.ai/interface/accessibility.md
@@ -53,3 +53,11 @@ Accessibility expectations for Kube9 VS Code **webview** surfaces, with emphasis
 - Verify badge/icon pairs have non-empty accessible names in high-contrast themes.
 - Graph changes should be reviewed for focus loss after polling updates (focus should remain on the current tile when possible).
 - AI Conformance report changes should include a keyboard pass through Refresh, category headings, expandable requirement rows, and high-contrast badge review.
+
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### ArgoCD diagram accessibility
+- Define the exact manual keyboard and high-contrast acceptance pass for selectable tiles, overflow menus, limited-topology hints, and View In Tree from a selected node.
+- Decide whether parent/child edge relationships need explicit accessible descriptions beyond tile names and Details table navigation.

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -46,6 +46,7 @@ The tree **does not** embed the graph; it continues to list applications with st
 
 - **Glance:** Read sync and health from each tile and from the Application root without opening menus.
 - **Topology:** Follow dashed edges from parent to dependent resources.
+- **Selection:** Activate a tile to select it. Selection scopes resource-aware actions and should persist across refresh when the same `GraphNodeId` survives.
 - **Deeper metadata or drift scan:** Switch to **Details** for overview sections and the filterable resource table (same navigate-to-tree behavior as the former drift tab).
 
 ### Operate from tiles and header
@@ -71,6 +72,15 @@ The tree **does not** embed the graph; it continues to list applications with st
 
 - Missing permissions, unreachable application, or empty resource set: show dedicated empty/error presentation on the graph or full-panel error (consistent with other webviews).
 - If topology cannot be built (integration provides a flat list only), graph still renders nodes with **no inferred edges** and surfaces a non-blocking hint that relationships are unavailable; **Details** drift table remains usable.
+
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### ArgoCD diagram interaction
+- Define exact click, keyboard activation, drag, pan, and overflow interactions so selection does not conflict with graph movement.
+- Specify final tile menu contents per initial Kind Capability entry and whether unsupported actions are hidden or disabled.
+- Add focused acceptance for View In Tree from selected managed-resource nodes, including the fallback when no tree item can be revealed.
 
 ## Kubernetes AI Conformance Flow
 

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -76,6 +76,7 @@ The cluster **tree list** for Argo CD Applications is unchanged: sync and health
 - **Edges:** Dependency relationships use **dashed** connectors distinct from node chrome so topology reads at a glance.
 - **Canvas toolbar:** A compact control strip on the graph viewport offers **zoom in**, **zoom out**, and **fit view** (re-center and scale to show all nodes). Pan is available on the canvas; toolbar actions are the primary zoom affordances for precision and reset.
 - **Theme:** Graph background, nodes, edges, and controls use **VS Code theme CSS variables** (`--vscode-*`) so light/dark and contrast follow the host editor.
+- **Completeness:** Every returned managed resource is reachable in the graph experience. If large-application grouping or collapse is used, the UI must make the grouped resources discoverable and keep Details/tree navigation available.
 
 ### Graph tiles (nodes)
 
@@ -88,6 +89,8 @@ Each node is a **tile** styled for quick scan (Argo CD UI–like density, adapte
 | Status | **Sync badge** and **health badge** on every tile, including the Application root. |
 | Trailing | **Overflow menu** (⋮) for kind-appropriate actions. |
 | Optional | **Age** or **revision** chip when the data model supplies it; omit the chip when absent rather than showing placeholders. |
+
+Tiles have separate focus and selected states. Primary activation selects the tile and makes resource-aware actions target that node; it does not execute a cluster operation unless the user invokes a menu item or command.
 
 **Status semantics on tiles:** Tiles show Argo CD **sync** (`Synced`, `OutOfSync`, etc.) and **health** (`Healthy`, `Degraded`, `Progressing`, `Missing`, `Suspended`, `Unknown`, etc.) from the application/resource model. They do **not** by default show Kubernetes **Ready** replica counts or pod-level readiness; if workload readiness is surfaced later, it must be labeled distinctly from Argo health so users are not misled.
 
@@ -136,3 +139,12 @@ Each category shows MUST and SHOULD rollups. Requirement rows show id/title, lev
 - No `aiConformance` summary: show an empty state that no conformance run has been published.
 - Stale cache or degraded operator: show a banner consistent with the Well-Architected assessment report pattern and keep any bounded summary clearly marked as stale when present.
 - Invalid payload: show a safe error state without raw ConfigMap JSON.
+
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### ArgoCD diagram interface
+- Choose concrete graph spacing constants, fit-view behavior, and tile sizing that keep large Applications readable without encoding pixel values as a product contract.
+- Define the selected-tile visual treatment across normal, focus, hover, selected, and overflow-open states.
+- Define the user-facing copy and placement for limited-topology and large-application grouping hints.

--- a/.ai/knowledge_map.json
+++ b/.ai/knowledge_map.json
@@ -72,6 +72,14 @@
             ".ai/operations/observability.md",
             ".ai/operations/security.md"
           ]
+        },
+        {
+          "name": "specs",
+          "primary_doc": ".ai/specs/index.md",
+          "description": "Durable capability-level architecture and behavior specifications.",
+          "children": [
+            ".ai/specs/argocd-diagram-interface.spec.md"
+          ]
         }
       ]
     }

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -82,6 +82,15 @@ The conformance report follows the existing operator report bundle pattern:
 
 `npm run build:webview` must include the conformance report bundle and style copy before the feature is considered packaged. `npm run build`, `npm run compile`, and CI must therefore exercise the new webview bundle. If packaging adds a new media path, `.vscodeignore` must continue to include `media/` artifacts in the VSIX.
 
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### ArgoCD diagram delivery checks
+- Decide the exact validation checklist per implementation story, including which graph interactions are covered by unit tests, webview component tests, packaged build checks, and manual keyboard review.
+- Define how maintainers record Argo CD webview bundle-size spot checks when React Flow or layout dependencies change.
+- Add packaging verification for any new Argo CD graph CSS or asset paths copied beside `media/argocd-application/main.js`.
+
 ## Packaging Contract
 
 Release artifacts are VSIX packages built from current repository state. Versioning and publishing run in **[Cut Release](../../.github/workflows/cut-release.yml)** (`workflow_dispatch`), which maintainers start manually after merges to `main`; semantic-release updates the version and changelog before marketplaces publish.

--- a/.ai/operations/observability.md
+++ b/.ai/operations/observability.md
@@ -23,8 +23,17 @@ Operational expectations:
 - **Google Analytics (GA4)** is the planned **shared backend** for product analytics across IDE extension and desktop surfaces; dashboards and funnel analysis live there subject to `.ai/integration/external_systems.md`—still only allowlisted, non-identifying fields.
 - **Local diagnostics** remain the default for troubleshooting; product telemetry complements aggregate product insight, not per-user debugging.
 
+Argo CD graph telemetry, when added, follows the same allowlist: event names may describe coarse feature use or outcome categories such as graph opened, topology fallback shown, resource action succeeded, or resource action failed. Payloads must not include cluster context, namespace, Application name, resource kind/name, manifest content, kubeconfig data, Argo CD URLs, tokens, or raw API payloads.
+
 ## Operational Principle
 
 Diagnostics should be rich enough for troubleshooting while keeping end-user messaging concise and action-oriented.
 
 Product telemetry (when shipped) must stay **minimal, enumerated, and reviewable**, consistent with `.ai/operations/security.md`.
+
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### ArgoCD diagram telemetry
+- If graph telemetry is included, define catalog entries and allowed payload shapes through the existing telemetry catalog workflow before implementation emits events.

--- a/.ai/operations/security.md
+++ b/.ai/operations/security.md
@@ -11,6 +11,8 @@
 
 Kube9 desktop IDE surfaces prioritize **explicit user control** consistent with VS Code settings. Telemetry is for **aggregate product insight**—not a substitute for support logs—and must remain guardrailed via code-reviewable event APIs so engineers cannot accidentally attach cluster context to payloads.
 
+Argo CD diagram actions preserve the local-first trust model. The webview never receives kubeconfig paths, Argo CD bearer tokens, raw REST endpoints, or raw API responses; it sends selected-resource intent to the extension host, and the host validates context, RBAC, action eligibility, and optional Argo CD REST credentials before any cluster or server call.
+
 ## Supply Chain And Release
 
 - CI-managed release flow with repository secrets for marketplace publishing.

--- a/.ai/runtime/execution_model.md
+++ b/.ai/runtime/execution_model.md
@@ -51,9 +51,10 @@ See [Startup and bootstrap](startup_bootstrap.md): the extension may send `appli
 
 | type | Purpose |
 |------|---------|
-| `graphAction` | Kind-scoped action from a node menu; payload includes `action` (e.g. `restartRollout`), stable `nodeId`, `kind`, `name`, `namespace` |
+| `graphRefresh` | Explicit graph refresh request; host reloads Application CRD and optional topology inputs, then emits `resourceGraph` |
+| `resourceAction` | Kind-scoped action from a node menu; payload includes `actionId`, stable `nodeId`, `kind`, `name`, `namespace`, and optional `group` / `version` |
 
-Application-level actions stay on the root node or header; tile menus use `graphAction`.
+Application-level actions stay on the root node or header; tile menus use `resourceAction`.
 
 ### Extension → webview (shipped)
 
@@ -69,10 +70,10 @@ The webview **listens** for `updateStatus` (application-level sync/health patch)
 
 | type | Purpose |
 |------|---------|
-| `graphData` | Nodes, edges, stable ids, optional pre-computed positions |
-| `graphPatch` | Incremental node status updates without full graph replace (keeps panel open and preserves layout where possible) |
-| `updateStatus` | Narrow application-level sync/health-only updates (optional complement to `graphPatch` on root) |
-| `actionResult` | Outcome of a `graphAction` for tile or toast feedback |
+| `resourceGraph` | Complete `ApplicationResourceGraph` snapshot with stable ids, topology metadata, structure version, and optional layout hints |
+| `updateStatus` | Narrow application-level sync/health-only updates (optional complement on the root when a full graph snapshot is not needed) |
+| `resourceActionProgress` | In-flight state for a `resourceAction` |
+| `resourceActionResult` | Outcome of a `resourceAction` for tile or toast feedback |
 
 Integration SME owns DTO field shapes. Runtime requires **stable node ids** across refreshes so React Flow state and selection survive merge-style updates.
 
@@ -100,11 +101,20 @@ After triggering sync, refresh, hard refresh, or a graph action (e.g. rollout re
 
 1. Post `operationProgress` with `phase: 'Running'` and a clear `message`.
 2. Poll application (and graph DTO inputs) on a bounded interval with timeout and optional `CancellationToken` (service default: **2 s** interval, **300 s** timeout unless overridden).
-3. Push **`graphPatch` or `applicationData`** when state changes so the graph updates **without** disposing the `WebviewPanel`.
-4. On terminal phase (`Succeeded`, `Failed`, `Error`), post a matching `operationProgress`, then a final consistency push (`applicationData` and/or `graphData` as needed).
+3. Push **`resourceGraph` or `applicationData`** when state changes so the graph updates **without** disposing the `WebviewPanel`.
+4. On terminal phase (`Succeeded`, `Failed`, `Error`), post a matching `operationProgress`, then a final consistency push (`applicationData` and/or `resourceGraph` as needed).
 
-Prefer **`graphPatch`** for status-only deltas to limit layout thrash; reserve full `graphData` for topology changes or initial load.
+Prefer merge-style handling of `resourceGraph` snapshots for status-only deltas to limit layout thrash; reserve full relayout for topology changes, `structureVersion` changes, or initial load.
 
 ### Concurrent operations
 
 While `operationProgress.phase === 'Running'`, treat the application as busy: block conflicting header and node actions until terminal phase or `error`.
+
+## Open Implementation Decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### ArgoCD diagram protocol cleanup
+- Remove or alias legacy graph protocol names (`graphData`, `graphPatch`, `graphAction`, `actionResult`) in code and tests so the shipped host/webview protocol consistently uses `resourceGraph`, `resourceAction`, `resourceActionProgress`, and `resourceActionResult`.
+- Decide whether a future patch-style graph message is needed after complete `resourceGraph` snapshot merging is implemented and measured.
+- Define concurrent busy-state behavior when an Application-level operation and a selected resource action are requested close together.

--- a/.ai/runtime/lifecycle_shutdown.md
+++ b/.ai/runtime/lifecycle_shutdown.md
@@ -28,7 +28,7 @@ On extension deactivate, all open webviews are torn down by VS Code. Host code s
 
 ## Graph-Specific Lifecycle
 
-- **Initial load:** Full `graphData` (or `applicationData` from which the webview derives graph) after `ready`.
-- **Poll updates:** Prefer `graphPatch` for sync/health-only deltas during operations.
-- **Structural change:** Full `graphData` when nodes/edges set changes (sync finished, hard refresh, resource added/removed).
-- **Panel hidden:** Retained context keeps React Flow viewport; polling continues only while an operation is active, not as a background watch on hidden panels unless explicitly started by user action.
+- **Initial load:** Full `resourceGraph` (or `applicationData` from which the webview derives graph) after `ready`.
+- **Poll updates:** Prefer complete `resourceGraph` snapshots when sync, health, or topology changes; future patch-style messages must preserve the same stable node identity rules.
+- **Structural change:** Full `resourceGraph` when the node or edge set changes (sync finished, hard refresh, resource added/removed).
+- **Panel hidden:** Retained context keeps React Flow viewport, selected node, and layout cache when stable node ids survive. Polling continues only while an operation is active, not as a background watch on hidden panels unless explicitly started by user action.

--- a/.ai/runtime/startup_bootstrap.md
+++ b/.ai/runtime/startup_bootstrap.md
@@ -28,7 +28,7 @@ Webviews are **not** started at extension activation. Each panel is created on d
 1. Extension creates or reveals `WebviewPanel` (`retainContextWhenHidden: true`). If the panel already exists for the same `context:namespace:applicationName`, it is **revealed** and data is **reloaded** for that tuple.
 2. HTML loads shipped header CSS, React Flow base CSS, application CSS, then `main.js`.
 3. React app mounts and posts `{ type: 'ready' }` to the extension.
-4. Extension loads application (and graph) data and posts initial DTO messages (`applicationData`, `graphData` when active).
+4. Extension loads application and graph data and posts initial DTO messages (`applicationData`, `resourceGraph` when active).
 
 Data may arrive before or after `ready`; the webview must handle both orderings.
 

--- a/.ai/specs/argocd-diagram-interface.spec.md
+++ b/.ai/specs/argocd-diagram-interface.spec.md
@@ -1,0 +1,61 @@
+# ArgoCD Diagram Interface
+
+## Introduction
+
+The ArgoCD Diagram Interface is the default Argo CD Application detail surface in kube9-vscode. It turns an Application's managed-resource inventory into an interactive graph inside VS Code so GitOps users can inspect every returned resource, understand topology when it is available, select resources, invoke kind-appropriate actions, and reveal matching Kubernetes tree items without leaving the IDE.
+
+The capability is owned by kube9-vscode. It does not require kube9-operator, kube9-api, kube9-web, kube9-desktop, or the native Argo CD UI for baseline behavior. The native Argo CD UI is prior art for graph density, overflow affordances, and resource-tree topology, while kube9-vscode contracts remain authoritative for local-first trust, webview accessibility, and VS Code theme behavior.
+
+## Functional Specification
+
+Opening an Argo CD Application from the cluster tree presents Graph as the default view and Details as the secondary view. Graph shows the Application root and every returned managed resource from the Application's resource inventory. When full Argo CD resource-tree topology is available, edges reflect parent/child relationships. When only the Application CRD is available, the graph still renders the complete managed-resource set with limited topology disclosure.
+
+Each graph tile shows kind, name, Argo CD sync status, Argo CD health status, and an overflow control for eligible actions. Tile selection is a visible, keyboard-operable state that scopes resource-aware actions. Selection does not mutate cluster state by itself; mutating actions require explicit menu or command intent and host-side validation.
+
+Application-level sync, refresh, hard refresh, and View In Tree remain available from the webview header, sub-header, or Application root affordances. Managed-resource tiles support View In Tree and open describe/detail where resource identity can be mapped into the existing Kubernetes tree and describe surfaces. Deployment tiles may expose rollout restart through the Kind Capability Registry when RBAC and action eligibility allow it.
+
+Large Applications must remain usable. Grouping, collapse, capped initial render, or progressive disclosure may be used, but the experience must preserve a path to every returned managed resource through the graph, Details, tree navigation, or explicit expansion. Empty, partial, permission-denied, and limited-topology states use explicit user-facing messaging instead of blank canvases or silent graph degradation.
+
+## Technical Specification
+
+The capability runs in the existing VS Code extension model: Node.js extension host plus isolated browser webview. Repository metadata requires VS Code engine `^1.80.0`, Node `>=22.0.0`, and `.nvmrc` pins local Node `v22.14.0`. The Argo CD webview is bundled by esbuild from `src/webview/argocd-application/index.tsx` into `media/argocd-application/main.js`. Browser-side graph rendering uses React 18, `@xyflow/react`, and a layout engine such as `@dagrejs/dagre`; these stay in the webview bundle and not in the extension host bundle.
+
+Kubernetes and Argo CD I/O happen only in the extension host. The required baseline source is the Argo CD Application CRD, including `status.resources`. Optional enrichment may use Argo CD REST `resource-tree` when explicitly configured and authorized, or Kubernetes owner references when enabled and permitted. Optional enrichment failure falls back to CRD-flat graph rendering without failing the whole panel when the Application CRD remains readable.
+
+The graph data contract is `ApplicationResourceGraph`, a derived JSON-safe DTO with `applicationKey`, `nodes`, `edges`, `topologySource`, `topologyMode`, `structureVersion`, optional `layoutHint`, `observedAt`, and optional `truncated`. Stable identity is based on `ManagedResourceKey` and `GraphNodeId`, not visible labels or React Flow internals. `ArgoCDApplication.resources` remains the sync and health authority for CRD-backed resources.
+
+The canonical webview protocol uses `resourceGraph` for complete graph snapshots and `resourceAction` for tile actions. `resourceActionProgress` and `resourceActionResult` communicate action progress and terminal state. Legacy naming such as `graphData`, `graphPatch`, and `graphAction` is treated as implementation cleanup, not the durable contract. The host preserves panel identity by `context:namespace:applicationName`, owns polling and cancellation, and pushes graph refreshes without disposing the panel.
+
+The webview owns rendering, selection, viewport, focus, menu state, and layout cache for the panel session. Refresh merges preserve selection, viewport, and positions when stable node ids survive; structural changes use `structureVersion` to determine when relayout or selection clearing is needed.
+
+## Testing Strategy
+
+Contract validation should prove the CRD-flat baseline first: every `ArgoCDApplication.resources` row produces a managed-resource node, the Application root exists, sync/health status matches the flat list, and limited topology is disclosed when full topology is unavailable. Resource-tree and owner-reference enrichment tests should verify that optional edges do not override CRD sync/health for matching resource keys.
+
+Runtime and serialization tests should cover `resourceGraph`, `resourceAction`, `resourceActionProgress`, and `resourceActionResult` message handling, including stable node ids, `structureVersion` merge behavior, selected-node preservation, removed-node selection clearing, and host-owned polling after sync, refresh, hard refresh, or rollout restart.
+
+Interface validation should include graph layout readability, selectable tiles, overflow menu behavior, View In Tree from a selected resource, Details fallback, limited-topology messaging, and large-application grouping or expansion. Accessibility review must include keyboard traversal through header, toolbar, tiles, overflow menus, Graph/Details tabs, high-contrast status badges, reduced-motion behavior, and focus preservation across refresh.
+
+Build and packaging checks should run the existing repository commands for the affected scope: `npm run compile`, `npm run build`, `npm run test:unit`, and `npm run package` as appropriate for implementation changes. Packaging review should confirm Argo CD webview scripts, CSS, React Flow styles, and shared webview header CSS are present in the VSIX, and bundle-size changes to `media/argocd-application/main.js` remain within the documented target or are explicitly justified.
+
+## References
+
+- `.ai/business_logic/domain_model.md`
+- `.ai/business_logic/user_stories.md`
+- `.ai/business_logic/error_state.md`
+- `.ai/business_logic/error_handling.md`
+- `.ai/data/data_model.md`
+- `.ai/data/serialization.md`
+- `.ai/data/consistency.md`
+- `.ai/integration/api_contracts.md`
+- `.ai/integration/external_systems.md`
+- `.ai/integration/messaging_async.md`
+- `.ai/integration/authorization.md`
+- `.ai/interface/presentation.md`
+- `.ai/interface/interaction_flow.md`
+- `.ai/interface/accessibility.md`
+- `.ai/runtime/execution_model.md`
+- `.ai/runtime/lifecycle_shutdown.md`
+- `.ai/operations/build_packaging.md`
+- `.ai/operations/observability.md`
+- `.ai/operations/security.md`

--- a/.ai/specs/index.md
+++ b/.ai/specs/index.md
@@ -1,0 +1,7 @@
+# Capability Specs
+
+Durable capability-level architecture and behavior specifications for kube9-vscode.
+
+| Slug | Title | Purpose | Status |
+|------|-------|---------|--------|
+| `argocd-diagram-interface` | ArgoCD Diagram Interface | Complete interactive Argo CD Application resource graph with selectable nodes, per-resource actions, tree reveal, and topology-aware refresh. | draft |


### PR DESCRIPTION
Contract-only PR from ideation (`/ideate`).

- **Initiative:** argocd-diagram-interface
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and cross-repo coherence before merge

Merge before `/plan-roadmap` when downstream work should read merged contracts on `main`.