### PR TITLE
docs(ai): refine issue #227 contract updates

### DIFF
--- a/.ai/data/consistency.md
+++ b/.ai/data/consistency.md
@@ -20,36 +20,60 @@ Graph-relevant data updates on:
 
 Each trigger produces a new `observedAt` on the graph DTO or application payload.
 
-## Merge on refresh (webview)
+## Merge on refresh (two layers)
 
-Goal: update sync/health and topology without resetting pan/zoom or discarding user-dragged positions.
+Goal: update sync/health and topology without resetting pan/zoom, tile selection, or known React Flow positions when `ApplicationKey` and stable `GraphNodeId` values survive.
 
-### When ApplicationKey is unchanged
+Refresh merge runs in **two layers**:
 
-1. **Build incoming graph** from latest `ArgoCDApplication` (+ topology if available).
-2. **Index existing layout** by `GraphNodeId`.
-3. **For each incoming node** with an existing id:
-   - Replace `status`, `label`, and `kindLabel` from incoming data.
-   - Retain `position` (and optional `measured`) from layout cache.
-4. **For new ids**: insert node with layout algorithm default position (or append column in dagre pass).
-5. **For removed ids**: drop node, incident edges, and layout cache entries.
-6. **Edges**: replace edge set from incoming graph; stable edge ids prevent React Flow duplicate-key issues. If only status changed, skip edge relayout unless `topologySource` or node count changed.
+1. **Host DTO merge** (`mergeApplicationResourceGraphSnapshots`) before posting `resourceGraph`. Shallow-merges attribute fields on unchanged topology; posts a full incoming snapshot when structure changes.
+2. **Webview layout merge** (`mergeGraphFlowState`) when applying each `resourceGraph` message. Maps DTO nodes to React Flow nodes, decides relayout vs position retention, and updates session layout cache, viewport, and selection refs.
 
-7. **Structural fingerprint**: when the incoming graph includes **`structureVersion`**, a change versus the prior snapshot forces the same posture as topology upgrade (new subgraph layout, optional fit). When **`structureVersion` matches**, treat the tick as attribute-only: apply shallow node status updates (steps 3–6) and preserve viewport/selection unless another rule contradicts.
+Both layers use the same **`structureVersion`** fingerprint (see [serialization.md](./serialization.md)). Attribute-only ticks keep the same version; node-id or edge-endpoint changes bump it.
 
-8. **Viewport**: preserve unless node count changed dramatically, **`structureVersion` changed**, or user invokes fit-view.
+### Host DTO merge (`ApplicationKey` unchanged)
 
-9. **Selection**: clear selection if selected node was removed; otherwise keep.
+Given `previous` (last posted graph for the panel) and `incoming` (newly assembled graph):
 
-### When ApplicationKey changes
+| Condition | Result |
+|-----------|--------|
+| No `previous`, or `applicationKey` differs | Return `incoming` unchanged; `structureChanged: true` |
+| `structureVersion` differs | Return `incoming` unchanged; `structureChanged: true` |
+| Node id set differs | Return `incoming` unchanged; `structureChanged: true` |
+| `structureVersion` matches but recomputed fingerprint from `incoming.nodes` / `incoming.edges` differs | Treat as structural mismatch; return `incoming` unchanged; `structureChanged: true` |
+| Otherwise (attribute-only tick) | For each incoming node id, replace `status`, `label`, and `kindLabel` from incoming; keep incoming `edges`, `topologySource`, `topologyMode`, `observedAt`, and metadata; `structureChanged: false` |
 
