### PR TITLE
docs(ai): refine issue #222 contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -174,7 +174,7 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - **Unsupported or non-navigable managed-resource nodes** hide the overflow control entirely when the Kind Capability Registry yields zero eligible actions. There is no disabled-only ⋮ affordance and no placeholder “No actions” menu.
 - **Application root overflow** shows **View in tree** only (`viewInTree` message). Sync, refresh, and hard refresh stay on the webview header and sub-header in v1; root overflow does not duplicate GitOps operations.
 - **Managed-resource overflow labels (v1):** Deployment — **Restart rollout**, **Navigate to resource in tree**; other navigate-supported kinds — **Navigate to resource in tree** only. Labels match `graphNodeCapabilities.ts` and host `actionId` registry entries.
-- **Progressive disclosure for very large Applications** (grouping, collapse, capped render) is owned by issue #222; tiles on visible nodes still follow the rules above.
+- **Progressive disclosure for very large Applications** — resolved in `.ai/interface/presentation.md` and `.ai/data/consistency.md` (issue #222): webview kind-based grouping over complete DTO; threshold 40 managed resources.
 
 **Resolved (View In Tree and tree reveal, issue #221):**
 

--- a/.ai/data/consistency.md
+++ b/.ai/data/consistency.md
@@ -67,13 +67,18 @@ Otherwise:
 
 ### Grouping and progressive disclosure (presentation layer)
 
-Large-application grouping (#222) is a **webview presentation transform** over the complete DTO node set unless a future contract explicitly adds grouped DTO nodes.
+Large-application grouping (#222) is a **webview presentation transform** over the complete DTO node set. The host always posts every valid managed-resource node; it does not omit nodes to meet a render cap.
 
-Until then:
+**Kind-based grouping (v1):**
 
+- When managed-resource count exceeds **40** (`LARGE_APP_KIND_GROUP_THRESHOLD`), the webview initially renders **kind group** summary tiles (synthetic React Flow nodes, not DTO entities) collapsed by default.
+- Each kind group aggregates managed resources sharing the same `kind` (case-sensitive Kubernetes kind string). The Application root tile is always visible.
+- Expanding a kind group reveals the member leaf tiles using stable `GraphNodeId` values from the incoming DTO. Collapsing a group hides leaf tiles in the canvas only; DTO identity is unchanged.
+- **Reachability:** every returned managed resource remains reachable through at least one of: expand its kind group on the canvas, the **Details** drift table, or **Navigate to resource in tree** for supported kinds.
 - **Selection** is keyed by `GraphNodeId` on the DTO. A selected resource stays selected across refresh while that id remains in `resourceGraph.nodes`.
 - **Clear selection** when the selected id disappears from the incoming DTO (removed resource, renamed resource, or `ApplicationKey` change).
-- Collapsing or hiding a tile in the UI must not clear selection if the underlying id is still present in the DTO; expanding again should restore the selected styling on that tile.
+- Collapsing a kind group must not clear selection if the underlying id is still present in the DTO; re-expanding restores selected styling on that leaf tile.
+- Grouped presentation does not change `structureVersion` or host merge behavior; only the webview render layer maps DTO nodes to visible React Flow nodes.
 
 ## Flat list vs graph consistency
 
@@ -122,6 +127,4 @@ While `operationState.phase` is `Running` or `Terminating`:
 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
-### ArgoCD large graph consistency (M16 #222)
-- Specify how grouping or progressive disclosure preserves access to every returned `ArgoCDResource` while keeping `crd_flat` count checks meaningful.
-- If grouped nodes are represented in the DTO, define how grouped tiles map to underlying `GraphNodeId` values for selection and merge. Until then, selection and merge rules above apply to the flat DTO node set.
+_(No open bullets for ArgoCD large graph consistency — resolved in **Grouping and progressive disclosure** above, issue #222.)_

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -120,7 +120,7 @@ The **Application resource graph** is a derived, directed view model for React F
 | `structureVersion` | string | Fingerprint that changes when the **set of node ids** or **edge endpoints** changes. Used with polling merge (see [consistency.md](./consistency.md)). Attribute-only sync/health updates do not bump it. |
 | `layoutHint` | optional object | Non-authoritative hints from the assembler (for example `{ "algorithm": "dagre-lr", "version": "1" }`). Webview ignores when `structureVersion` changes or may omit hints entirely. |
 | `observedAt` | ISO 8601 string | When this graph snapshot was assembled |
-| `truncated` | boolean (optional) | `true` when the delivered graph is presentation-limited for a large application. The Application root is always present, and the interface must still preserve a path to every returned managed resource through grouping, expansion, Details, or tree navigation rather than silently losing resources. Omitted or `false` when the full managed set is directly visible. |
+| `truncated` | boolean (optional) | **Reserved; omit in v1.** Host must not use this flag to omit managed-resource nodes from `nodes[]`. Large-application kind grouping is a webview-only presentation transform (issue #222). If a future contract adds grouped DTO nodes, this field may signal presentation-limited delivery while preserving reachability through expansion, Details, or tree navigation. |
 
 ### ResourceGraphNode
 

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -154,4 +154,4 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 - **`apiGroup` for tree navigation:** Not required for v1 reveal of core kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`. Host reveal uses `kind`, `name`, and trimmed `namespace` from `ManagedResourceKey`. When `apiGroup` is present on the key or `resourceAction` payload, forward it for future CRD-kind routing; omitting it must not block core-kind reveal. Canonical `group` vs `apiGroup` naming on the wire remains in #223.
 
-- Define whether large-application grouping is represented in the DTO as grouped nodes or remains an interface-only transform over complete resource nodes. _(M16 #222.)_
+- **Large-application grouping (issue #222):** Remains an **interface-only transform** over the complete flat DTO node set in v1. Kind group tiles are synthetic webview nodes; they are not serialized in `ApplicationResourceGraph.nodes`. The host does not set `truncated: true` to omit managed-resource nodes.

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -107,7 +107,7 @@ Native Argo CD UI resource graphs use this API; kube9-vscode targets **visual pa
 
 - **Stable node id**: deterministic string from `(group/,)kind/namespace/name` (and Application root id from app metadata).
 - **Incremental refresh**: new `resourceGraph` messages merge by node id; layout cache is a data/runtime concern, and graph payloads are complete snapshots for the host-to-webview contract unless a future patch message is explicitly added.
-- **Caps**: when node count exceeds product limit, host sets `truncated: true` and groups or collapses visible nodes per data/interface contracts; never silently drop Application root or remove the user's path to a returned managed resource.
+- **Large applications**: the host delivers the complete managed-resource node set on every `resourceGraph` post. Kind-based grouping and collapse are webview presentation concerns (issue #222); the host does not omit nodes to meet a render cap. Do not set `truncated: true` to signal node omission in v1.
 
 ### Status semantics (integration boundary)
 

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -110,7 +110,11 @@ Drift table presentation inside **Details** is unchanged in intent: filter for o
 
 ### Large applications
 
-When node count exceeds a practical layout threshold, the graph uses **progressive disclosure** (grouping, collapse, or capped initial render with explicit expand) so layout and polling updates stay responsive. Empty or single-node graphs show an explicit empty state, not a blank canvas.
+When managed-resource count exceeds **40**, the graph enters **kind-based grouping** on initial render: collapsed kind summary tiles replace direct leaf tiles until the user expands a group. At or below 40 managed resources, all leaf tiles render directly without grouping.
+
+**Affordance placement:** Limited-topology and large-application hints render in the `GraphTopologyAffordances` strip between the canvas toolbar and the React Flow viewport (same region as today). Large-application copy when grouping is active: _"Large application: resources are grouped by kind. Expand a group or open the Details tab to reach every managed resource."_
+
+**Empty and root-only graphs:** Zero managed resources show the explicit empty state (`GraphEmptyState`), not a blank canvas. A single managed resource renders a normal Application root plus one leaf tile without an extra banner.
 
 ### Loading and errors
 
@@ -148,7 +152,10 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 **Resolved (graph tile chrome, issue #224):**
 
-- **Tile sizing baseline:** 220px width, minimum 72px height, VS Code widget background and panel border — implementation constants in `styles.css`, not product-level pixel mandates. Large-application spacing and fit-view thresholds remain issue #222.
+- **Tile sizing baseline:** 220px width, minimum 72px height, VS Code widget background and panel border — implementation constants in `styles.css`, not product-level pixel mandates.
+- **Layout spacing (issue #222):** Dagre and tier-fallback layout use the same 220×72 node box; rank separation 96px and node separation 48px are implementation constants in `constants.ts`.
+- **Fit-view (issue #222):** Auto-fit runs on initial graph load and when the user activates **Fit** on the canvas toolbar. Structural refresh, kind-group expand/collapse, and attribute-only ticks preserve viewport per refresh-merge contracts (#227).
+- **Large-application hints (issue #222):** Copy and placement defined under **Large applications** above; limited-topology copy remains in `graphTopologyAffordanceRules.ts`.
 - **Visual states:**
 
 | State | Treatment |
@@ -160,4 +167,4 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 | Overflow open | `argocd-graph-node--overflow-open` on tile; menu uses VS Code menu background tokens |
 
 - Sync and health badges, kind icon, truncated name, and ⋮ overflow align with the **Graph tiles (nodes)** table above in this document.
-- **Limited-topology and large-application hints** — copy and placement for `topologyMode: limited` and grouping affordances are defined in graph topology components and issue #222; not repeated here.
+- **Limited-topology and large-application hints** — resolved under **Large applications** in this document and in `graphTopologyAffordanceRules.ts` (issue #222).

--- a/.ai/specs/argocd-diagram-interface.spec.md
+++ b/.ai/specs/argocd-diagram-interface.spec.md
@@ -22,7 +22,7 @@ The capability runs in the existing VS Code extension model: Node.js extension h
 
 Kubernetes and Argo CD I/O happen only in the extension host. The required baseline source is the Argo CD Application CRD, including `status.resources`. Optional enrichment may use Argo CD REST `resource-tree` when explicitly configured and authorized, or Kubernetes owner references when enabled and permitted. Optional enrichment failure falls back to CRD-flat graph rendering without failing the whole panel when the Application CRD remains readable.
 
-The graph data contract is `ApplicationResourceGraph`, a derived JSON-safe DTO with `applicationKey`, `nodes`, `edges`, `topologySource`, `topologyMode`, `structureVersion`, optional `layoutHint`, `observedAt`, and optional `truncated`. Stable identity is based on `ManagedResourceKey` and `GraphNodeId`, not visible labels or React Flow internals. `ArgoCDApplication.resources` remains the sync and health authority for CRD-backed resources.
+The graph data contract is `ApplicationResourceGraph`, a derived JSON-safe DTO with `applicationKey`, `nodes`, `edges`, `topologySource`, `topologyMode`, `structureVersion`, optional `layoutHint`, `observedAt`, and optional `truncated` (reserved; host omits in v1 — see [data_model.md](../data/data_model.md)). Stable identity is based on `ManagedResourceKey` and `GraphNodeId`, not visible labels or React Flow internals. `ArgoCDApplication.resources` remains the sync and health authority for CRD-backed resources.
 
 **CRD-flat baseline assembly (`topologySource: crd_flat`):**
 
@@ -97,6 +97,19 @@ Interface validation should include graph layout readability, selectable tiles, 
 | Provider stubs | `ArgoCDApplicationWebviewProvider.navigation.test.ts` | `viewInTree` calls `revealTreeApplication` with panel namespace; `navigateToResource` delegates to shared reveal helper (no info-toast stub) |
 | Parity | `argocdGraphNodeCapabilities.test.ts` | Webview navigate kinds still match host `NAVIGATE_TREE_SUPPORTED_KINDS` |
 | Manual | Extension Development Host + Argo CD cluster | Application View In Tree selects app in tree; Deployment tile Navigate reveals workload; Job tile has no overflow; wrong-context cluster shows context-mismatch message |
+
+**Large-application layout and grouping test matrix (issue #222):**
+
+| Area | Module / suite | Must prove |
+|------|----------------|------------|
+| Host completeness | `ApplicationResourceGraphAssembler.test.ts` | Assembler does not call `truncateApplicationResourceGraph` in production paths; managed node count equals valid `resources[]` rows for graphs above 40 managed resources |
+| Layout constants | `argocdGraphLayout.test.ts` | Dagre uses 220×72 node box; left-to-right rank ordering; ranksep/nodesep constants match `constants.ts` |
+| Kind grouping | `argocdGraphGrouping.test.ts` (new) | Above threshold, initial render shows collapsed kind groups; expand reveals all member `GraphNodeId` values; collapse hides leaves without clearing DTO selection |
+| Reachability | `argocdGraphGrouping.test.ts` | `countManagedResourceNodes(dto)` unchanged by grouping transform; every DTO managed id reachable after expand or via Details row fixture |
+| Fit-view | `argocdGraphLayout.test.ts` | Auto-fit on initial load only; explicit Fit triggers fit; structural tick and group expand/collapse do not set `shouldAutoFit` |
+| Affordances | `graphTopologyAffordances.test.ts` | Large-app grouping message when grouped mode active; truncation omission message removed; limited-topology message unchanged |
+| Refresh merge | `argocdGraphLayout.test.ts` + `mergeGraphFlowState` | Grouped presentation preserves positions on attribute-only ticks; relayout on `structureVersion` change; selection survives collapse when id remains in DTO (#227) |
+| Manual | Extension Development Host + Application with 50+ managed resources | Initial grouped view readable; expand one kind group; Fit resets viewport; Details lists all resources; refresh preserves expanded group selection when possible |
 
 Build and packaging checks should run the existing repository commands for the affected scope: `npm run compile`, `npm run build`, `npm run test:unit`, and `npm run package` as appropriate for implementation changes. Packaging review should confirm Argo CD webview scripts, CSS, React Flow styles, and shared webview header CSS are present in the VSIX, and bundle-size changes to `media/argocd-application/main.js` remain within the documented target or are explicitly justified.
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #222
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.