### PR TITLE
feat(argocd): reveal graph resources in cluster tree (#221)

### DIFF
--- a/src/services/KindCapabilityRegistry.ts
+++ b/src/services/KindCapabilityRegistry.ts
@@ -13,6 +13,7 @@ import type {
     ResourceNodeRef
 } from '../types/argocdWebviewProtocol';
 import { ClusterTreeProvider } from '../tree/ClusterTreeProvider';
+import { revealManagedResourceInTree } from './treeRevealHelper';
 
 export const ACTION_DEPLOYMENT_RESTART_ROLLOUT = 'deployment.restartRollout';
 export const ACTION_RESOURCE_NAVIGATE_TREE = 'resource.navigateTree';
@@ -299,65 +300,43 @@ async function handleResourceNavigateTree(
         `Navigating to ${kind} ${name}...`
     );
 
-    if (!ctx.treeProvider.getKubeconfigPath()) {
-        postResourceActionProgress(ctx.panel, message, 'Failed', 'Tree view is unavailable');
+    const result = await revealManagedResourceInTree(
+        { treeProvider: ctx.treeProvider, panelContext: ctx.context },
+        kind,
+        name,
+        namespace
+    );
+
+    if (result.success) {
+        postResourceActionProgress(
+            ctx.panel,
+            message,
+            'Succeeded',
+            result.message ?? `Focused ${kind} ${name} in cluster tree`
+        );
         postResourceActionResult(
             ctx.panel,
             message,
-            false,
-            `${actionId} failed for ${kind} ${name}: tree view is unavailable`
+            true,
+            result.message ?? `Focused ${kind} ${name} in cluster tree`
         );
         return;
     }
 
-    const contextMatches = await ctx.treeProvider.isCurrentContext(ctx.context);
-    if (!contextMatches) {
-        postResourceActionProgress(ctx.panel, message, 'Failed', 'Cluster context mismatch');
-        postResourceActionResult(
-            ctx.panel,
-            message,
-            false,
-            `${actionId} failed for ${kind} ${name}: active cluster context does not match this application`
-        );
-        return;
-    }
+    const failureDetail =
+        result.reason === 'not_found'
+            ? 'Resource not found in tree'
+            : result.reason === 'context_mismatch'
+              ? 'Cluster context mismatch'
+              : result.reason === 'tree_unavailable'
+                ? 'Tree view is unavailable'
+                : result.detail ?? 'Navigation failed';
 
-    try {
-        await vscode.commands.executeCommand('kube9.treeView.focus');
-        ctx.treeProvider.refresh();
-
-        const revealed = await ctx.treeProvider.revealTreeResource(kind, name, namespace);
-        if (revealed) {
-            postResourceActionProgress(
-                ctx.panel,
-                message,
-                'Succeeded',
-                `Focused ${kind} ${name} in cluster tree`
-            );
-            postResourceActionResult(
-                ctx.panel,
-                message,
-                true,
-                `Focused ${kind} ${name} in cluster tree`
-            );
-            return;
-        }
-
-        postResourceActionProgress(ctx.panel, message, 'Failed', 'Resource not found in tree');
-        postResourceActionResult(
-            ctx.panel,
-            message,
-            false,
-            `${actionId} failed for ${kind} ${name}: resource not found in cluster tree`
-        );
-    } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        postResourceActionProgress(ctx.panel, message, 'Failed', detail);
-        postResourceActionResult(
-            ctx.panel,
-            message,
-            false,
-            `${actionId} failed for ${kind} ${name}: ${detail}`
-        );
-    }
+    postResourceActionProgress(ctx.panel, message, 'Failed', failureDetail);
+    postResourceActionResult(
+        ctx.panel,
+        message,
+        false,
+        result.message ?? `${actionId} failed for ${kind} ${name}: ${failureDetail}`
+    );
 }