-Full replace: discard prior graph and layout cache. Equivalent to opening a different Application.
+The host stores the merged graph on the panel (`lastGraph`) and posts it as `resourceGraph`. The webview never receives stale nodes after a structural change.
+
+### Webview layout merge (`ApplicationKey` unchanged)
+
+When `applicationKey` on the incoming graph differs from the panel session key, discard layout cache, viewport cache, and selection. Equivalent to opening a different Application.
+
+Otherwise:
+
+1. Map incoming DTO to React Flow nodes and edges.
+2. **Relayout** when any of: initial load (no prior `structureVersion` in cache), user **fit view**, incoming `structureVersion` differs from cache, `topologySource` differs from cache, or managed node count delta exceeds `NODE_COUNT_RELAYOUT_THRESHOLD` (currently `0`, so any add/remove relayouts).
+3. **Retain positions** from the layout cache for matching node ids when relayout is false.
+4. Replace the edge set from incoming data (stable edge ids prevent duplicate-key issues).
+5. **Viewport**: after merge, auto-fit only on initial load or explicit fit-view. Otherwise restore the cached pan/zoom from `onMoveEnd` when available.
+6. **Selection**: keep `selectedNodeId` when it exists in the post-merge node id set; clear selection when the id is absent (resource removed or identity changed). Do not clear on attribute-only status updates.
 
 ### When topologySource upgrades (e.g. crd_flat → argocd_resource_tree)
 
