### PR TITLE
docs(ai): refine issue #226 contract updates

### DIFF
--- a/.ai/data/consistency.md
+++ b/.ai/data/consistency.md
@@ -64,6 +64,13 @@ After every successful application fetch:
 
 If a resource appears in `status.resources` but fails graph node construction (missing name/kind), omit the node and surface a non-fatal warning in the UI layer; do not invent placeholder keys.
 
+**Invalid-row surfacing (CRD-flat):**
+
+1. Assembler records `assemblyWarnings` (see [api_contracts.md](../integration/api_contracts.md) Tier A).
+2. Host logs each warning to the **`kube9 ArgoCD Service`** output channel.
+3. When at least one invalid row was skipped, the graph viewport shows a non-blocking info banner (for example: "Some managed resources could not be shown because Argo CD returned incomplete resource rows."). The banner must not include raw CRD JSON or cluster credentials.
+4. The Details drift table still lists all parsed `ArgoCDResource` rows from `parseResources`; graph omission affects canvas nodes only.
+
 ## Operation in progress
 
 While `operationState.phase` is `Running` or `Terminating`:

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -129,11 +129,23 @@ Raw upstream JSON must not leak into the webview bundle; normalize in the extens
 - Changing `GraphNodeId` derivation is **breaking** for layout cache merge; avoid without migration logic.
 - Webview should tolerate unknown `topologySource` values by rendering nodes and ignoring unrecognized edge semantics while still honoring `topologyMode` when present.
 
+## `structureVersion` derivation
+
+`structureVersion` fingerprints **graph structure**, not tile status. Attribute-only sync/health updates must not change it.
+
+Algorithm (implementation may hash the canonical string; SHA-256 is acceptable):
+
+1. Collect all node `id` values; sort lexicographically.
+2. Collect all edges as `{source}\t{target}` pairs; sort lexicographically.
+3. Build payload: `nodes:{ids joined by newline}\nedges:{pairs joined by newline}`.
+4. Set `structureVersion` to a stable digest of that payload (for example SHA-256 hex).
+
+Bump `structureVersion` when node ids are added/removed or when any edge source/target pair changes. Do not bump for sync/health/message-only updates on existing ids.
+
 ## Open Implementation Decisions
 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### ArgoCD graph DTO details
-- Define the exact `structureVersion` derivation in implementation and tests without binding the contract to one hash function.
-- Decide when `apiGroup` / `group` is required for tree navigation and action routing, and update `ManagedResourceKey` parsing and serialization together.
-- Define whether large-application grouping is represented in the DTO as grouped nodes or remains an interface-only transform over complete resource nodes.
+- Decide when `apiGroup` / `group` is required for tree navigation and action routing, and update `ManagedResourceKey` parsing and serialization together. _(M16 protocol / tree-reveal issues.)_
+- Define whether large-application grouping is represented in the DTO as grouped nodes or remains an interface-only transform over complete resource nodes. _(M16 large-application issue.)_

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -47,13 +47,39 @@ The host sets `topologySource` on each push so the webview can label degraded vs
 | Item | Contract |
 |------|----------|
 | **Source** | Single Application CRD get (same as `getApplication`) |
-| **Nodes** | One node per `status.resources[]` row plus one **Application root** node |
-| **Edges** | Synthetic only: root → each resource (or implementation-defined grouping); no claim of Argo CD UI parity |
+| **Nodes** | One node per **valid** `status.resources[]` row plus one **Application root** node |
+| **Edges** | Synthetic star only: one `manages` edge from Application root to each managed node; no claim of Argo CD UI parent/child parity |
 | **Status on tiles** | Resource `syncStatus` + `healthStatus`; root uses application-level `syncStatus` / `healthStatus` |
 | **RBAC** | `applications` get (and list for refresh flows) — see [authorization.md](./authorization.md) |
 | **Failure** | If Application get fails, post `error`; no `resourceGraph` |
 
-This tier matches **current** `ArgoCDService.parseResources` behavior and is sufficient for MVP graph rendering.
+#### ManagedResourceKey parsing (Tier A)
+
+Each `ArgoCDResource` row from `ArgoCDService.parseResources` maps to `ManagedResourceKey` as follows:
+
+| Field | Rule |
+|-------|------|
+| `namespace` | Trim whitespace; use empty string when CRD omits namespace (cluster-scoped kinds) |
+| `kind` | Trim whitespace; **required** — blank or missing → invalid row |
+| `name` | Trim whitespace; **required** — blank or missing → invalid row |
+| `apiGroup` | Omitted in Tier A (CRD `status.resources[]` rows do not carry a stable group field in the current parser) |
+
+`GraphNodeId` for managed resources is `res:{namespace}/{kind}/{name}` (no `apiGroup` suffix in Tier A). Application root id is `app:{applicationNamespace}/{applicationName}`.
+
+#### Invalid and duplicate rows
+
+| Condition | Graph behavior | Warning |
+|-----------|----------------|---------|
+| Missing or whitespace-only `kind` or `name` | Omit node; do not invent placeholder keys | `Skipped resource row: missing kind or name` |
+| Duplicate `ManagedResourceKey` (same namespace/kind/name) | Keep **first** row's sync/health; omit later rows | `Skipped duplicate managed resource: {namespace}/{kind}/{name}` |
+
+Assembly warnings are non-fatal. The host logs each warning to the **`kube9 ArgoCD Service`** output channel with a `crd_flat graph assembly` prefix. When any invalid row was skipped, the webview shows a non-blocking graph info banner (no raw CRD fragments).
+
+#### Count consistency
+
+After assembly, managed-resource node count must equal the count of **valid** rows in `ArgoCDApplication.resources` (invalid and duplicate rows excluded). See [consistency.md](../data/consistency.md).
+
+This tier matches **current** `ArgoCDService.parseResources` behavior and is sufficient for baseline graph rendering. Optional Tier B/C enrichment runs only after Tier A completeness is shippable; enrichment failure falls back to Tier A without failing the panel.
 
 ### Tier B — `argocd_resource_tree` (optional enrichment)
 