--- a/src/services/treeRevealHelper.ts
+++ b/src/services/treeRevealHelper.ts
@@ -79,7 +79,11 @@ export async function revealApplicationInTree(
     treeProvider: ClusterTreeProvider,
     applicationName: string,
     applicationNamespace: string
-): Promise<{ success: boolean; notFound?: boolean; error?: string }> {
+): Promise<{ success: boolean; notFound?: boolean; treeUnavailable?: boolean; error?: string }> {
+    if (!treeProvider.getKubeconfigPath()) {
+        return { success: false, treeUnavailable: true };
+    }
+
     try {
         await focusAndRefreshClusterTree(treeProvider);
         const revealed = await treeProvider.revealTreeApplication(applicationName, applicationNamespace);

--- a/src/services/treeRevealHelper.ts
+++ b/src/services/treeRevealHelper.ts
@@ -1,0 +1,95 @@
+import * as vscode from 'vscode';
+import { ClusterTreeProvider } from '../tree/ClusterTreeProvider';
+
+export type ManagedResourceRevealFailureReason =
+    | 'tree_unavailable'
+    | 'context_mismatch'
+    | 'not_found'
+    | 'unexpected_error';
+
+export interface ManagedResourceRevealResult {
+    success: boolean;
+    reason?: ManagedResourceRevealFailureReason;
+    message?: string;
+    detail?: string;
+}
+
+export interface TreeRevealContext {
+    treeProvider: ClusterTreeProvider;
+    panelContext: string;
+}
+
+export async function focusAndRefreshClusterTree(treeProvider: ClusterTreeProvider): Promise<void> {
+    await vscode.commands.executeCommand('kube9ClusterView.focus');
+    treeProvider.refresh();
+}
+
+export async function revealManagedResourceInTree(
+    ctx: TreeRevealContext,
+    kind: string,
+    name: string,
+    namespace: string
+): Promise<ManagedResourceRevealResult> {
+    const trimmedNamespace = namespace.trim();
+
+    if (!ctx.treeProvider.getKubeconfigPath()) {
+        return {
+            success: false,
+            reason: 'tree_unavailable',
+            message: `resource.navigateTree failed for ${kind} ${name}: tree view is unavailable`
+        };
+    }
+
+    const contextMatches = await ctx.treeProvider.isCurrentContext(ctx.panelContext);
+    if (!contextMatches) {
+        return {
+            success: false,
+            reason: 'context_mismatch',
+            message: `resource.navigateTree failed for ${kind} ${name}: active cluster context does not match this application`
+        };
+    }
+
+    try {
+        await focusAndRefreshClusterTree(ctx.treeProvider);
+        const revealed = await ctx.treeProvider.revealTreeResource(kind, name, trimmedNamespace);
+        if (revealed) {
+            return {
+                success: true,
+                message: `Focused ${kind} ${name} in cluster tree`
+            };
+        }
+
+        return {
+            success: false,
+            reason: 'not_found',
+            message: `resource.navigateTree failed for ${kind} ${name}: resource not found in cluster tree`
+        };
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        return {
+            success: false,
+            reason: 'unexpected_error',
+            message: `resource.navigateTree failed for ${kind} ${name}: ${detail}`,
+            detail
+        };
+    }
+}
+
+export async function revealApplicationInTree(
+    treeProvider: ClusterTreeProvider,
+    applicationName: string,
+    applicationNamespace: string
+): Promise<{ success: boolean; notFound?: boolean; error?: string }> {
+    try {
+        await focusAndRefreshClusterTree(treeProvider);
+        const revealed = await treeProvider.revealTreeApplication(applicationName, applicationNamespace);
+        if (revealed) {
+            return { success: true };
+        }
+
+        return { success: false, notFound: true };
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        return { success: false, error: errorMessage };
+    }
+}

--- a/src/test/suite/services/kindCapabilityRegistry.test.ts
+++ b/src/test/suite/services/kindCapabilityRegistry.test.ts
@@ -308,4 +308,59 @@ suite('KindCapabilityRegistry', () => {
         assert.match(result.message, /not found in cluster tree/);
         panel.dispose();
     });
+
+    test('resource.navigateTree posts failure on context mismatch', async () => {
+        const dispatch = loadDispatch();
+        const panel = vscode.window.createWebviewPanel(
+            'kube9.argocdApplication',
+            'test',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+        const messages = capturePostMessages(panel);
+        const ctx = buildContext(panel);
+        (ctx.treeProvider as unknown as { isCurrentContext: () => Promise<boolean> }).isCurrentContext =
+            async () => false;
+
+        await dispatch(
+            ctx,
+            resourceActionMessage({
+                actionId: ACTION_RESOURCE_NAVIGATE_TREE,
+                kind: 'Deployment'
+            })
+        );
+
+        const result = lastResult(messages);
+        assert.ok(result);
+        assert.strictEqual(result.success, false);
+        assert.match(result.message, /context does not match/i);
+        panel.dispose();
+    });
+
+    test('resource.navigateTree posts failure when tree is unavailable', async () => {
+        const dispatch = loadDispatch();
+        const panel = vscode.window.createWebviewPanel(
+            'kube9.argocdApplication',
+            'test',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+        const messages = capturePostMessages(panel);
+        const ctx = buildContext(panel);
+        (ctx.treeProvider as unknown as { getKubeconfigPath: () => string }).getKubeconfigPath = () => '';
+
+        await dispatch(
+            ctx,
+            resourceActionMessage({
+                actionId: ACTION_RESOURCE_NAVIGATE_TREE,
+                kind: 'Deployment'
+            })
+        );
+
+        const result = lastResult(messages);
+        assert.ok(result);
+        assert.strictEqual(result.success, false);
+        assert.match(result.message, /tree view is unavailable/i);
+        panel.dispose();
+    });
 });

--- a/src/test/suite/tree/ClusterTreeProvider.reveal.test.ts
+++ b/src/test/suite/tree/ClusterTreeProvider.reveal.test.ts
@@ -121,6 +121,38 @@ suite('ClusterTreeProvider reveal', () => {
         assert.strictEqual(revealedItem, service);
     });
 
+    test('revealTreeResource maps Pod through workloads hierarchy', async () => {
+        const pod = treeItem(
+            'guestbook-ui-pod',
+            'pod',
+            resourceData({ resourceName: 'guestbook-ui-pod', namespace: 'guestbook' })
+        );
+        const deployment = treeItem(
+            'guestbook-ui',
+            'deployment',
+            resourceData({ resourceName: 'guestbook-ui', namespace: 'guestbook' })
+        );
+
+        providerInternals.getCategoryChildren = async (category) => {
+            if (category.type === 'workloads') {
+                return [treeItem('Deployments', 'deployments', resourceData())];
+            }
+            if (category.type === 'deployments') {
+                return [deployment];
+            }
+            if (category.type === 'deployment') {
+                return [pod];
+            }
+            return [];
+        };
+
+        const revealed = await provider.revealTreeResource('Pod', 'guestbook-ui-pod', 'guestbook');
+
+        assert.strictEqual(revealed, true);
+        assert.strictEqual(revealedItem, pod);
+        assert.strictEqual(focusCommandCalls, 1);
+    });
+
     test('revealTreeResource maps ConfigMap to configuration/configmaps', async () => {
         const configMap = treeItem(
             'guestbook-config',

--- a/src/test/suite/tree/ClusterTreeProvider.reveal.test.ts
+++ b/src/test/suite/tree/ClusterTreeProvider.reveal.test.ts
@@ -1,0 +1,206 @@
+import * as assert from 'assert';
+import * as vscode from '../../mocks/vscode';
+import { ClusterTreeProvider } from '../../../tree/ClusterTreeProvider';
+import { ClusterTreeItem } from '../../../tree/ClusterTreeItem';
+import { ParsedKubeconfig } from '../../../kubernetes/KubeconfigParser';
+import { TreeItemData } from '../../../tree/TreeItemTypes';
+import { resetKubernetesApiClient } from '../../../kubernetes/apiClient';
+
+function resourceData(overrides: Partial<TreeItemData> = {}): TreeItemData {
+    return {
+        context: { name: 'context-1', cluster: 'test-cluster-1' },
+        cluster: { name: 'test-cluster-1', server: 'https://api.test1.com:6443' },
+        ...overrides
+    };
+}
+
+function treeItem(
+    label: string,
+    type: ClusterTreeItem['type'],
+    data?: TreeItemData
+): ClusterTreeItem {
+    return new ClusterTreeItem(label, type, vscode.TreeItemCollapsibleState.Collapsed, data);
+}
+
+function mockKubeconfig(): ParsedKubeconfig {
+    return {
+        filePath: '/test/kubeconfig.yaml',
+        clusters: [{ name: 'test-cluster-1', server: 'https://api.test1.com:6443' }],
+        contexts: [{ name: 'context-1', cluster: 'test-cluster-1', user: 'user-1' }],
+        users: [{ name: 'user-1' }],
+        currentContext: 'context-1'
+    };
+}
+
+suite('ClusterTreeProvider reveal', () => {
+    let provider: ClusterTreeProvider;
+    let providerInternals: {
+        clusterItemsCache: Map<string, ClusterTreeItem>;
+        getCategoryChildren: (category: ClusterTreeItem) => Promise<ClusterTreeItem[]>;
+        treeView: { reveal: (item: ClusterTreeItem) => Promise<void> };
+    };
+    let revealedItem: ClusterTreeItem | undefined;
+    let focusCommandCalls = 0;
+
+    setup(() => {
+        resetKubernetesApiClient();
+        revealedItem = undefined;
+        focusCommandCalls = 0;
+
+        provider = new ClusterTreeProvider();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        providerInternals = provider as any;
+        provider.setKubeconfig(mockKubeconfig());
+
+        const clusterItem = treeItem('context-1', 'cluster', resourceData());
+        providerInternals.clusterItemsCache.set('context-1', clusterItem);
+
+        providerInternals.getCategoryChildren = async () => [];
+
+        (vscode.commands as unknown as { _registerCommand: (id: string, fn: () => Promise<void>) => void })
+            ._registerCommand('kube9ClusterView.focus', async () => {
+                focusCommandCalls += 1;
+            });
+
+        const mockTreeView = {
+            reveal: async (item: ClusterTreeItem) => {
+                revealedItem = item;
+            }
+        };
+        providerInternals.treeView = mockTreeView;
+    });
+
+    teardown(() => {
+        provider.dispose();
+    });
+
+    test('revealTreeResource maps Deployment to workloads/deployments', async () => {
+        const deployment = treeItem(
+            'guestbook-ui',
+            'deployment',
+            resourceData({ resourceName: 'guestbook-ui', namespace: 'guestbook' })
+        );
+
+        providerInternals.getCategoryChildren = async (category) => {
+            if (category.type === 'workloads') {
+                return [treeItem('Deployments', 'deployments', resourceData())];
+            }
+            if (category.type === 'deployments') {
+                return [deployment];
+            }
+            return [];
+        };
+
+        const revealed = await provider.revealTreeResource('Deployment', 'guestbook-ui', 'guestbook');
+
+        assert.strictEqual(revealed, true);
+        assert.strictEqual(revealedItem, deployment);
+        assert.strictEqual(focusCommandCalls, 1);
+    });
+
+    test('revealTreeResource maps Service to networking/services', async () => {
+        const service = treeItem(
+            'guestbook-svc',
+            'service',
+            resourceData({ resourceName: 'guestbook-svc', namespace: 'guestbook' })
+        );
+
+        providerInternals.getCategoryChildren = async (category) => {
+            if (category.type === 'networking') {
+                return [treeItem('Services', 'services', resourceData())];
+            }
+            if (category.type === 'services') {
+                return [service];
+            }
+            return [];
+        };
+
+        const revealed = await provider.revealTreeResource('Service', 'guestbook-svc', 'guestbook');
+
+        assert.strictEqual(revealed, true);
+        assert.strictEqual(revealedItem, service);
+    });
+
+    test('revealTreeResource maps ConfigMap to configuration/configmaps', async () => {
+        const configMap = treeItem(
+            'guestbook-config',
+            'configmap',
+            resourceData({ resourceName: 'guestbook-config', namespace: 'guestbook' })
+        );
+
+        providerInternals.getCategoryChildren = async (category) => {
+            if (category.type === 'configuration') {
+                return [treeItem('ConfigMaps', 'configmaps', resourceData())];
+            }
+            if (category.type === 'configmaps') {
+                return [configMap];
+            }
+            return [];
+        };
+
+        const revealed = await provider.revealTreeResource('ConfigMap', 'guestbook-config', 'guestbook');
+
+        assert.strictEqual(revealed, true);
+        assert.strictEqual(revealedItem, configMap);
+    });
+
+    test('revealTreeResource returns false when resource is missing', async () => {
+        providerInternals.getCategoryChildren = async (category) => {
+            if (category.type === 'workloads') {
+                return [treeItem('Deployments', 'deployments', resourceData())];
+            }
+            if (category.type === 'deployments') {
+                return [];
+            }
+            return [];
+        };
+
+        const revealed = await provider.revealTreeResource('Deployment', 'missing', 'guestbook');
+
+        assert.strictEqual(revealed, false);
+        assert.strictEqual(revealedItem, undefined);
+    });
+
+    test('revealTreeApplication finds argocdApplication by name and namespace', async () => {
+        const application = treeItem(
+            'guestbook',
+            'argocdApplication',
+            resourceData({ resourceName: 'guestbook', namespace: 'argocd' })
+        );
+
+        providerInternals.getCategoryChildren = async (category) => {
+            if (category.type === 'argocd') {
+                return [application];
+            }
+            return [];
+        };
+
+        const cluster = providerInternals.clusterItemsCache.get('context-1');
+        assert.ok(cluster);
+        cluster.argoCDInstalled = true;
+
+        const revealed = await provider.revealTreeApplication('guestbook', 'argocd');
+
+        assert.strictEqual(revealed, true);
+        assert.strictEqual(revealedItem, application);
+        assert.strictEqual(focusCommandCalls, 1);
+    });
+
+    test('revealTreeApplication returns false when application is missing', async () => {
+        providerInternals.getCategoryChildren = async (category) => {
+            if (category.type === 'argocd') {
+                return [];
+            }
+            return [];
+        };
+
+        const cluster = providerInternals.clusterItemsCache.get('context-1');
+        assert.ok(cluster);
+        cluster.argoCDInstalled = true;
+
+        const revealed = await provider.revealTreeApplication('guestbook', 'argocd');
+
+        assert.strictEqual(revealed, false);
+        assert.strictEqual(revealedItem, undefined);
+    });
+});

--- a/src/test/suite/webview/ArgoCDApplicationWebviewProvider.navigation.test.ts
+++ b/src/test/suite/webview/ArgoCDApplicationWebviewProvider.navigation.test.ts
@@ -1,0 +1,234 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { ArgoCDService } from '../../../services/ArgoCDService';
+import { ClusterTreeProvider } from '../../../tree/ClusterTreeProvider';
+import { ArgoCDApplicationWebviewProvider } from '../../../webview/ArgoCDApplicationWebviewProvider';
+import type { ArgoCDApplication, ArgoCDResource } from '../../../types/argocd';
+
+type MockWebviewWithFire = vscode.Webview & { _fireMessage(message: unknown): void };
+
+async function flushAsyncWork(): Promise<void> {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function flushUntil(predicate: () => boolean, maxTicks = 80): Promise<void> {
+    for (let i = 0; i < maxTicks; i++) {
+        if (predicate()) {
+            return;
+        }
+        await flushAsyncWork();
+    }
+}
+
+function deploymentRow(): ArgoCDResource {
+    return {
+        kind: 'Deployment',
+        name: 'guestbook-ui',
+        namespace: 'guestbook',
+        syncStatus: 'Synced',
+        healthStatus: 'Healthy'
+    };
+}
+
+function sampleApplication(): ArgoCDApplication {
+    return {
+        name: 'guestbook',
+        namespace: 'argocd',
+        project: 'default',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        syncStatus: {
+            status: 'Synced',
+            revision: 'abc123',
+            comparedTo: {
+                source: {
+                    repoURL: 'https://github.com/example/guestbook',
+                    path: '.',
+                    targetRevision: 'main'
+                }
+            }
+        },
+        healthStatus: { status: 'Healthy' },
+        source: {
+            repoURL: 'https://github.com/example/guestbook',
+            path: '.',
+            targetRevision: 'main'
+        },
+        destination: {
+            server: 'https://kubernetes.default.svc',
+            namespace: 'guestbook'
+        },
+        resources: [deploymentRow()]
+    };
+}
+
+function getWebviewPanels(): vscode.WebviewPanel[] {
+    return (vscode.window as unknown as { _getWebviewPanels(): vscode.WebviewPanel[] })._getWebviewPanels();
+}
+
+function disposeAllPanels(): void {
+    for (const panel of getWebviewPanels()) {
+        panel.dispose();
+    }
+}
+
+function getWarningMessages(): string[] {
+    return (vscode.window as unknown as { _getWarningMessages(): string[] })._getWarningMessages();
+}
+
+function getErrorMessages(): string[] {
+    return (vscode.window as unknown as { _getErrorMessages(): string[] })._getErrorMessages();
+}
+
+suite('ArgoCDApplicationWebviewProvider navigation', () => {
+    const contextName = 'minikube';
+    const namespace = 'argocd';
+    const applicationName = 'guestbook';
+
+    let mockExtensionContext: vscode.ExtensionContext;
+    let mockArgoCDService: ArgoCDService;
+    let mockTreeProvider: ClusterTreeProvider;
+    let revealTreeApplicationCalls = 0;
+    let revealTreeResourceCalls = 0;
+    let focusCommandCalls = 0;
+
+    setup(() => {
+        revealTreeApplicationCalls = 0;
+        revealTreeResourceCalls = 0;
+        focusCommandCalls = 0;
+
+        (vscode.commands as unknown as { _registerCommand: (id: string, fn: () => Promise<void>) => void })
+            ._registerCommand('kube9ClusterView.focus', async () => {
+                focusCommandCalls += 1;
+            });
+
+        mockExtensionContext = {
+            subscriptions: [],
+            extensionUri: vscode.Uri.file('/mock/extension/path'),
+            extensionPath: '/mock/extension/path',
+            secrets: {
+                get: async () => undefined
+            }
+        } as unknown as vscode.ExtensionContext;
+
+        mockArgoCDService = {
+            getApplication: async () => sampleApplication(),
+            refreshApplication: async () => {
+                /**/
+            },
+            invalidateCache: () => {
+                /**/
+            }
+        } as unknown as ArgoCDService;
+
+        mockTreeProvider = {
+            refresh: () => {
+                /**/
+            },
+            isCurrentContext: async () => true,
+            getKubeconfigPath: () => '/mock/kubeconfig',
+            revealTreeApplication: async () => {
+                revealTreeApplicationCalls += 1;
+                return true;
+            },
+            revealTreeResource: async () => {
+                revealTreeResourceCalls += 1;
+                return true;
+            }
+        } as unknown as ClusterTreeProvider;
+
+        (vscode.window as unknown as { _clearMessages(): void })._clearMessages();
+        disposeAllPanels();
+    });
+
+    teardown(async () => {
+        disposeAllPanels();
+        await flushAsyncWork();
+    });
+
+    async function openPanel(): Promise<vscode.WebviewPanel> {
+        const pending = ArgoCDApplicationWebviewProvider.showApplication(
+            mockExtensionContext,
+            mockArgoCDService,
+            mockTreeProvider,
+            applicationName,
+            namespace,
+            contextName
+        );
+        const panel = getWebviewPanels().at(-1);
+        assert.ok(panel);
+        await pending;
+        await flushUntil(() => getWebviewPanels().length > 0);
+        return panel;
+    }
+
+    test('viewInTree calls revealTreeApplication with panel namespace', async () => {
+        const panel = await openPanel();
+        const webview = panel.webview as unknown as MockWebviewWithFire;
+
+        webview._fireMessage({ type: 'viewInTree' });
+        await flushUntil(() => revealTreeApplicationCalls === 1);
+
+        assert.strictEqual(revealTreeApplicationCalls, 1);
+        assert.strictEqual(focusCommandCalls, 1);
+        assert.strictEqual(getWarningMessages().length, 0);
+        assert.strictEqual(getErrorMessages().length, 0);
+    });
+
+    test('viewInTree shows warning when application is not found', async () => {
+        mockTreeProvider = {
+            refresh: () => {
+                /**/
+            },
+            isCurrentContext: async () => true,
+            getKubeconfigPath: () => '/mock/kubeconfig',
+            revealTreeApplication: async () => false,
+            revealTreeResource: async () => true
+        } as unknown as ClusterTreeProvider;
+
+        const panel = await openPanel();
+        const webview = panel.webview as unknown as MockWebviewWithFire;
+
+        webview._fireMessage({ type: 'viewInTree' });
+        await flushUntil(() => getWarningMessages().length > 0);
+
+        const warning = getWarningMessages().at(-1);
+        assert.ok(warning);
+        assert.match(warning, /guestbook/);
+    });
+
+    test('navigateToResource delegates to revealTreeResource for supported kinds', async () => {
+        const panel = await openPanel();
+        const webview = panel.webview as unknown as MockWebviewWithFire;
+
+        webview._fireMessage({
+            type: 'navigateToResource',
+            kind: 'Deployment',
+            name: 'guestbook-ui',
+            namespace: 'guestbook'
+        });
+        await flushUntil(() => revealTreeResourceCalls === 1);
+
+        assert.strictEqual(revealTreeResourceCalls, 1);
+        assert.strictEqual(focusCommandCalls, 1);
+        assert.strictEqual(getWarningMessages().length, 0);
+        assert.strictEqual(getErrorMessages().length, 0);
+    });
+
+    test('navigateToResource shows error for unsupported kinds', async () => {
+        const panel = await openPanel();
+        const webview = panel.webview as unknown as MockWebviewWithFire;
+
+        webview._fireMessage({
+            type: 'navigateToResource',
+            kind: 'Job',
+            name: 'guestbook-job',
+            namespace: 'guestbook'
+        });
+        await flushUntil(() => getErrorMessages().length > 0);
+
+        assert.strictEqual(revealTreeResourceCalls, 0);
+        const error = getErrorMessages().at(-1);
+        assert.ok(error);
+        assert.match(error, /not supported/i);
+    });
+});

--- a/src/test/suite/webview/ArgoCDApplicationWebviewProvider.navigation.test.ts
+++ b/src/test/suite/webview/ArgoCDApplicationWebviewProvider.navigation.test.ts
@@ -174,6 +174,33 @@ suite('ArgoCDApplicationWebviewProvider navigation', () => {
         assert.strictEqual(getErrorMessages().length, 0);
     });
 
+    test('viewInTree shows warning on context mismatch', async () => {
+        mockTreeProvider = {
+            refresh: () => {
+                /**/
+            },
+            isCurrentContext: async () => false,
+            getKubeconfigPath: () => '/mock/kubeconfig',
+            revealTreeApplication: async () => {
+                revealTreeApplicationCalls += 1;
+                return true;
+            },
+            revealTreeResource: async () => true
+        } as unknown as ClusterTreeProvider;
+
+        const panel = await openPanel();
+        const webview = panel.webview as unknown as MockWebviewWithFire;
+
+        webview._fireMessage({ type: 'viewInTree' });
+        await flushUntil(() => getWarningMessages().length > 0);
+
+        assert.strictEqual(revealTreeApplicationCalls, 0);
+        assert.strictEqual(focusCommandCalls, 0);
+        const warning = getWarningMessages().at(-1);
+        assert.ok(warning);
+        assert.match(warning, /context does not match/i);
+    });
+
     test('viewInTree shows warning when application is not found', async () => {
         mockTreeProvider = {
             refresh: () => {

--- a/src/tree/ClusterTreeProvider.ts
+++ b/src/tree/ClusterTreeProvider.ts
@@ -297,6 +297,102 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
     }
 
     /**
+     * Resolve the parent of a tree element.
+     * Required for TreeView.reveal to expand ancestor nodes for nested items.
+     */
+    getParent(element: ClusterTreeItem): ClusterTreeItem | undefined {
+        const resourceData = element.resourceData;
+        if (!resourceData?.context?.name) {
+            return undefined;
+        }
+
+        const contextName = resourceData.context.name;
+
+        switch (element.type) {
+            case 'cluster':
+            case 'folder':
+            case 'helmPackageManager':
+                return undefined;
+
+            case 'dashboard':
+            case 'nodes':
+            case 'namespaces':
+            case 'workloads':
+            case 'storage':
+            case 'networking':
+            case 'helm':
+            case 'configuration':
+            case 'argocd':
+            case 'customResources':
+            case 'reports':
+            case 'events':
+                return this.resolveClusterItemForContext(contextName);
+
+            case 'argocdApplication':
+                return TreeItemFactory.createArgoCDCategory(resourceData);
+
+            case 'deployments':
+            case 'statefulsets':
+            case 'daemonsets':
+            case 'cronjobs':
+                return TreeItemFactory.createWorkloadsCategory(resourceData);
+
+            case 'deployment':
+                return this.findSubcategoryByType(
+                    WorkloadsCategory.getWorkloadSubcategories(resourceData),
+                    'deployments'
+                );
+
+            case 'statefulset':
+                return this.findSubcategoryByType(
+                    WorkloadsCategory.getWorkloadSubcategories(resourceData),
+                    'statefulsets'
+                );
+
+            case 'daemonset':
+                return this.findSubcategoryByType(
+                    WorkloadsCategory.getWorkloadSubcategories(resourceData),
+                    'daemonsets'
+                );
+
+            case 'cronjob':
+                return this.findSubcategoryByType(
+                    WorkloadsCategory.getWorkloadSubcategories(resourceData),
+                    'cronjobs'
+                );
+
+            case 'services':
+            case 'portForwarding':
+                return TreeItemFactory.createNetworkingCategory(resourceData);
+
+            case 'service':
+                return this.findSubcategoryByType(
+                    NetworkingCategory.getNetworkingSubcategories(resourceData),
+                    'services'
+                );
+
+            case 'configmaps':
+            case 'secrets':
+                return TreeItemFactory.createConfigurationCategory(resourceData);
+
+            case 'configmap':
+                return this.findSubcategoryByType(
+                    ConfigurationCategory.getConfigurationSubcategories(resourceData),
+                    'configmaps'
+                );
+
+            case 'secret':
+                return this.findSubcategoryByType(
+                    ConfigurationCategory.getConfigurationSubcategories(resourceData),
+                    'secrets'
+                );
+
+            default:
+                return undefined;
+        }
+    }
+
+    /**
      * Get the children of a tree element.
      * This method is called by VS Code to populate the tree view.
      * 
@@ -1986,16 +2082,16 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
                     });
                     
                     if (matchingPod) {
-                        // Found the pod! Reveal it
-                        await this.treeView.reveal(matchingPod, { 
-                            select: true, 
-                            focus: true, 
-                            expand: true 
-                        });
-                        
-                        // Focus the tree view
-                        await vscode.commands.executeCommand('kube9ClusterView.focus');
-                        return true;
+                        return this.revealAlongPath(
+                            [
+                                clusterItem,
+                                workloadsCategory,
+                                subcategory,
+                                workloadResource,
+                                matchingPod
+                            ],
+                            { select: true, focus: true, expand: true }
+                        );
                     }
                 }
             }
@@ -2243,10 +2339,18 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
         }
 
         try {
+            if (clusterItem.argoCDInstalled !== true) {
+                await this.checkArgoCDStatus(clusterItem, false);
+            }
+
+            if (clusterItem.argoCDInstalled !== true) {
+                return false;
+            }
+
             const categories = this.getCategories(clusterItem);
-            let argocdCategory = categories.find((cat) => cat.type === 'argocd');
+            const argocdCategory = categories.find((cat) => cat.type === 'argocd');
             if (!argocdCategory) {
-                argocdCategory = TreeItemFactory.createArgoCDCategory(clusterItem.resourceData);
+                return false;
             }
 
             const applications = await this.getCategoryChildren(argocdCategory);
@@ -2260,16 +2364,51 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
                 return false;
             }
 
-            await this.treeView.reveal(matchingApplication, {
-                select: true,
-                focus: true,
-                expand: true
-            });
+            return this.revealAlongPath(
+                [clusterItem, argocdCategory, matchingApplication],
+                { select: true, focus: true, expand: true }
+            );
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.error(`Error revealing ArgoCD application ${applicationName}:`, errorMessage);
+            return false;
+        }
+    }
+
+    private resolveClusterItemForContext(contextName: string): ClusterTreeItem | undefined {
+        return this.clusterItemsCache.get(contextName);
+    }
+
+    private findSubcategoryByType(
+        subcategories: ClusterTreeItem[],
+        type: TreeItemType
+    ): ClusterTreeItem | undefined {
+        return subcategories.find((item) => item.type === type);
+    }
+
+    private async revealAlongPath(
+        path: ClusterTreeItem[],
+        targetOptions: { select?: boolean; focus?: boolean; expand?: boolean } = {
+            select: true,
+            focus: true,
+            expand: true
+        }
+    ): Promise<boolean> {
+        if (!this.treeView || path.length === 0) {
+            return false;
+        }
+
+        try {
+            for (let index = 0; index < path.length - 1; index += 1) {
+                await this.treeView.reveal(path[index], { expand: true, focus: false });
+            }
+
+            await this.treeView.reveal(path[path.length - 1], targetOptions);
             await vscode.commands.executeCommand('kube9ClusterView.focus');
             return true;
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            console.error(`Error revealing ArgoCD application ${applicationName}:`, errorMessage);
+            console.error('Error revealing tree path:', errorMessage);
             return false;
         }
     }
@@ -2337,13 +2476,10 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
                 return false;
             }
 
-            await this.treeView.reveal(matchingResource, {
-                select: true,
-                focus: true,
-                expand: true
-            });
-            await vscode.commands.executeCommand('kube9ClusterView.focus');
-            return true;
+            return this.revealAlongPath(
+                [clusterItem, category, subcategory, matchingResource],
+                { select: true, focus: true, expand: true }
+            );
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             console.error(

--- a/src/tree/ClusterTreeProvider.ts
+++ b/src/tree/ClusterTreeProvider.ts
@@ -2227,6 +2227,53 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
         return false;
     }
 
+    /**
+     * Reveal an Argo CD Application in the cluster tree by name and namespace.
+     *
+     * @returns true when the application was found and revealed.
+     */
+    public async revealTreeApplication(applicationName: string, applicationNamespace: string): Promise<boolean> {
+        if (!this.treeView || !this.kubeconfig) {
+            return false;
+        }
+
+        const clusterItem = await this.resolveClusterItemForReveal();
+        if (!clusterItem?.resourceData) {
+            return false;
+        }
+
+        try {
+            const categories = this.getCategories(clusterItem);
+            let argocdCategory = categories.find((cat) => cat.type === 'argocd');
+            if (!argocdCategory) {
+                argocdCategory = TreeItemFactory.createArgoCDCategory(clusterItem.resourceData);
+            }
+
+            const applications = await this.getCategoryChildren(argocdCategory);
+            const matchingApplication = applications.find(
+                (app) =>
+                    app.type === 'argocdApplication' &&
+                    this.itemMatchesResource(app, applicationName, applicationNamespace)
+            );
+
+            if (!matchingApplication) {
+                return false;
+            }
+
+            await this.treeView.reveal(matchingApplication, {
+                select: true,
+                focus: true,
+                expand: true
+            });
+            await vscode.commands.executeCommand('kube9ClusterView.focus');
+            return true;
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.error(`Error revealing ArgoCD application ${applicationName}:`, errorMessage);
+            return false;
+        }
+    }
+
     private async resolveClusterItemForReveal(): Promise<ClusterTreeItem | undefined> {
         const currentContext = this.kubeconfig?.currentContext;
         if (!currentContext) {

--- a/src/webview/ArgoCDApplicationWebviewProvider.ts
+++ b/src/webview/ArgoCDApplicationWebviewProvider.ts
@@ -1076,6 +1076,13 @@ export class ArgoCDApplicationWebviewProvider {
                 return;
             }
 
+            if (result.treeUnavailable) {
+                vscode.window.showErrorMessage(
+                    'Cannot reveal application in tree: cluster tree is unavailable'
+                );
+                return;
+            }
+
             if (result.notFound) {
                 vscode.window.showWarningMessage(
                     `Argo CD Application "${applicationName}" was not found in the cluster tree`

--- a/src/webview/ArgoCDApplicationWebviewProvider.ts
+++ b/src/webview/ArgoCDApplicationWebviewProvider.ts
@@ -20,7 +20,11 @@ import {
     type ResourceActionWebviewMessage,
     type WebviewToExtensionMessage
 } from '../types/argocdWebviewProtocol';
-import { dispatchResourceAction } from '../services/KindCapabilityRegistry';
+import {
+    dispatchResourceAction,
+    NAVIGATE_TREE_SUPPORTED_KINDS
+} from '../services/KindCapabilityRegistry';
+import { revealApplicationInTree, revealManagedResourceInTree } from '../services/treeRevealHelper';
 import { getHelpController } from '../extension';
 import { WebviewHelpHandler } from './WebviewHelpHandler';
 import { getWebviewHeaderStyleUri } from './webviewHeaderStyles';
@@ -716,13 +720,16 @@ export class ArgoCDApplicationWebviewProvider {
                     case 'viewInTree':
                         await ArgoCDApplicationWebviewProvider.handleViewInTree(
                             treeProvider,
-                            applicationName
+                            applicationName,
+                            namespace,
+                            context
                         );
                         break;
                     
                     case 'navigateToResource':
                         await ArgoCDApplicationWebviewProvider.handleNavigateToResource(
                             treeProvider,
+                            context,
                             message.kind,
                             message.name,
                             message.namespace
@@ -1042,26 +1049,42 @@ export class ArgoCDApplicationWebviewProvider {
 
     /**
      * Handle view in tree action from webview.
-     * Focuses the tree view and attempts to reveal the application.
-     * 
-     * @param treeProvider The cluster tree provider instance
-     * @param applicationName The name of the application
+     * Focuses the tree view and reveals the open Argo CD Application.
      */
     private static async handleViewInTree(
         treeProvider: ClusterTreeProvider,
-        applicationName: string
+        applicationName: string,
+        applicationNamespace: string,
+        panelContext: string
     ): Promise<void> {
+        const contextMatches = await treeProvider.isCurrentContext(panelContext);
+        if (!contextMatches) {
+            vscode.window.showWarningMessage(
+                `Cannot reveal ${applicationName} in tree: active cluster context does not match this application`
+            );
+            return;
+        }
+
         try {
-            // Focus tree view
-            await vscode.commands.executeCommand('kube9.treeView.focus');
+            const result = await revealApplicationInTree(
+                treeProvider,
+                applicationName,
+                applicationNamespace
+            );
 
-            // Refresh tree to ensure ArgoCD applications are loaded
-            treeProvider.refresh();
+            if (result.success) {
+                return;
+            }
 
-            // Note: revealApplication method may not exist yet, so we just refresh
-            // This can be enhanced when tree provider methods are available
-            vscode.window.showInformationMessage(
-                `Tree view focused. Look for ArgoCD Application: ${applicationName}`
+            if (result.notFound) {
+                vscode.window.showWarningMessage(
+                    `Argo CD Application "${applicationName}" was not found in the cluster tree`
+                );
+                return;
+            }
+
+            vscode.window.showErrorMessage(
+                `Failed to view in tree: ${result.error ?? 'unknown error'}`
             );
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
@@ -1070,36 +1093,47 @@ export class ArgoCDApplicationWebviewProvider {
     }
 
     /**
-     * Handle navigate to resource action from webview.
-     * Focuses the tree view and attempts to reveal the resource.
-     * 
-     * @param treeProvider The cluster tree provider instance
-     * @param kind The resource kind
-     * @param name The resource name
-     * @param namespace The resource namespace
+     * Handle navigate to resource action from the Details tab.
+     * Delegates to the shared tree reveal helper for supported kinds.
      */
     private static async handleNavigateToResource(
         treeProvider: ClusterTreeProvider,
+        panelContext: string,
         kind: string,
         name: string,
         namespace: string
     ): Promise<void> {
-        try {
-            // Focus tree view
-            await vscode.commands.executeCommand('kube9.treeView.focus');
-
-            // Refresh tree to ensure resources are loaded
-            treeProvider.refresh();
-
-            // Note: revealResource method may not exist yet, so we just refresh
-            // This can be enhanced when tree provider methods are available
-            vscode.window.showInformationMessage(
-                `Tree view focused. Look for ${kind} ${name} in namespace ${namespace}`
+        if (!NAVIGATE_TREE_SUPPORTED_KINDS.has(kind)) {
+            vscode.window.showErrorMessage(
+                `Navigate to tree is not supported for kind ${kind}`
             );
-        } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            vscode.window.showErrorMessage(`Failed to navigate to resource: ${errorMessage}`);
+            return;
         }
+
+        const result = await revealManagedResourceInTree(
+            { treeProvider, panelContext },
+            kind,
+            name,
+            namespace
+        );
+
+        if (result.success) {
+            return;
+        }
+
+        if (result.reason === 'tree_unavailable' || result.reason === 'context_mismatch') {
+            vscode.window.showWarningMessage(result.message ?? `Failed to navigate to ${kind} ${name}`);
+            return;
+        }
+
+        if (result.reason === 'not_found') {
+            vscode.window.showWarningMessage(result.message ?? `Failed to navigate to ${kind} ${name}`);
+            return;
+        }
+
+        vscode.window.showErrorMessage(
+            result.message ?? `Failed to navigate to resource: ${result.detail ?? 'unknown error'}`
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add `revealTreeApplication` on `ClusterTreeProvider` to focus and select Argo CD Applications under the ArgoCD Applications category.
- Extract shared `treeRevealHelper` used by `resource.navigateTree`, Details tab `navigateToResource`, and application `viewInTree`; replace info-toast stubs with real tree reveal behavior.
- Align tree focus on `kube9ClusterView.focus` and add unit tests for reveal mapping and provider navigation handlers.

Closes #221

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit -- --grep "KindCapabilityRegistry|ClusterTreeProvider|ArgoCDApplicationWebviewProvider"`
- [ ] Manual: View in tree from Application header/sub-header reveals the app under ArgoCD Applications
- [ ] Manual: Navigate to resource in tree from graph tile overflow reveals Deployment/Service under correct category
- [ ] Manual: Context mismatch shows warning and graph action-notice banner on failure