-- Recompute edges and possibly add nodes.
-- Preserve positions for nodes whose `GraphNodeId` survives the transition (same `ManagedResourceKey`).
-- Run layout only for new nodes or when user requests fit-view / re-layout.
+- Host posts a new graph with updated edges and possibly supplemental nodes; `structureVersion` and/or node ids typically change → structural path above.
+- Webview relayouts because `topologySource` changed.
+- Preserve positions for nodes whose `GraphNodeId` survives (same `ManagedResourceKey`) when relayout runs; new ids receive layout defaults.
+- Do not auto-fit viewport unless initial load or user invokes fit-view.
+
+### Grouping and progressive disclosure (presentation layer)
+
+Large-application grouping (#222) is a **webview presentation transform** over the complete DTO node set unless a future contract explicitly adds grouped DTO nodes.
+
+Until then:
+
+- **Selection** is keyed by `GraphNodeId` on the DTO. A selected resource stays selected across refresh while that id remains in `resourceGraph.nodes`.
+- **Clear selection** when the selected id disappears from the incoming DTO (removed resource, renamed resource, or `ApplicationKey` change).
+- Collapsing or hiding a tile in the UI must not clear selection if the underlying id is still present in the DTO; expanding again should restore the selected styling on that tile.
 
 ## Flat list vs graph consistency
 
@@ -98,6 +122,6 @@ While `operationState.phase` is `Running` or `Terminating`:
 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
-### ArgoCD large graph consistency
+### ArgoCD large graph consistency (M16 #222)
 - Specify how grouping or progressive disclosure preserves access to every returned `ArgoCDResource` while keeping `crd_flat` count checks meaningful.
-- Define the refresh behavior for selected nodes when grouping, expansion, or topology upgrades change the visible tile set.
+- If grouped nodes are represented in the DTO, define how grouped tiles map to underlying `GraphNodeId` values for selection and merge. Until then, selection and merge rules above apply to the flat DTO node set.

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -140,7 +140,9 @@ Algorithm (implementation may hash the canonical string; SHA-256 is acceptable):
 3. Build payload: `nodes:{ids joined by newline}\nedges:{pairs joined by newline}`.
 4. Set `structureVersion` to a stable digest of that payload (for example SHA-256 hex).
 
-Bump `structureVersion` when node ids are added/removed or when any edge source/target pair changes. Do not bump for sync/health/message-only updates on existing ids.
+Bump `structureVersion` when node ids are added/removed or when any edge source/target pair changes. Do not bump for sync/health/message/label-only updates on existing ids. Edge **relationship** or edge **id** string changes do not bump the fingerprint when source/target pairs are unchanged.
+
+Producers MUST set `structureVersion` on every `resourceGraph` post. Consumers MUST treat a missing `structureVersion` as a structural update (full relayout, no position merge).
 
 ## Open Implementation Decisions
 
@@ -148,4 +150,4 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 ### ArgoCD graph DTO details
 - Decide when `apiGroup` / `group` is required for tree navigation and action routing, and update `ManagedResourceKey` parsing and serialization together. _(M16 protocol / tree-reveal issues.)_
-- Define whether large-application grouping is represented in the DTO as grouped nodes or remains an interface-only transform over complete resource nodes. _(M16 large-application issue.)_
+- Define whether large-application grouping is represented in the DTO as grouped nodes or remains an interface-only transform over complete resource nodes. _(M16 #222.)_

--- a/.ai/specs/argocd-diagram-interface.spec.md
+++ b/.ai/specs/argocd-diagram-interface.spec.md
@@ -37,6 +37,12 @@ The canonical webview protocol uses `resourceGraph` for complete graph snapshots
 
 The webview owns rendering, selection, viewport, focus, menu state, and layout cache for the panel session. Refresh merges preserve selection, viewport, and positions when stable node ids survive; structural changes use `structureVersion` to determine when relayout or selection clearing is needed.
 
+**Refresh merge (host + webview):**
+
+- **Host:** `mergeApplicationResourceGraphSnapshots` shallow-merges status/labels when `structureVersion` and node id sets match; otherwise posts the full incoming snapshot. See `.ai/data/consistency.md`.
+- **Webview:** `mergeGraphFlowState` retains React Flow positions and restores viewport on attribute-only ticks; relayouts on `structureVersion` change, `topologySource` change, node add/remove, initial load, or explicit fit-view. Selection clears only when the selected `GraphNodeId` is absent from the incoming DTO.
+- **Terminal operations:** After sync/refresh/hard refresh polling reaches a terminal phase, the host invalidates application cache and posts fresh `applicationData` + `resourceGraph` before the panel considers the operation complete.
+
 ## Testing Strategy
 
 Contract validation should prove the CRD-flat baseline first:
@@ -52,6 +58,21 @@ Contract validation should prove the CRD-flat baseline first:
 Resource-tree and owner-reference enrichment tests should verify that optional edges do not override CRD sync/health for matching resource keys.
 
 Runtime and serialization tests should cover `resourceGraph`, `resourceAction`, `resourceActionProgress`, and `resourceActionResult` message handling, including stable node ids, `structureVersion` merge behavior, selected-node preservation, removed-node selection clearing, and host-owned polling after sync, refresh, hard refresh, or rollout restart.
+
+**Refresh merge test matrix (unit):**
+
+| Area | Module / suite | Must prove |
+|------|----------------|------------|
+| Fingerprint | `applicationResourceGraph.test.ts` → `computeStructureVersion` | Deterministic; unchanged on status/label-only edits; changes on node add/remove or edge endpoint change |
+| Host merge | `ApplicationResourceGraphMerger.test.ts` | Attribute-only tick (`structureChanged: false`); structural add/remove/rename; `ApplicationKey` change; structureVersion mismatch guard |
+| Webview layout | `argocdGraphLayout.test.ts` | Position retention on matching `structureVersion`; relayout on structural change without auto-fit; selection resolve/clear; viewport preserve rules |
+| Provider push | `ArgoCDApplicationWebviewProvider.graph.test.ts` | Open and refresh post `applicationData` then `resourceGraph`; second load with same topology preserves `structureVersion` |
+| Long operations | `ArgoCDApplicationWebviewProvider.trackOperation.test.ts` | Terminal sync posts fresh `applicationData` and `resourceGraph`; `operationProgress` sequence |
+
+**Gap tests to add during #227 implementation:**
+
+- Webview: `topologySource` change triggers relayout while preserving positions for surviving ids when feasible.
+- Host: terminal operation path calls cache invalidation before final graph post (`reloadApplicationAfterTerminalOperation`).
 
 Interface validation should include graph layout readability, selectable tiles, overflow menu behavior, View In Tree from a selected resource, Details fallback, limited-topology messaging, and large-application grouping or expansion. Accessibility review must include keyboard traversal through header, toolbar, tiles, overflow menus, Graph/Details tabs, high-contrast status badges, reduced-motion behavior, and focus preservation across refresh.
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #227
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.