### PR TITLE
docs(ai): argocd-visual-integration-completion contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -107,7 +107,7 @@ Page-level commands on webview panels (header, **Actions** overflow, documented 
 | Tier | Placement | Examples |
 |------|-----------|----------|
 | **A — primary header** | Up to three labeled primaries | Refresh; View YAML on describe surfaces; Argo CD **Sync** and **Refresh**; Events **Refresh** |
-| **B — overflow or sub-header** | **Actions** menu when over cap, or sub-header when standardized | Argo **Hard refresh**, **View in tree** (sub-header); Events **Auto-refresh**, **Clear Filters** (primary or overflow per cap) |
+| **B — overflow or sub-header** | **Actions** menu when over cap, or sub-header when standardized | Argo **Hard refresh** (sub-header); Events **Auto-refresh**, **Clear Filters** (primary or overflow per cap) |
 | **C — sub-header or toolbar** | Below primary header or in-panel toolbar | Events **Export**, **Search**; Pod Logs stream controls; Helm section actions |
 | **D — never page header** | In-content or graph/tree only | Row actions, graph node overflow, graph canvas zoom/fit |
 
@@ -119,7 +119,7 @@ Page-level commands on webview panels (header, **Actions** overflow, documented 
 
 **Disabled actions:** Remain **visible** when inapplicable (for example Clear Filters with no active filters) unless a future story chooses hide-when-inapplicable.
 
-Argo CD application-level **sync**, **refresh**, **hard refresh**, and **view in tree** stay **page-level** (header/sub-header), not on the graph canvas toolbar. Graph node overflow and canvas toolbar remain separate surfaces.
+Argo CD application-level **sync**, **refresh**, and **hard refresh** stay **page-level** (header/sub-header), not on the graph canvas toolbar. Graph node overflow, canvas zoom/fit toolbar, and **graph filter controls** remain separate surfaces. Application-level **View In Tree** is demoted or removed from page-level chrome; managed-resource **Navigate to resource in tree** remains on tile overflow.
 
 ## Resource inspection and mutation surfaces
 
@@ -158,9 +158,9 @@ Rules below are the **kube9-vscode reference baseline** for built-in Kubernetes 
 4. Resource views should degrade gracefully when optional integrations are unavailable.
 5. Resource identity and scope must remain consistent across tree items, command routing, detail providers, YAML views, and Resource Graph Nodes.
 6. The Application Resource Graph must remain usable when dependency topology is partial; missing edges or unknown parentage must not prevent rendering available nodes and status.
-7. Application-level sync, refresh, hard refresh, and view-in-tree flows remain available from the webview header/sub-header and Application root overflow; they are not replaced by the graph canvas toolbar.
+7. Application-level sync, refresh, and hard refresh remain available from the webview header/sub-header; they are not replaced by the graph canvas toolbar. Application-level View In Tree is demoted or removed from sub-header and Application root overflow; managed-resource tree navigation via `resource.navigateTree` is the primary graph-first path.
 8. Graph presentation and actions must not require the user to leave VS Code or open the native Argo CD server UI.
-9. **Extension-local graph assembly** for the first delivery: the extension owns graph DTO assembly and refresh paths; kube9-operator does not supply resource-tree snapshots today and is **not** required for this capability set. A future operator-mediated snapshot may align later without changing Kind Capability Registry rules stated here.
+9. **Extension-owned graph assembly:** the extension owns `ApplicationResourceGraph` DTO assembly, webview rendering, graph filters, and tree reveal. In **operated clusters**, kube9-operator supplies on-demand Argo CD resource-tree JSON (raw passthrough); the extension normalizes via existing `buildResourceTreeApplicationResourceGraph` and emits `topologySource: argocd_resource_tree`. CRD-flat baseline remains when all enrichment tiers fail. Kind Capability Registry rules are unchanged by topology source or filters.
 
 ## Open Implementation Decisions
 
@@ -172,17 +172,21 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 - **Tile visual states** do not change action scope. **Focus** uses `:focus-visible` with a 2px `--vscode-focusBorder` outline on the tile group. **Selection** adds `argocd-graph-node--selected` (2px focus-border box shadow) from React Flow selection. **Hover** applies `--vscode-list-hoverBackground` on the tile when the pointer is over it and the tile is not selected. **Overflow-open** adds `argocd-graph-node--overflow-open` while the menu is open; the ⋮ trigger exposes `aria-expanded=true`. Primary tile activation (click, Enter, Space) selects only; it does not run menu actions or mutate cluster state.
 - **Unsupported or non-navigable managed-resource nodes** hide the overflow control entirely when the Kind Capability Registry yields zero eligible actions. There is no disabled-only ⋮ affordance and no placeholder “No actions” menu.
-- **Application root overflow** shows **View in tree** only (`viewInTree` message). Sync, refresh, and hard refresh stay on the webview header and sub-header in v1; root overflow does not duplicate GitOps operations.
+- **Application root overflow** does not expose View In Tree in M17; sync, refresh, and hard refresh stay on the webview header and sub-header. Root overflow may be hidden when no eligible actions remain.
 - **Managed-resource overflow labels (v1):** Deployment — **Restart rollout**, **Navigate to resource in tree**; other navigate-supported kinds — **Navigate to resource in tree** only. Labels match `graphNodeCapabilities.ts` and host `actionId` registry entries.
 - **Progressive disclosure for very large Applications** — resolved in `.ai/interface/presentation.md` and `.ai/data/consistency.md` (issue #222): webview kind-based grouping over complete DTO; threshold 40 managed resources.
 
-**Resolved (View In Tree and tree reveal, issue #221):**
+**Resolved (tree navigation, M17):**
 
-- **Application-level View In Tree** (`viewInTree` message from header, sub-header, or Application root overflow) reveals the open Application's `argocdApplication` tree item under the **ArgoCD Applications** category when the panel's kubeconfig context matches the active context. It does not reveal managed Kubernetes resources.
-- **Managed-resource View In Tree** routes through `resource.navigateTree` with the tile's `ManagedResourceKey`. The host maps supported kinds to existing cluster-tree categories via `ClusterTreeProvider.revealTreeResource`; unsupported kinds remain without overflow (#224).
+- **Application-level View In Tree** (`viewInTree` message) is **removed or demoted** from sub-header, Application root overflow, and related page-level chrome. It does not receive selection-aware behavior.
+- **Managed-resource navigation** routes through `resource.navigateTree` with the tile's `ManagedResourceKey`. The host maps supported kinds to cluster-tree categories via `ClusterTreeProvider.revealTreeResource`, using **destination namespace** for workload lookup where the managed resource key differs from the Application namespace. The host **refreshes the cluster tree before reveal lookup**.
 - **Details tab parity:** `navigateToResource` from the Details view uses the same reveal helper as `resource.navigateTree` for supported kinds.
 - **Failure is non-mutating:** When no tree item can be mapped, the extension reports navigation failure with user-facing copy; it must not create tree nodes or alter resource identity.
 
-**Deferred:**
+**Deferred (M17):**
+
+- **Graph filter UX:** Widget shape (chips vs dropdown), zero-match empty state, selection-when-filtered behavior, filter visibility (hide vs de-emphasize), and a11y live-region announcements (`/refine-issue`).
+- **Limited-topology affordance copy:** Per-`topologySource` strings for operator-absent, operator-degraded, REST-disabled, and enrichment-pending states (`/refine-issue`).
+- **Supported reveal kinds expansion:** Whether resource-tree-only kinds (ReplicaSet, etc.) gain overflow navigate actions (`/refine-issue`).
 
 - **`resource.openDescribe` on graph tiles** — registry entry exists for future direct describe routing from `ManagedResourceKey`; v1 graph overflow does not expose it. Users open describe via tree reveal or Details tab navigate affordances.

--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -20,7 +20,9 @@
 - As a GitOps engineer, I can open a three-dot actions menu on each eligible resource tile and only see actions that are valid for that resource kind and permission state.
 - As a GitOps engineer, I can run **application-level sync, refresh, and hard refresh** from the Application root node using the same flows already available for ArgoCD applications.
 - As a GitOps engineer, I can **restart rollout** on a Deployment node from the graph when I need to recycle pods without leaving the application detail panel.
-- As a GitOps engineer, I can use **View In Tree** or resource navigation from a selected graph node to reveal the corresponding Kubernetes tree resource where the extension can map that resource identity.
+- As a GitOps engineer, I can **navigate to resource in tree** from a managed-resource graph tile to reveal the corresponding Kubernetes tree workload (including destination-namespace resources) where the extension can map that resource identity.
+- As a GitOps engineer in an operated cluster, I can see **full topology** (pods, replica sets, parent/child edges) when kube9-operator or extension REST resource-tree enrichment succeeds, without configuring a personal bearer token when the operator path is active.
+- As a GitOps engineer, I can **filter the graph** by resource name, kind, and sync status from the graph toolbar without mutating cluster state or losing the underlying complete resource inventory on refresh.
 - As a GitOps engineer, after I sync or refresh an application, the graph **updates in place** with refreshed sync and health on affected nodes without requiring me to close and reopen the panel.
 - As a GitOps engineer working on a large application, I can still use the graph when node count is high because the experience avoids unusable clutter through progressive disclosure or grouping rather than failing silently.
 

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -173,7 +173,7 @@ Initial delivery may emit only `manages` edges when topology is CRD-only; richer
 | `crd_flat` | Star: Application → each `status.resources` entry | Application root + one node per `ArgoCDResource` |
 | `argocd_resource_tree` | From Argo CD resource-tree `parentRefs` | Tree nodes mapped to `ManagedResourceKey` where possible |
 | `kubernetes_owner_ref` | Inferred ownerReference chain among known resources | Subset or superset of flat list |
-| `operator_snapshot` | From operator-normalized tree DTO when available | Peer contract; not required for vscode-only path |
+| `operator_snapshot` | Reserved for future operator-normalized tree DTO; M17 operator transport emits `argocd_resource_tree` on success |
 
 ### TopologyMode (`full` vs `limited`)
 

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -114,11 +114,12 @@ Actions that target a resource continue to send `kind`, `name`, `namespace` (and
 
 ## Topology from non-CRD sources
 
-When Argo CD resource-tree or operator snapshots are integrated:
+When Argo CD resource-tree or operator CLI transport is integrated:
 
 1. Normalize external nodes to `ManagedResourceKey` + optional extended status.
 2. Normalize parent links to `ResourceGraphEdge` with stable ids.
-3. Set `topologySource` accordingly before serialization.
+3. Set `topologySource: argocd_resource_tree` when assembling from resource-tree shape (REST or operator raw JSON).
+4. Set `topologyMode: full` when the tree is complete; `limited` on partial fallback.
 
 Raw upstream JSON must not leak into the webview bundle; normalize in the extension host (or a shared pure module) first.
 
@@ -156,3 +157,10 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - **`group` vs `apiGroup` on the wire (issue #223):** DTO field `apiGroup`; webview protocol field `group` on `resourceAction` and `ResourceNodeRef`. Map at the webview boundary (`buildResourceActionPayload` / `buildResourceNodeRef`). Validators reject `apiGroup` on webview messages. Do not emit both fields on the same message.
 
 - **Large-application grouping (issue #222):** Remains an **interface-only transform** over the complete flat DTO node set in v1. Kind group tiles are synthetic webview nodes; they are not serialized in `ApplicationResourceGraph.nodes`. The host does not set `truncated: true` to omit managed-resource nodes.
+
+**Deferred (M17):**
+
+- Extension read path: dedicated `OperatorResourceTreeClient` vs inline exec in `ApplicationResourceGraphBuilder`.
+- In-memory memo keyed by `ApplicationKey` + fetch timestamp for same panel session.
+- CRD ↔ tree reconciliation edge cases for duplicate Application node in tree response.
+- Graph filter webview state shape and selection-when-filtered behavior.

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -32,13 +32,26 @@ Each entry is a **flat** managed-resource row, not a graph edge list:
 
 ## Argo CD — resource graph data sourcing
 
-The application detail **resource graph** consumes a normalized **`ApplicationResourceGraph`** DTO (node/edge model owned in data contracts). The integration layer defines **how** that DTO is populated, in strict precedence:
+The application detail **resource graph** consumes a normalized **`ApplicationResourceGraph`** DTO (node/edge model owned in data contracts). The integration layer defines **how** that DTO is populated, in strict precedence.
+
+**Operated mode** (kube9-operator installed, `status.argocd.detected`):
 
 ```text
-1. argocd_resource_tree — Argo CD REST resource-tree (preferred when configured and reachable)
-2. kubernetes_owner_ref — Kubernetes metadata.ownerReferences (optional fallback for edges)
-3. crd_flat       — Application CRD status.resources only (required baseline)
+1. argocd_resource_tree — Extension REST when kube9.argocd.restEnabled and authorized (wins over operator)
+2. argocd_resource_tree — Operator CLI on-demand fetch (raw Argo CD JSON → buildResourceTreeApplicationResourceGraph)
+3. kubernetes_owner_ref — Kubernetes metadata.ownerReferences (optional fallback for edges)
+4. crd_flat       — Application CRD status.resources only (required baseline)
 ```
+
+**Basic mode** (no operator):
+
+```text
+1. argocd_resource_tree — Extension REST when restEnabled and authorized
+2. kubernetes_owner_ref
+3. crd_flat
+```
+
+On operator or REST success assembling from resource-tree shape, the host sets `topologySource: argocd_resource_tree` and `topologyMode: full`. Operator is transport only; it does not emit a separate `operator_snapshot` topology label on success.
 
 The host sets `topologySource` on each push so the webview can label degraded vs full topology.
 
@@ -88,11 +101,25 @@ This tier matches **current** `ArgoCDService.parseResources` behavior and is suf
 | **Source** | Argo CD server REST: `GET /api/v1/applications/{name}/resource-tree` with application namespace as query parameter when namespaced |
 | **Response use** | Map Argo CD `nodes[]` (`group`, `kind`, `namespace`, `name`, `version`, `parentRefs`, optional `network`, hook/health fields) into `ApplicationResourceGraph` nodes and directed edges (`parentRefs` → edges parent → child, layout left-to-right in UI) |
 | **Auth** | Bearer token (or equivalent) to argocd-server; TLS per settings; optional local access via **kubectl port-forward** to `argocd-server` Service — token and base URL remain in extension host only |
-| **Preconditions** | User-enabled REST path; server reachable; Argo CD RBAC allows resource-tree for the application |
+| **Preconditions** | User-enabled REST path; server reachable; Argo CD RBAC allows resource-tree for the application. In operated mode, extension REST **wins** over operator when both are available and authorized. |
 | **Failure** | Log, set `topologySource` to fallback tier, do not fail the whole panel solely for tree API errors |
-| **Peer note** | kube9-operator today implements **`GET /api/v1/applications`** list only, not resource-tree; extension must not depend on operator for this tier |
+| **Peer note** | kube9-operator exposes on-demand `query argocd resource-tree get` returning raw Argo CD JSON when extension REST is not configured or authorized |
 
 Native Argo CD UI resource graphs use this API; kube9-vscode targets **visual parity** when Tier B is active.
+
+### Tier B2 — Operator CLI resource-tree (operated mode)
+
+| Item | Contract |
+|------|----------|
+| **When** | Operated mode; extension REST not configured or not authorized; operator present with `status.argocd.detected` and resource-tree capability |
+| **Source** | `kubectl exec` → `kube9-operator query argocd resource-tree get <appName> --namespace=<appNamespace> [--format=json]` |
+| **Response use** | Raw Argo CD resource-tree JSON (`nodes[]`, `parentRefs[]`); extension reuses `buildResourceTreeApplicationResourceGraph` |
+| **Auth** | Operator authenticates to argocd-server with platform-supplied dedicated bearer token (Helm Secret); extension does not hold operator token |
+| **Preconditions** | Operator installed; Argo CD detected; operator `resourceTreeCapable` (or equivalent) true; extension exec RBAC |
+| **Failure** | Fall through to extension REST (if configured) → `kubernetes_owner_ref` → `crd_flat` |
+| **topologySource on success** | `argocd_resource_tree` (operator is transport only) |
+
+See peer contract: `kube9-operator/.ai/integration/api_contracts.md` (resource-tree query).
 
 ### Tier C — `kubernetes_owner_ref` (optional edge fallback)
 
@@ -167,16 +194,17 @@ Canonical values match [data model](../data/data_model.md#topologysource):
 | `argocd_resource_tree` | Edges primarily from resource-tree `parentRefs` |
 | `kubernetes_owner_ref` | Edges from Kubernetes owner references |
 | `crd_flat` | No real hierarchy; synthetic root edges only |
-| `operator_snapshot` | Reserved for future operator-normalized tree DTO |
+| `operator_snapshot` | Reserved for future operator-normalized tree DTO; M17 operator path emits `argocd_resource_tree` instead |
 
 ## Operator cross-read (informative)
 
 kube9-operator Argo CD module:
 
-- HTTP client: `GET /api/v1/applications` → normalized `ApplicationSnapshot` (sync/health/revision, optional `resourcesOutOfSyncCount` from list payload).
-- Does **not** expose resource-tree to kube9-vscode.
+- HTTP client: `GET /api/v1/applications` → normalized `ApplicationSnapshot` (sync/health/revision) into SQLite `argocd_apps`.
+- **Resource-tree:** `GET /api/v1/applications/{name}/resource-tree` on-demand via CLI query; returns raw Argo CD JSON to kube9-vscode.
+- Status ConfigMap: detection, bounded application summaries, and `resourceTreeCapable` (or equivalent) enrichment signal.
 
-Extension continues to use operator status for **detection** only unless a future operator contract adds graph snapshots.
+Extension uses operator status for **detection and enrichment gating**; per-application trees are fetched on graph open/refresh via CLI exec, not embedded in ConfigMap.
 
 ## Operator status — AI Conformance report
 

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -9,9 +9,9 @@ Primary integration for cluster tree, resource describe, YAML, workload commands
 
 ## kube9-operator (optional)
 
-When operated mode is available, the extension reads **detection metadata** from the operator status ConfigMap (`status.argocd`: detected, namespace, version, lastChecked). Application queries still use the Application CRD in the detected namespace unless a future contract adds operator-mediated snapshots.
+When operated mode is available, the extension reads **detection and enrichment metadata** from the operator status ConfigMap (`status.argocd`: detected, namespace, version, lastChecked, `resourceTreeCapable` or equivalent). Per-application **resource-tree** payloads are fetched on-demand via `kubectl exec` → `kube9-operator query argocd resource-tree get` when the Application graph opens or refreshes. Application CRD reads remain the sync/health baseline.
 
-The operator peer today calls Argo CD **`GET /api/v1/applications`** for drift/status cycles only. It does **not** publish resource-tree or per-resource graph DTOs to the extension. Resource graph topology for kube9-vscode is **extension-local** unless a later cross-repo contract adds operator export.
+The operator peer calls Argo CD **`GET /api/v1/applications`** for status cycles and **`GET /api/v1/applications/{name}/resource-tree`** for topology enrichment. It returns **raw Argo CD resource-tree JSON** to kube9-vscode; the extension assembles `ApplicationResourceGraph` and emits `topologySource: argocd_resource_tree` on success. Full tree payloads do **not** belong in the status ConfigMap (1 MiB limit).
 
 The operator status ConfigMap may also publish bounded report summaries for VS Code report surfaces. For Kubernetes AI Conformance, kube9-vscode consumes `status.aiConformance` as a readiness summary only. The operator remains the evaluator and publisher; the extension is the viewer/parser and does not run conformance checks itself.
 
@@ -22,7 +22,7 @@ Two distinct integration surfaces:
 | Surface | Role | Required for graph? |
 |---------|------|---------------------|
 | **Application CRD** (`argoproj.io/v1alpha1`, `Application`) | List/get apps, `status.resources`, sync/refresh via annotation patch | Yes (baseline nodes and status) |
-| **Argo CD API server** (REST, v1) | `resource-tree` and other UI-parity topology | No (optional enrichment) |
+| **Argo CD API server** (REST, v1) | `resource-tree` topology | No in basic mode; optional via extension REST or operator CLI in operated mode |
 
 Argo CD server URL and API token are **user- or environment-supplied** when REST enrichment is enabled (settings, port-forward to `argocd-server`, or cluster ingress). They are not inferred from the Application CRD alone.
 

--- a/.ai/interface/accessibility.md
+++ b/.ai/interface/accessibility.md
@@ -11,7 +11,7 @@ Accessibility expectations for Kube9 VS Code **webview** surfaces, with emphasis
 
 ### Keyboard and focus
 
-- **Tab order:** Webview header actions -> graph toolbar (zoom in, zoom out, fit view) -> graph canvas -> **Graph | Details** tabs -> panel content for the active tab.
+- **Tab order:** Webview header actions -> graph toolbar (zoom in, zoom out, fit view, **filter controls**) -> graph canvas -> **Graph | Details** tabs -> panel content for the active tab.
 - **Nodes:** Each graph tile is a single focus stop; **Enter** or **Space** activates the tile (selection/focus ring). Focus order among nodes follows a **stable, predictable** sequence (layout order left-to-right, then top-to-bottom within a column) so repeated visits do not jump arbitrarily after data refresh.
 - **Overflow menu (⋮):** Opens with keyboard from the focused tile; menu items are standard focusable actions; **Escape** closes the menu and returns focus to the tile.
 - **Canvas pan/zoom:** Pointer-first for pan; toolbar buttons are fully keyboard-operable with visible focus. Do not require drag-only gestures for essential information.
@@ -33,7 +33,8 @@ Accessibility expectations for Kube9 VS Code **webview** surfaces, with emphasis
 - **Details** drift table: preserve header/row associations (`th`/`scope` or grid roles), expandable row state announced on toggle, and keyboard activation for navigate-to-tree links.
 - Header operation buttons expose **disabled** state and in-progress labels ("Syncing...", "Refreshing...") to assistive tech when operations run.
 - **Actions overflow menu:** The overflow trigger and menu items are keyboard operable with visible focus; **Escape** closes the menu and returns focus to the trigger. Menu items use the same accessible names as visible primary buttons would. Overflow must not trap focus.
-- **Sub-header row** controls (Events export/search, Argo hard refresh/view in tree) follow the same button semantics and disabled/in-progress labeling as primary header actions.
+- **Sub-header row** controls (Events export/search, Argo hard refresh) follow the same button semantics and disabled/in-progress labeling as primary header actions.
+- **Graph filter controls** use standard button/combobox semantics with visible `:focus-visible` rings consistent with toolbar rules. Live-region match-count announcements are optional TW (`/refine-issue`).
 
 ## Kubernetes AI Conformance report
 

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -51,7 +51,7 @@ The tree **does not** embed the graph; it continues to list applications with st
 
 ### Operate from tiles and header
 
-- **Application-level:** **Sync** and **Refresh** on the **primary webview header**; **Hard refresh** and **View in tree** on the **sub-header row** directly below (disabled while an operation is in progress, same semantics as today). The Application root tile may expose the same actions in its overflow menu.
+- **Application-level:** **Sync** and **Refresh** on the **primary webview header**; **Hard refresh** on the **sub-header row** directly below (disabled while an operation is in progress). Application-level View In Tree is removed or demoted in M17.
 - **Per-resource overflow (⋮):** Actions are **kind-driven** via a capability registry (not ad hoc per screen). Initial set:
   - **Deployment:** restart rollout (pods), with progress/error feedback through existing extension notification patterns.
   - **Supported workload/kinds:** navigate to resource in tree; open describe where the extension already supports that kind.
@@ -87,7 +87,7 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 | Node role | Kind | Menu items | Message path |
 |-----------|------|------------|--------------|
-| Application root | Application | View in tree | `viewInTree` |
+| Application root | Application | _(overflow hidden or empty in M17)_ | — |
 | Managed resource | Deployment | Restart rollout; Navigate to resource in tree | `resourceAction` (`deployment.restartRollout`, `resource.navigateTree`) |
 | Managed resource | StatefulSet, DaemonSet, CronJob, Pod, Service, ConfigMap, Secret | Navigate to resource in tree | `resourceAction` (`resource.navigateTree`) |
 | Managed resource | Other kinds (Job, Ingress, CRD, unknown) | _(overflow hidden)_ | — |
@@ -95,17 +95,16 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - **Hidden vs disabled:** When no rows apply, the overflow control is not rendered. During application-level sync/refresh (`operationProgress` Running or webview `menusDisabled`), all tile overflow menus disable. During a per-node in-flight `resourceAction` (`resourceActionProgress` Running with `nodeRef`), only that tile's overflow disables (optional in-menu copy: "Action in progress…"). The webview is the primary guard; the host does not queue overlapping `resourceAction` messages in v1.
 - **Action results:** Terminal `resourceActionResult` with `success: false` shows a dismissible graph action-notice banner. User-cancelled restart confirmation does not show the banner. Unknown `actionId` or unsupported kind for a known id returns explicit host messages without crashing the panel.
 
-### View In Tree and tree reveal (resolved, issue #221)
+### Tree navigation and reveal (M17)
 
-Two navigation surfaces share one host tree-reveal implementation; neither mutates cluster state.
+Managed-resource tree reveal is the primary graph-first navigation path. Application-level `viewInTree` is removed or demoted from sub-header and Application root overflow.
 
 | Source | Message / action | Host behavior | User feedback |
 |--------|------------------|---------------|---------------|
-| Application root overflow, sub-header, or header | `viewInTree` | Focus `kube9ClusterView`, refresh tree, call `ClusterTreeProvider.revealTreeApplication(applicationName, applicationNamespace)` bound to the open panel's `ApplicationKey` | On success: tree reveals and selects the matching `argocdApplication` item. On failure: `showWarningMessage` when the tree is focused but the application item is not found; `showErrorMessage` on unexpected host errors |
-| Managed-resource tile overflow | `resourceAction` with `actionId: resource.navigateTree` | Same pre-checks as registry handler: kubeconfig available, active context matches panel context; focus tree, refresh, `revealTreeResource(kind, name, namespace)` from the tile's `ManagedResourceKey` | `resourceActionProgress` then terminal `resourceActionResult`; failures also show the dismissible graph action-notice banner |
-| Details tab navigate affordance | `navigateToResource` with `kind`, `name`, `namespace` | Delegate to the same reveal helper as `resource.navigateTree` for kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`; reject or no-op with explicit error for unsupported kinds | Unsupported kind: `showErrorMessage` with safe copy. Supported kind failure: same messages as `resource.navigateTree` result text (Details tab does not use the graph action-notice banner) |
+| Managed-resource tile overflow | `resourceAction` with `actionId: resource.navigateTree` | Kubeconfig available, active context matches panel context; focus tree, **refresh tree**, `revealTreeResource(kind, name, namespace)` using **destination namespace** for workload lookup when applicable | `resourceActionProgress` then terminal `resourceActionResult`; failures show dismissible graph action-notice banner |
+| Details tab navigate affordance | `navigateToResource` with `kind`, `name`, `namespace` | Delegate to the same reveal helper as `resource.navigateTree` for kinds in `NAVIGATE_TREE_SUPPORTED_KINDS` | Same messages as `resource.navigateTree` result text |
 
-**Identity for reveal:** Use `ManagedResourceKey.namespace` (trimmed; empty only for cluster-scoped kinds when the CRD omits namespace), `kind`, and `name`. Optional `apiGroup` is forwarded when present but is not required for v1 reveal of core kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`.
+**Identity for reveal:** Use `ManagedResourceKey.namespace` (trimmed; destination namespace for workloads in multi-destination apps), `kind`, and `name`. The host refreshes the cluster tree before lookup. Optional `apiGroup` is forwarded when present.
 
 **Failure copy (managed resource, terminal result message):**
 

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -45,7 +45,7 @@ Some panels need a **standardized sub-header row** directly under the primary he
 | Surface | Primary header | Sub-header row |
 |---------|----------------|----------------|
 | **Events Viewer** | Refresh, Auto-refresh, Clear Filters (within primary cap; overflow if needed) | **Export**, **Search** |
-| **Argo CD Application** | **Sync**, **Refresh** (within primary cap) | **Hard refresh**, **View in tree** |
+| **Argo CD Application** | **Sync**, **Refresh** (within primary cap) | **Hard refresh** |
 
 Other dense tooling (Pod Logs stream controls, Helm section actions) stays in documented toolbar or body regions, not competing with Tier A header actions (see business logic **Webview page-level actions**).
 
@@ -96,7 +96,11 @@ Tiles have separate focus and selected states. Primary activation selects the ti
 
 **Status iconography:** Sync and health badges reuse the **same visual language** as the tree and the existing drift table: codicon-based sync indicators, health-colored badge backgrounds mapped through `testing.iconPassed`, `testing.iconFailed`, `testing.iconQueued`, and related VS Code tokens. Unknown or missing health uses muted/description styling, not a false-positive green.
 
-**Application root tile:** Mirrors application-level sync and health on the tile; application-level **sync** and **refresh** sit on the **primary webview header**; **hard refresh** and **view in tree** sit on the **sub-header row** under the primary header (root tile overflow may duplicate subset actions for in-graph context).
+**Application root tile:** Mirrors application-level sync and health on the tile; application-level **sync** and **refresh** sit on the **primary webview header**; **hard refresh** sits on the **sub-header row** under the primary header. Application-level View In Tree is removed or demoted in M17; managed-resource overflow remains the primary tree-navigation path.
+
+### Graph toolbar filters (M17)
+
+The canvas-adjacent toolbar (zoom in, zoom out, fit view) also hosts **graph filter controls**: resource name search, kind filter, and sync-status filter. Filters are **webview presentation only**; the host posts the complete `resourceGraph` on every refresh. Combined active filters use **AND** semantics. Topology-only nodes without a CRD sync value are treated as **Unknown** for sync filtering. Filter state is session-local to the open Application panel.
 
 ### Secondary: Details (overview and drift)
 
@@ -167,4 +171,12 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 | Overflow open | `argocd-graph-node--overflow-open` on tile; menu uses VS Code menu background tokens |
 
 - Sync and health badges, kind icon, truncated name, and ⋮ overflow align with the **Graph tiles (nodes)** table above in this document.
-- **Limited-topology and large-application hints** — resolved under **Large applications** in this document and in `graphTopologyAffordanceRules.ts` (issue #222).
+- **Limited-topology and large-application hints** — resolved under **Large applications** in this document and in `graphTopologyAffordanceRules.ts` (issue #222). Limited-topology affordance is **suppressed** when `topologyMode: full`. Copy tiers distinguish `crd_flat`, `kubernetes_owner_ref`, and enrichment-pending/fallback states (exact strings TW).
+
+**Deferred (M17 graph filters):**
+
+- Filter control widgets (chips vs dropdown vs combobox), labels, placeholders, and clear/reset affordance placement.
+- Zero-match filter outcome (empty-filter state vs Application root only vs de-emphasized tiles).
+- Filter visibility model (hide non-matching tiles vs de-emphasize in place).
+- Filter + kind-grouping interaction when collapsed groups contain filtered-out members.
+- Live region announcements for filter match counts (a11y bar).

--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -18,7 +18,7 @@ Separate from Kubernetes Application CRD RBAC. Credentials and base URL stay in 
 
 | Setting | Type | Scope | Default | Purpose |
 |---------|------|-------|---------|---------|
-| `kube9.argocd.restEnabled` | boolean | application | `false` | Gate Tier B `resource-tree` HTTP calls (#166). When `false`, graph stays on CRD / owner-ref tiers only. |
+| `kube9.argocd.restEnabled` | boolean | application | `false` | Gate Tier B extension REST `resource-tree` HTTP calls. When `false` in operated mode, graph uses operator CLI path when available; when `true` and authorized, extension REST **wins** over operator. |
 | `kube9.argocd.serverUrl` | string or object | application | `null` | HTTPS API base (no trailing path). **Object** keys are kubeconfig **context names** (same pattern as `kube9.operatorNamespace`). |
 | `kube9.argocd.accessMode` | string | application | `direct` | `direct` uses `serverUrl` as-is. `portForward` starts (or reuses) a host-managed `kubectl port-forward` to the detected `argocd-server` Service and uses `http://127.0.0.1:{localPort}` as the API base for that context. |
 | `kube9.argocd.tlsInsecure` | boolean | application | `false` | Skip TLS verification for HTTPS bases. Labs / local port-forward only; must not be the default for production ingress URLs. |

--- a/.ai/specs/argocd-diagram-interface.spec.md
+++ b/.ai/specs/argocd-diagram-interface.spec.md
@@ -4,7 +4,7 @@
 
 The ArgoCD Diagram Interface is the default Argo CD Application detail surface in kube9-vscode. It turns an Application's managed-resource inventory into an interactive graph inside VS Code so GitOps users can inspect every returned resource, understand topology when it is available, select resources, invoke kind-appropriate actions, and reveal matching Kubernetes tree items without leaving the IDE.
 
-The capability is owned by kube9-vscode. It does not require kube9-operator, kube9-api, kube9-web, kube9-desktop, or the native Argo CD UI for baseline behavior. The native Argo CD UI is prior art for graph density, overflow affordances, and resource-tree topology, while kube9-vscode contracts remain authoritative for local-first trust, webview accessibility, and VS Code theme behavior.
+The capability is owned by kube9-vscode. **CRD-flat baseline** graph rendering does not require kube9-operator, kube9-api, kube9-web, kube9-desktop, or the native Argo CD UI. In **operated clusters**, kube9-operator supplies on-demand Argo CD resource-tree JSON so users reach full topology without extension bearer-token setup. The native Argo CD UI is prior art for graph density, overflow affordances, resource-tree topology, and graph-side filtering, while kube9-vscode contracts remain authoritative for local-first trust, webview accessibility, and VS Code theme behavior.
 
 ## Functional Specification
 
@@ -12,7 +12,9 @@ Opening an Argo CD Application from the cluster tree presents Graph as the defau
 
 Each graph tile shows kind, name, Argo CD sync status, Argo CD health status, and an overflow control for eligible actions. Tile selection is a visible, keyboard-operable state that scopes resource-aware actions. Selection does not mutate cluster state by itself; mutating actions require explicit menu or command intent and host-side validation.
 
-Application-level sync, refresh, hard refresh, and View In Tree remain available from the webview header, sub-header, or Application root affordances. Managed-resource tiles support View In Tree and open describe/detail where resource identity can be mapped into the existing Kubernetes tree and describe surfaces. Deployment tiles may expose rollout restart through the Kind Capability Registry when RBAC and action eligibility allow it.
+Application-level sync, refresh, and hard refresh remain available from the webview header and sub-header. **Application-level View In Tree** is demoted or removed from sub-header, Application root overflow, and related page-level chrome; **managed-resource** "Navigate to resource in tree" (`resource.navigateTree`) is the primary graph-first navigation affordance. Managed-resource tiles support tree reveal and open describe/detail where resource identity can be mapped into the existing Kubernetes tree and describe surfaces. Deployment tiles may expose rollout restart through the Kind Capability Registry when RBAC and action eligibility allow it.
+
+The graph toolbar exposes **presentation-only filters** for resource name search, kind, and sync status (minimum parity with native Argo CD resource graph filtering). Active filters use **AND** semantics across dimensions. The host continues posting the **complete** `resourceGraph` DTO; filters hide or de-emphasize non-matching managed-resource tiles without mutating cluster state or trimming the host payload.
 
 Large Applications must remain usable. Grouping, collapse, capped initial render, or progressive disclosure may be used, but the experience must preserve a path to every returned managed resource through the graph, Details, tree navigation, or explicit expansion. Empty, partial, permission-denied, and limited-topology states use explicit user-facing messaging instead of blank canvases or silent graph degradation.
 
@@ -20,7 +22,22 @@ Large Applications must remain usable. Grouping, collapse, capped initial render
 
 The capability runs in the existing VS Code extension model: Node.js extension host plus isolated browser webview. Repository metadata requires VS Code engine `^1.80.0`, Node `>=22.0.0`, and `.nvmrc` pins local Node `v22.14.0`. The Argo CD webview is bundled by esbuild from `src/webview/argocd-application/index.tsx` into `media/argocd-application/main.js`. Browser-side graph rendering uses React 18, `@xyflow/react`, and a layout engine such as `@dagrejs/dagre`; these stay in the webview bundle and not in the extension host bundle.
 
-Kubernetes and Argo CD I/O happen only in the extension host. The required baseline source is the Argo CD Application CRD, including `status.resources`. Optional enrichment may use Argo CD REST `resource-tree` when explicitly configured and authorized, or Kubernetes owner references when enabled and permitted. Optional enrichment failure falls back to CRD-flat graph rendering without failing the whole panel when the Application CRD remains readable.
+Kubernetes and Argo CD I/O happen only in the extension host. The required baseline source is the Argo CD Application CRD, including `status.resources`. **Topology enrichment** follows strict precedence (see `.ai/integration/api_contracts.md`):
+
+```text
+Operated mode (kube9-operator installed, Argo CD detected):
+  1. Extension REST resource-tree — when kube9.argocd.restEnabled and authorized (wins over operator)
+  2. Operator CLI resource-tree — on-demand fetch via kubectl exec; raw JSON → buildResourceTreeApplicationResourceGraph
+  3. kubernetes_owner_ref — optional inferred edges
+  4. crd_flat — required baseline
+
+Basic mode (no operator):
+  1. Extension REST resource-tree — when restEnabled and authorized
+  2. kubernetes_owner_ref
+  3. crd_flat
+```
+
+On operator or REST success, the host emits `topologySource: argocd_resource_tree` and `topologyMode: full` (operator is transport only). Enrichment failure falls back to lower tiers without failing the whole panel when the Application CRD remains readable. `resource.navigateTree` / `ClusterTreeProvider.revealTreeResource` must map managed resources to the correct **destination namespace** workloads, refresh the cluster tree before lookup, and surface actionable failure copy when reveal fails.
 
 The graph data contract is `ApplicationResourceGraph`, a derived JSON-safe DTO with `applicationKey`, `nodes`, `edges`, `topologySource`, `topologyMode`, `structureVersion`, optional `layoutHint`, `observedAt`, and optional `truncated` (reserved; host omits in v1 — see [data_model.md](../data/data_model.md)). Stable identity is based on `ManagedResourceKey` and `GraphNodeId`, not visible labels or React Flow internals. `ArgoCDApplication.resources` remains the sync and health authority for CRD-backed resources.
 
@@ -35,7 +52,7 @@ The graph data contract is `ApplicationResourceGraph`, a derived JSON-safe DTO w
 
 The canonical webview protocol uses `resourceGraph` for complete graph snapshots and `resourceAction` for tile actions. `resourceActionProgress` and `resourceActionResult` communicate action progress and terminal state. Legacy naming such as `graphData`, `graphPatch`, and `graphAction` is treated as implementation cleanup, not the durable contract. The host preserves panel identity by `context:namespace:applicationName`, owns polling and cancellation, and pushes graph refreshes without disposing the panel.
 
-The webview owns rendering, selection, viewport, focus, menu state, and layout cache for the panel session. Refresh merges preserve selection, viewport, and positions when stable node ids survive; structural changes use `structureVersion` to determine when relayout or selection clearing is needed.
+The webview owns rendering, selection, viewport, focus, menu state, **graph filter state**, and layout cache for the panel session. Filter state is session-local to the open Application panel (same boundary as layout cache); no extension `globalState` in v1. Refresh merges preserve filter inputs, selection, viewport, and positions when stable node ids survive; structural changes use `structureVersion` to determine when relayout or selection clearing is needed. Filter changes do not bump `structureVersion`.
 
 **Refresh merge (host + webview):**
 
@@ -85,7 +102,7 @@ Runtime and serialization tests should cover `resourceGraph`, `resourceAction`, 
 - Webview: `topologySource` change triggers relayout while preserving positions for surviving ids when feasible.
 - Host: terminal operation path calls cache invalidation before final graph post (`reloadApplicationAfterTerminalOperation`).
 
-Interface validation should include graph layout readability, selectable tiles, overflow menu behavior, View In Tree from a selected resource, Details fallback, limited-topology messaging, and large-application grouping or expansion. Accessibility review must include keyboard traversal through header, toolbar, tiles, overflow menus, Graph/Details tabs, high-contrast status badges, reduced-motion behavior, and focus preservation across refresh.
+Interface validation should include graph layout readability, selectable tiles, overflow menu behavior, **Navigate to resource in tree** from a managed-resource tile, graph toolbar filters (name, kind, sync status), Details fallback, limited-topology messaging (suppressed when `topologyMode: full`), and large-application grouping or expansion. Accessibility review must include keyboard traversal through header, toolbar (zoom controls then filter controls), tiles, overflow menus, Graph/Details tabs, high-contrast status badges, reduced-motion behavior, and focus preservation across refresh.
 
 **Graph tile and overflow test matrix (issue #224):**
 
@@ -99,15 +116,33 @@ Interface validation should include graph layout readability, selectable tiles, 
 
 **Implementation polish (#224):** Add tile `:hover` and `argocd-graph-node--overflow-open` styling; wire overflow-open class from `ResourceGraphNodeTile` when menu is open; suppress action-notice banner when result message is `Cancelled`.
 
-**View In Tree test matrix (issue #221):**
+**Tree navigation test matrix (M17):**
 
 | Area | Module / suite | Must prove |
 |------|----------------|------------|
 | Registry (existing) | `kindCapabilityRegistry.test.ts` | `resource.navigateTree` success when `revealTreeResource` returns true; failure when false; context mismatch and tree-unavailable paths |
-| Tree provider | `ClusterTreeProvider.reveal.test.ts` (or extend existing tree suite) | `revealTreeResource` maps Deployment/Pod/Service/ConfigMap to correct categories; `revealTreeApplication` finds `argocdApplication` by name+namespace; returns false when item missing |
-| Provider stubs | `ArgoCDApplicationWebviewProvider.navigation.test.ts` | `viewInTree` calls `revealTreeApplication` with panel namespace; `navigateToResource` delegates to shared reveal helper (no info-toast stub) |
-| Parity | `argocdGraphNodeCapabilities.test.ts` | Webview navigate kinds still match host `NAVIGATE_TREE_SUPPORTED_KINDS` |
-| Manual | Extension Development Host + Argo CD cluster | Application View In Tree selects app in tree; Deployment tile Navigate reveals workload; Job tile has no overflow; wrong-context cluster shows context-mismatch message |
+| Tree provider | `ClusterTreeProvider.reveal.test.ts` (or extend existing tree suite) | `revealTreeResource` maps Deployment/Pod/Service/ConfigMap to correct categories using **destination namespace** for workload lookup; returns false when item missing after tree refresh |
+| Provider stubs | `ArgoCDApplicationWebviewProvider.navigation.test.ts` | `navigateToResource` delegates to shared reveal helper; destination-namespace Deployment fixture (e.g. apisocial) reveals successfully |
+| Parity | `argocdGraphNodeCapabilities.test.ts` | Webview navigate kinds still match host `NAVIGATE_TREE_SUPPORTED_KINDS`; Application root overflow no longer exposes `viewInTree` |
+| Manual | Extension Development Host + Argo CD cluster | Deployment tile Navigate reveals workload in destination namespace; Job tile has no overflow; wrong-context cluster shows context-mismatch message |
+
+**Operator topology test matrix (M17):**
+
+| Area | Module / suite | Must prove |
+|------|----------------|------------|
+| Operator client | `OperatorResourceTreeClient.test.ts` (new) | Exec `query argocd resource-tree get`; parse raw JSON; structured error on CLI failure |
+| Assembler | `ApplicationResourceGraphAssembler.test.ts` | Operator-fed raw JSON → `topologySource: argocd_resource_tree`, `topologyMode: full`; pods/ReplicaSets visible under Deployment |
+| Precedence | `ApplicationResourceGraphBuilder.test.ts` | REST wins when `restEnabled` + authorized; operator path when REST not configured; fallback ladder on operator fail |
+| Affordance | `graphTopologyAffordances.test.ts` | Limited-topology suppressed on full topology; distinct copy tiers for `crd_flat`, `kubernetes_owner_ref`, enrichment-pending |
+
+**Graph filter test matrix (M17):**
+
+| Area | Module / suite | Must prove |
+|------|----------------|------------|
+| Filter state | `argocdGraphFilters.test.ts` (new) | AND semantics across name/kind/sync; topology-only nodes without CRD sync treated as Unknown |
+| DTO completeness | `argocdGraphFilters.test.ts` | Host posts full `resourceGraph`; filters do not trim DTO or bump `structureVersion` |
+| Selection | `useGraphInteractionState` or component tests | Selection clears or falls back when selected tile filtered out (TW picks behavior) |
+| Accessibility | `argocdGraphAccessibility.test.ts` | Filter controls keyboard-operable; tab order: header → zoom → filters → canvas |
 
 **Large-application layout and grouping test matrix (issue #222):**
 
@@ -145,3 +180,4 @@ Build and packaging checks should run the existing repository commands for the a
 - `.ai/operations/build_packaging.md`
 - `.ai/operations/observability.md`
 - `.ai/operations/security.md`
+- `kube9-operator/.ai/integration/api_contracts.md` (resource-tree CLI query; peer contract)

--- a/.ai/specs/index.md
+++ b/.ai/specs/index.md
@@ -4,4 +4,4 @@ Durable capability-level architecture and behavior specifications for kube9-vsco
 
 | Slug | Title | Purpose | Status |
 |------|-------|---------|--------|
-| `argocd-diagram-interface` | ArgoCD Diagram Interface | Complete interactive Argo CD Application resource graph with selectable nodes, per-resource actions, tree reveal, and topology-aware refresh. | draft |
+| `argocd-diagram-interface` | ArgoCD Diagram Interface | Interactive Argo CD Application resource graph with full topology (operator/REST), tree navigation, graph filters, and topology-aware refresh. | draft |


### PR DESCRIPTION
Contract-only PR from ideation (`/ideate`).

- **Initiative:** argocd-visual-integration-completion (M17 Argo CD Graph Native Parity)
- **Scope:** `.ai` contract updates only; no application code
- **Highlights:** Extended `argocd-diagram-interface` spec; operator-mediated topology tier; tree navigation fix; graph filters; demoted app-level View In Tree
- **Review:** confirm timeless contract prose and cross-repo coherence with kube9-operator peer PR before merge

Merge before `/plan-roadmap` when downstream work should read merged contracts on `main`.