### PR TITLE
docs(ai): refine issue #223 contract updates

### DIFF
--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -152,6 +152,7 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 **Resolved (tree reveal v1, issue #221):**
 
-- **`apiGroup` for tree navigation:** Not required for v1 reveal of core kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`. Host reveal uses `kind`, `name`, and trimmed `namespace` from `ManagedResourceKey`. When `apiGroup` is present on the key or `resourceAction` payload, forward it for future CRD-kind routing; omitting it must not block core-kind reveal. Canonical `group` vs `apiGroup` naming on the wire remains in #223.
+- **`apiGroup` for tree navigation:** Not required for v1 reveal of core kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`. Host reveal uses `kind`, `name`, and trimmed `namespace` from `ManagedResourceKey`. When `apiGroup` is present on the key, forward it for future CRD-kind routing; omitting it must not block core-kind reveal.
+- **`group` vs `apiGroup` on the wire (issue #223):** DTO field `apiGroup`; webview protocol field `group` on `resourceAction` and `ResourceNodeRef`. Map at the webview boundary (`buildResourceActionPayload` / `buildResourceNodeRef`). Validators reject `apiGroup` on webview messages. Do not emit both fields on the same message.
 
 - **Large-application grouping (issue #222):** Remains an **interface-only transform** over the complete flat DTO node set in v1. Kind group tiles are synthetic webview nodes; they are not serialized in `ApplicationResourceGraph.nodes`. The host does not set `truncated: true` to omit managed-resource nodes.

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -144,7 +144,7 @@ JSON messages over `webview.postMessage` / `onDidReceiveMessage`. Types are stri
 | `viewInTree` | — | Focus `kube9ClusterView`, refresh tree, reveal open Application as `argocdApplication` item when context matches |
 | `navigateToResource` | `kind`, `name`, `namespace` | Same reveal path as `resource.navigateTree` for supported kinds; explicit error for unsupported kinds |
 | `graphRefresh` | optional `bypassCache?: boolean` | Reload Application and rebuild `ApplicationResourceGraph` |
-| `resourceAction` | `actionId`, `kind`, `name`, `namespace`, optional `group`, `version` | Run registry action; emit progress/result |
+| `resourceAction` | `actionId`, `kind`, `name`, `namespace`, optional `group`, `version` | Run registry action; emit progress/result. Wire uses `group` (not `apiGroup`); maps from `ManagedResourceKey.apiGroup` at the webview boundary. No `nodeId` on the wire — identity is the resource reference fields above. |
 
 ### Extension → webview
 
@@ -240,7 +240,12 @@ The report does not shell out beyond the existing operator status read path. It 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### ArgoCD resource graph integration
-- Define the final `resourceAction` payload shape for selected nodes, including whether both `group` and `apiGroup` appear or one canonical field is used across parser, tree reveal, and action routing. _(Tracked in M16 protocol issue; out of CRD-flat baseline scope.)_
+
+**Resolved (`resourceAction` wire shape, issue #223):**
+
+- **`resourceAction` payload (webview → host):** Required fields: `actionId`, `kind`, `name`, `namespace`. Optional: `group`, `version`. `GraphNodeId` is not serialized on this message; the host routes by resource reference plus `actionId`.
+- **Canonical API group naming:** Internal DTOs and parsers use `ManagedResourceKey.apiGroup`. The webview protocol uses optional wire field `group` only. `buildResourceActionPayload` maps `apiGroup` → `group`; `buildResourceNodeRef` maps `group` → `ResourceNodeRef.group`. Validators reject `apiGroup` on webview messages. Tree reveal and action routing accept omitted `group` for core kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`.
+- **`resourceActionProgress` / `resourceActionResult`:** Include `actionId`, `phase` or `success`/`message`, and optional `nodeRef` with the same `kind`, `name`, `namespace`, optional `group`, `version` shape.
 
 **Resolved (CRD-flat baseline):**
 

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -92,7 +92,7 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 | Managed resource | StatefulSet, DaemonSet, CronJob, Pod, Service, ConfigMap, Secret | Navigate to resource in tree | `resourceAction` (`resource.navigateTree`) |
 | Managed resource | Other kinds (Job, Ingress, CRD, unknown) | _(overflow hidden)_ | — |
 
-- **Hidden vs disabled:** When no rows apply, the overflow control is not rendered. During application-level sync/refresh or per-node in-flight `resourceAction`, menus disable (busy nodes show optional “Action in progress…” in the open menu).
+- **Hidden vs disabled:** When no rows apply, the overflow control is not rendered. During application-level sync/refresh (`operationProgress` Running or webview `menusDisabled`), all tile overflow menus disable. During a per-node in-flight `resourceAction` (`resourceActionProgress` Running with `nodeRef`), only that tile's overflow disables (optional in-menu copy: "Action in progress…"). The webview is the primary guard; the host does not queue overlapping `resourceAction` messages in v1.
 - **Action results:** Terminal `resourceActionResult` with `success: false` shows a dismissible graph action-notice banner. User-cancelled restart confirmation does not show the banner. Unknown `actionId` or unsupported kind for a known id returns explicit host messages without crashing the panel.
 
 ### View In Tree and tree reveal (resolved, issue #221)

--- a/.ai/runtime/execution_model.md
+++ b/.ai/runtime/execution_model.md
@@ -52,7 +52,7 @@ See [Startup and bootstrap](startup_bootstrap.md): the extension may send `appli
 | type | Purpose |
 |------|---------|
 | `graphRefresh` | Explicit graph refresh request; host reloads Application CRD and optional topology inputs, then emits `resourceGraph` |
-| `resourceAction` | Kind-scoped action from a node menu; payload includes `actionId`, stable `nodeId`, `kind`, `name`, `namespace`, and optional `group` / `version` |
+| `resourceAction` | Kind-scoped action from a node menu; payload includes `actionId`, `kind`, `name`, `namespace`, and optional `group` / `version` (maps from `ManagedResourceKey.apiGroup` at the webview boundary). `GraphNodeId` stays on the graph DTO only. |
 
 Application-level actions stay on the root node or header; tile menus use `resourceAction`.
 
@@ -108,13 +108,22 @@ Prefer merge-style handling of `resourceGraph` snapshots for status-only deltas 
 
 ### Concurrent operations
 
-While `operationProgress.phase === 'Running'`, treat the application as busy: block conflicting header and node actions until terminal phase or `error`.
+**Application-level busy:** While `operationProgress.phase === 'Running'` for sync, refresh, or hard refresh, the host sets `operationInProgress` on the panel. Duplicate sync requests receive an `error` message. The webview sets `menusDisabled` from the same progress stream and disables all tile overflow menus until a terminal phase.
+
+**Per-node busy:** `resourceActionProgress` with `phase: 'Running'` and a `nodeRef` adds that resource key (`namespace/kind/name`) to webview `busyNodeKeys`, disabling only that tile's overflow (optional in-menu copy: "Action in progress…"). Terminal progress or `resourceActionResult` clears the key.
+
+**Cross-layer rule (v1):** The webview is the primary guard against conflicting menu clicks during app-level or per-node busy states. Host handlers remain safe when invoked; navigate is idempotent. No host-side queue for overlapping `resourceAction` messages is required in v1.
 
 ## Open Implementation Decisions
 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### ArgoCD diagram protocol cleanup
-- Remove or alias legacy graph protocol names (`graphData`, `graphPatch`, `graphAction`, `actionResult`) in code and tests so the shipped host/webview protocol consistently uses `resourceGraph`, `resourceAction`, `resourceActionProgress`, and `resourceActionResult`.
-- Decide whether a future patch-style graph message is needed after complete `resourceGraph` snapshot merging is implemented and measured.
-- Define concurrent busy-state behavior when an Application-level operation and a selected resource action are requested close together.
+
+**Resolved (canonical names, issue #223):**
+
+- Shipped host/webview protocol uses only `resourceGraph`, `resourceAction`, `resourceActionProgress`, and `resourceActionResult` for graph snapshots and tile actions. Legacy names (`graphData`, `graphPatch`, `graphAction`, `actionResult`) are rejected by validators; no runtime alias shim in v1.
+
+**Deferred:**
+
+- **Patch-style graph message:** Introduce only after complete `resourceGraph` snapshot merging is implemented and measured (#227). Until then, the host posts complete snapshots only.

--- a/.ai/specs/argocd-diagram-interface.spec.md
+++ b/.ai/specs/argocd-diagram-interface.spec.md
@@ -59,6 +59,17 @@ Resource-tree and owner-reference enrichment tests should verify that optional e
 
 Runtime and serialization tests should cover `resourceGraph`, `resourceAction`, `resourceActionProgress`, and `resourceActionResult` message handling, including stable node ids, `structureVersion` merge behavior, selected-node preservation, removed-node selection clearing, and host-owned polling after sync, refresh, hard refresh, or rollout restart.
 
+**Canonical protocol alignment test matrix (issue #223):**
+
+| Area | Module / suite | Must prove |
+|------|----------------|------------|
+| Webview validation | `argocdApplicationProtocol.test.ts` | Accepts `resourceAction` with required fields and optional `group`/`version`; rejects legacy types (`graphData`, `graphPatch`, `graphAction`); rejects `apiGroup` on webview messages |
+| Extension validation | `argocdApplicationProtocol.test.ts` | Accepts `resourceGraph`, `resourceActionProgress`, `resourceActionResult`; rejects legacy extension types (`graphPatch`, `actionResult`, `graphData`) |
+| Payload mapping | `argocdGraphNodeCapabilities.test.ts` | `buildResourceActionPayload` maps `ManagedResourceKey.apiGroup` to wire `group`; omits `group` when `apiGroup` absent |
+| Host nodeRef | `kindCapabilityRegistry.test.ts` | Progress/result `nodeRef` mirrors incoming `group`/`version`; navigate and restart handlers emit progress then terminal result |
+| Provider push | `ArgoCDApplicationWebviewProvider.graph.test.ts` | Open and refresh post `applicationData` then `resourceGraph` (not legacy graph message names) |
+| Busy state (webview) | `useGraphInteractionState` or component tests | App-level `menusDisabled` during sync/refresh; per-node `busyNodeKeys` from `resourceActionProgress` Running and cleared on terminal phases |
+
 **Refresh merge test matrix (unit):**
 
 | Area | Module / suite | Must prove |


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #223
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.