### PR TITLE
docs(ai): refine issue #221 contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -176,6 +176,13 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - **Managed-resource overflow labels (v1):** Deployment — **Restart rollout**, **Navigate to resource in tree**; other navigate-supported kinds — **Navigate to resource in tree** only. Labels match `graphNodeCapabilities.ts` and host `actionId` registry entries.
 - **Progressive disclosure for very large Applications** (grouping, collapse, capped render) is owned by issue #222; tiles on visible nodes still follow the rules above.
 
+**Resolved (View In Tree and tree reveal, issue #221):**
+
+- **Application-level View In Tree** (`viewInTree` message from header, sub-header, or Application root overflow) reveals the open Application's `argocdApplication` tree item under the **ArgoCD Applications** category when the panel's kubeconfig context matches the active context. It does not reveal managed Kubernetes resources.
+- **Managed-resource View In Tree** routes through `resource.navigateTree` with the tile's `ManagedResourceKey`. The host maps supported kinds to existing cluster-tree categories via `ClusterTreeProvider.revealTreeResource`; unsupported kinds remain without overflow (#224).
+- **Details tab parity:** `navigateToResource` from the Details view uses the same reveal helper as `resource.navigateTree` for supported kinds.
+- **Failure is non-mutating:** When no tree item can be mapped, the extension reports navigation failure with user-facing copy; it must not create tree nodes or alter resource identity.
+
 **Deferred:**
 
-- **`resource.openDescribe` on graph tiles** — registry entry exists for future direct describe routing from `ManagedResourceKey`; v1 graph overflow does not expose it. Users open describe via tree reveal (#221) or Details tab navigate affordances.
+- **`resource.openDescribe` on graph tiles** — registry entry exists for future direct describe routing from `ManagedResourceKey`; v1 graph overflow does not expose it. Users open describe via tree reveal or Details tab navigate affordances.

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -149,5 +149,9 @@ Producers MUST set `structureVersion` on every `resourceGraph` post. Consumers M
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### ArgoCD graph DTO details
-- Decide when `apiGroup` / `group` is required for tree navigation and action routing, and update `ManagedResourceKey` parsing and serialization together. _(M16 protocol / tree-reveal issues.)_
+
+**Resolved (tree reveal v1, issue #221):**
+
+- **`apiGroup` for tree navigation:** Not required for v1 reveal of core kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`. Host reveal uses `kind`, `name`, and trimmed `namespace` from `ManagedResourceKey`. When `apiGroup` is present on the key or `resourceAction` payload, forward it for future CRD-kind routing; omitting it must not block core-kind reveal. Canonical `group` vs `apiGroup` naming on the wire remains in #223.
+
 - Define whether large-application grouping is represented in the DTO as grouped nodes or remains an interface-only transform over complete resource nodes. _(M16 #222.)_

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -141,8 +141,8 @@ JSON messages over `webview.postMessage` / `onDidReceiveMessage`. Types are stri
 | `sync` | — | Patch Application, track operation, refresh data + graph |
 | `refresh` | — | Refresh annotation path, reload data + graph |
 | `hardRefresh` | — | Confirm, patch hard refresh, reload |
-| `viewInTree` | — | Focus cluster tree, refresh |
-| `navigateToResource` | `kind`, `name`, `namespace` | Focus tree / reveal resource (best effort) |
+| `viewInTree` | — | Focus `kube9ClusterView`, refresh tree, reveal open Application as `argocdApplication` item when context matches |
+| `navigateToResource` | `kind`, `name`, `namespace` | Same reveal path as `resource.navigateTree` for supported kinds; explicit error for unsupported kinds |
 | `graphRefresh` | optional `bypassCache?: boolean` | Reload Application and rebuild `ApplicationResourceGraph` |
 | `resourceAction` | `actionId`, `kind`, `name`, `namespace`, optional `group`, `version` | Run registry action; emit progress/result |
 
@@ -217,7 +217,23 @@ The report does not shell out beyond the existing operator status read path. It 
 | Kubernetes RBAC denied on CRD | `error` (`PERMISSION_DENIED` semantics) | Permission guidance |
 | Resource-tree / owner-ref partial failure | `resourceGraph` with lower tier + optional banner in UI | Informational (implementation) |
 | Resource action denied | `resourceActionResult` success false | Error message |
+| Tree reveal: context mismatch | `resourceActionResult` success false | Graph action-notice + result message |
+| Tree reveal: resource not in tree | `resourceActionResult` success false | Graph action-notice; message includes `not found in cluster tree` |
+| Application `viewInTree`: app not found | _(no webview message)_ | `showWarningMessage` naming application |
 | Network / timeout on CRD get | `error` | Warning or error per severity |
+
+### Tree reveal mapping (host)
+
+`ClusterTreeProvider.revealTreeResource(kind, name, namespace)` resolves existing tree items only:
+
+| Kind | Tree path |
+|------|-----------|
+| Pod | Workloads → Pods |
+| Deployment, StatefulSet, DaemonSet, CronJob | Workloads → matching subcategory |
+| Service | Networking → Services |
+| ConfigMap, Secret | Configuration → ConfigMaps / Secrets |
+
+`ClusterTreeProvider.revealTreeApplication(name, namespace)` resolves under **ArgoCD Applications** (`argocd` → `argocdApplication`) by matching `resourceName` and application namespace. Returns `false` when the category, application list, or matching item is unavailable.
 
 ## Open Implementation Decisions
 

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -94,7 +94,29 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 - **Hidden vs disabled:** When no rows apply, the overflow control is not rendered. During application-level sync/refresh or per-node in-flight `resourceAction`, menus disable (busy nodes show optional “Action in progress…” in the open menu).
 - **Action results:** Terminal `resourceActionResult` with `success: false` shows a dismissible graph action-notice banner. User-cancelled restart confirmation does not show the banner. Unknown `actionId` or unsupported kind for a known id returns explicit host messages without crashing the panel.
-- **View In Tree from managed-resource nodes** — success/failure semantics and tree-reveal fallback copy are specified in issue #221; #224 exposes the menu entry and routes `resource.navigateTree` through the host registry.
+
+### View In Tree and tree reveal (resolved, issue #221)
+
+Two navigation surfaces share one host tree-reveal implementation; neither mutates cluster state.
+
+| Source | Message / action | Host behavior | User feedback |
+|--------|------------------|---------------|---------------|
+| Application root overflow, sub-header, or header | `viewInTree` | Focus `kube9ClusterView`, refresh tree, call `ClusterTreeProvider.revealTreeApplication(applicationName, applicationNamespace)` bound to the open panel's `ApplicationKey` | On success: tree reveals and selects the matching `argocdApplication` item. On failure: `showWarningMessage` when the tree is focused but the application item is not found; `showErrorMessage` on unexpected host errors |
+| Managed-resource tile overflow | `resourceAction` with `actionId: resource.navigateTree` | Same pre-checks as registry handler: kubeconfig available, active context matches panel context; focus tree, refresh, `revealTreeResource(kind, name, namespace)` from the tile's `ManagedResourceKey` | `resourceActionProgress` then terminal `resourceActionResult`; failures also show the dismissible graph action-notice banner |
+| Details tab navigate affordance | `navigateToResource` with `kind`, `name`, `namespace` | Delegate to the same reveal helper as `resource.navigateTree` for kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`; reject or no-op with explicit error for unsupported kinds | Unsupported kind: `showErrorMessage` with safe copy. Supported kind failure: same messages as `resource.navigateTree` result text (Details tab does not use the graph action-notice banner) |
+
+**Identity for reveal:** Use `ManagedResourceKey.namespace` (trimmed; empty only for cluster-scoped kinds when the CRD omits namespace), `kind`, and `name`. Optional `apiGroup` is forwarded when present but is not required for v1 reveal of core kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`.
+
+**Failure copy (managed resource, terminal result message):**
+
+| Condition | `success` | Message pattern |
+|-----------|-----------|-----------------|
+| Kubeconfig / tree unavailable | false | `resource.navigateTree failed for {kind} {name}: tree view is unavailable` |
+| Active cluster context ≠ panel context | false | `resource.navigateTree failed for {kind} {name}: active cluster context does not match this application` |
+| Supported kind, no matching tree item | false | `resource.navigateTree failed for {kind} {name}: resource not found in cluster tree` |
+| Reveal succeeded | true | `Focused {kind} {name} in cluster tree` |
+
+Mapping failure is a navigation limitation: the host must not fabricate tree items or resource identity. List RBAC gaps that prevent category expansion may surface as "not found in cluster tree" when no item can be resolved.
 
 ## Kubernetes AI Conformance Flow
 

--- a/.ai/runtime/execution_model.md
+++ b/.ai/runtime/execution_model.md
@@ -44,8 +44,8 @@ See [Startup and bootstrap](startup_bootstrap.md): the extension may send `appli
 | `sync` | Application-level sync (CRD patch) |
 | `refresh` | Normal refresh |
 | `hardRefresh` | Hard refresh (confirmation in host) |
-| `viewInTree` | Focus application in cluster tree |
-| `navigateToResource` | `kind`, `name`, `namespace` — navigate to tree / describe where supported |
+| `viewInTree` | Reveal open Application under ArgoCD Applications in cluster tree |
+| `navigateToResource` | `kind`, `name`, `namespace` — reveal matching cluster-tree resource when kind is in `NAVIGATE_TREE_SUPPORTED_KINDS` |
 
 ### Webview → extension (resource graph extension)
 

--- a/.ai/specs/argocd-diagram-interface.spec.md
+++ b/.ai/specs/argocd-diagram-interface.spec.md
@@ -88,6 +88,16 @@ Interface validation should include graph layout readability, selectable tiles, 
 
 **Implementation polish (#224):** Add tile `:hover` and `argocd-graph-node--overflow-open` styling; wire overflow-open class from `ResourceGraphNodeTile` when menu is open; suppress action-notice banner when result message is `Cancelled`.
 
+**View In Tree test matrix (issue #221):**
+
+| Area | Module / suite | Must prove |
+|------|----------------|------------|
+| Registry (existing) | `kindCapabilityRegistry.test.ts` | `resource.navigateTree` success when `revealTreeResource` returns true; failure when false; context mismatch and tree-unavailable paths |
+| Tree provider | `ClusterTreeProvider.reveal.test.ts` (or extend existing tree suite) | `revealTreeResource` maps Deployment/Pod/Service/ConfigMap to correct categories; `revealTreeApplication` finds `argocdApplication` by name+namespace; returns false when item missing |
+| Provider stubs | `ArgoCDApplicationWebviewProvider.navigation.test.ts` | `viewInTree` calls `revealTreeApplication` with panel namespace; `navigateToResource` delegates to shared reveal helper (no info-toast stub) |
+| Parity | `argocdGraphNodeCapabilities.test.ts` | Webview navigate kinds still match host `NAVIGATE_TREE_SUPPORTED_KINDS` |
+| Manual | Extension Development Host + Argo CD cluster | Application View In Tree selects app in tree; Deployment tile Navigate reveals workload; Job tile has no overflow; wrong-context cluster shows context-mismatch message |
+
 Build and packaging checks should run the existing repository commands for the affected scope: `npm run compile`, `npm run build`, `npm run test:unit`, and `npm run package` as appropriate for implementation changes. Packaging review should confirm Argo CD webview scripts, CSS, React Flow styles, and shared webview header CSS are present in the VSIX, and bundle-size changes to `media/argocd-application/main.js` remain within the documented target or are explicitly justified.
 
 ## References


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #221
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.