@@ -198,6 +224,9 @@ The report does not shell out beyond the existing operator status read path. It 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### ArgoCD resource graph integration
-- Define the final `resourceAction` payload shape for selected nodes, including whether both `group` and `apiGroup` appear or one canonical field is used across parser, tree reveal, and action routing.
-- Decide whether owner-reference topology enrichment belongs in the first implementation slice or remains a documented optional extension after CRD-flat completeness ships.
-- Specify the safe user-facing fallback message when optional resource-tree topology fails without exposing raw upstream errors, endpoints, or credentials.
+- Define the final `resourceAction` payload shape for selected nodes, including whether both `group` and `apiGroup` appear or one canonical field is used across parser, tree reveal, and action routing. _(Tracked in M16 protocol issue; out of CRD-flat baseline scope.)_
+
+**Resolved (CRD-flat baseline):**
+
+- **Owner-reference enrichment** ships after CRD-flat completeness. Tier C is optional; when unavailable the host keeps Tier A (`crd_flat`) without failing the panel.
+- **Resource-tree fallback messaging:** When Tier B fails or is disabled, the webview shows the limited-topology affordance (`topologyMode: limited`) with user-facing copy that parent/child relationships may be incomplete. Raw upstream errors, endpoints, and credentials stay in the extension host output channel only, prefixed `[INFO] Argo CD resource-tree enrichment unavailable`.

--- a/.ai/specs/argocd-diagram-interface.spec.md
+++ b/.ai/specs/argocd-diagram-interface.spec.md
@@ -24,13 +24,32 @@ Kubernetes and Argo CD I/O happen only in the extension host. The required basel
 
 The graph data contract is `ApplicationResourceGraph`, a derived JSON-safe DTO with `applicationKey`, `nodes`, `edges`, `topologySource`, `topologyMode`, `structureVersion`, optional `layoutHint`, `observedAt`, and optional `truncated`. Stable identity is based on `ManagedResourceKey` and `GraphNodeId`, not visible labels or React Flow internals. `ArgoCDApplication.resources` remains the sync and health authority for CRD-backed resources.
 
+**CRD-flat baseline assembly (`topologySource: crd_flat`):**
+
+- Parse each `ArgoCDResource` to `ManagedResourceKey` (namespace trimmed; kind and name required).
+- Emit one Application root node plus one managed-resource node per valid row.
+- Emit one `manages` edge per managed node from root to resource.
+- Set `topologyMode: limited` and show the limited-topology affordance when managed nodes are visible.
+- Skip invalid rows (missing kind/name) and duplicate keys (keep first); log assembly warnings to the output channel and show a non-blocking graph banner when invalid rows were skipped.
+- Managed-resource node count must equal valid `application.resources` row count after assembly.
+
 The canonical webview protocol uses `resourceGraph` for complete graph snapshots and `resourceAction` for tile actions. `resourceActionProgress` and `resourceActionResult` communicate action progress and terminal state. Legacy naming such as `graphData`, `graphPatch`, and `graphAction` is treated as implementation cleanup, not the durable contract. The host preserves panel identity by `context:namespace:applicationName`, owns polling and cancellation, and pushes graph refreshes without disposing the panel.
 
 The webview owns rendering, selection, viewport, focus, menu state, and layout cache for the panel session. Refresh merges preserve selection, viewport, and positions when stable node ids survive; structural changes use `structureVersion` to determine when relayout or selection clearing is needed.
 
 ## Testing Strategy
 
-Contract validation should prove the CRD-flat baseline first: every `ArgoCDApplication.resources` row produces a managed-resource node, the Application root exists, sync/health status matches the flat list, and limited topology is disclosed when full topology is unavailable. Resource-tree and owner-reference enrichment tests should verify that optional edges do not override CRD sync/health for matching resource keys.
+Contract validation should prove the CRD-flat baseline first:
+
+- Every **valid** `ArgoCDApplication.resources` row produces exactly one managed-resource node; invalid rows are omitted with warnings.
+- `countManagedResourceNodes(graph) === validResourceRowCount` for `topologySource: crd_flat`.
+- Application root exists with application-level sync/health.
+- Managed tile sync/health matches the corresponding `ArgoCDResource` row.
+- Star topology: one `manages` edge per managed node from Application root; `topologyMode: limited`.
+- Limited-topology affordance visible when CRD-flat graph has managed nodes.
+- Invalid-row path: assembly warnings logged; non-blocking graph banner when rows were skipped.
+
+Resource-tree and owner-reference enrichment tests should verify that optional edges do not override CRD sync/health for matching resource keys.
 
 Runtime and serialization tests should cover `resourceGraph`, `resourceAction`, `resourceActionProgress`, and `resourceActionResult` message handling, including stable node ids, `structureVersion` merge behavior, selected-node preservation, removed-node selection clearing, and host-owned polling after sync, refresh, hard refresh, or rollout restart.
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #226
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.