### PR TITLE
docs(ai): refine issue #225 contract updates

### DIFF
--- a/.ai/interface/accessibility.md
+++ b/.ai/interface/accessibility.md
@@ -75,3 +75,14 @@ Manual acceptance before marking #224 done (full M16 packaging/high-contrast swe
 8. In a high-contrast theme, confirm sync/health badges are not color-only (icon + visible label in accessible name on the tile group).
 
 **Edge semantics:** Parent/child relationships do not require per-edge accessible descriptions in v1; tile accessible names plus **Details** drift table navigation are sufficient.
+
+**Resolved (#225 M16 close-out sweep):**
+
+Before the M16 Argo CD Application diagram is release-ready, run the full manual sweep below in the Extension Development Host against a running Argo CD Application (or a fixture cluster). This sweep supersedes the #224 tile pass as the release gate; it repeats the #224 steps and adds the packaging-era extras that only exist once graph filters, large-application grouping, and the packaged VSIX are in place:
+
+1. Repeat all eight #224 steps above (tab order through toolbar and tiles, Enter selection, overflow keyboard open/close, tree navigation, denied-action notice, tab switching, high-contrast badges).
+2. **Filter controls (when shipped):** Tab from the zoom controls into the filter toolbar (name search, kind, sync status). Confirm each control is reachable by keyboard, has a visible `:focus-visible` ring, and that applying a filter does not trap focus or require pointer interaction.
+3. **Large-application grouping (when shipped):** For an Application above the grouping threshold, confirm a collapsed kind group is keyboard-reachable, **Enter**/**Space** expands it, focus lands on a member tile after expand, and collapsing a group does not strand focus on a now-hidden tile.
+4. **Reduced motion:** With `prefers-reduced-motion: reduce` set in the OS/browser, trigger a data refresh that changes graph structure; confirm relayout is instant (no animated transition) per the Motion and density rule above.
+5. **High-contrast:** In a VS Code high-contrast theme, confirm sync/health badges on graph tiles and the Details table remain legible with visible icon + text label, and that filter/toolbar controls keep visible focus rings.
+6. Record sweep completion (steps 1-5, noting which of the conditional steps applied) as a checklist in the #225 PR description or issue comment; this is manual evidence, not a new automated suite.

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -82,14 +82,23 @@ The conformance report follows the existing operator report bundle pattern:
 
 `npm run build:webview` must include the conformance report bundle and style copy before the feature is considered packaged. `npm run build`, `npm run compile`, and CI must therefore exercise the new webview bundle. If packaging adds a new media path, `.vscodeignore` must continue to include `media/` artifacts in the VSIX.
 
-## Open Implementation Decisions
+## ArgoCD Diagram Delivery Checks (issue #225)
 
-Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+**Validation checklist tiers:**
 
-### ArgoCD diagram delivery checks
-- Decide the exact validation checklist per implementation story, including which graph interactions are covered by unit tests, webview component tests, packaged build checks, and manual keyboard review.
-- Define how maintainers record Argo CD webview bundle-size spot checks when React Flow or layout dependencies change.
-- Add packaging verification for any new Argo CD graph CSS or asset paths copied beside `media/argocd-application/main.js`.
+1. **Unit / component tests** — Fastest feedback; cover accessible name computation, focus order, filter AND-semantics, layout constants, protocol validation, and capability registry behavior (see `.ai/specs/argocd-diagram-interface.spec.md` test matrices). Run via `npm run test:unit`.
+2. **Packaged-build assertions** — Automated, run after `npm run package` in CI; assert the VSIX contains the required Argo CD webview entries (below). These catch missing `build:webview` outputs or `.vscodeignore` regressions that unit tests cannot see.
+3. **Manual keyboard / high-contrast / reduced-motion review** — Human verification in the Extension Development Host against a running Argo CD Application, covering interaction paths that require a real VS Code theme and focus system (see `.ai/interface/accessibility.md` **Resolved (#225 M16 close-out sweep)**).
+
+**Packaging verification (VSIX asset assertions):** Extend the `scripts/verify-vsix-header-css.sh` pattern with a sibling script `scripts/verify-vsix-argocd-media.sh` (wired to `npm run verify:vsix-argocd-media`) that asserts the packaged VSIX contains:
+
+- `extension/media/argocd-application/main.js` (esbuild output from `build:webview`)
+- `extension/media/argocd-application/style.css` (React Flow base styles, copied by `build:webview` from `node_modules/@xyflow/react/dist/style.css`)
+- `extension/media/argocd-application/styles.css` (application styles, copied by `build:webview` from `src/webview/argocd-application/styles.css`)
+
+Run this script in the same **Build Extension** CI job as `verify:vsix-header-css`, immediately after `npm run package`, so a missing Argo CD media path fails the build the same way a missing header CSS path does today.
+
+**Bundle-size spot-check:** After `npm run build` (or `npm run compile`, both of which invoke `build:webview`), maintainers run `ls -lh media/argocd-application/main.js` and record the reported size in the PR description whenever the PR changes React Flow, the layout engine, or graph webview source under `src/webview/argocd-application/`. The target remains **≤ 450 KB** minified (see Bundle Size Expectations above). There is no hard CI size gate; PRs that exceed the target justify the overage in the PR description, and releases that ship the overage note it in the release changelog entry for that version. No separate perpetual bundle-size log file is required.
 
 ## Packaging Contract
 

--- a/.ai/operations/observability.md
+++ b/.ai/operations/observability.md
@@ -31,9 +31,8 @@ Diagnostics should be rich enough for troubleshooting while keeping end-user mes
 
 Product telemetry (when shipped) must stay **minimal, enumerated, and reviewable**, consistent with `.ai/operations/security.md`.
 
-## Open Implementation Decisions
+## ArgoCD Diagram Telemetry (issue #225)
 
-Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+Graph-specific product telemetry is **optional** and not required for the Argo CD diagram to be release-ready. The existing `kube9.product.feature_usage.webview_open` event with `webviewSurface: argocd_application` (see `docs/telemetry-event-catalog.md`) already provides the open-panel signal for this surface.
 
-### ArgoCD diagram telemetry
-- If graph telemetry is included, define catalog entries and allowed payload shapes through the existing telemetry catalog workflow before implementation emits events.
+If a graph implementation PR adds **new** telemetry event keys or payload fields (for example a coarse "topology fallback shown" or "resource action outcome" event), the same PR must add the corresponding row(s) to `docs/telemetry-event-catalog.md` under **Proposed** or **Shipped** before the emitting code merges, following the existing catalog review workflow (author adds/updates rows, maintainer confirms allowlisted-only payload shapes, no cluster identifiers). Validation for #225 is a catalog review plus a negative check: confirm graph action/navigation/topology code paths do not emit raw resource names, namespaces, Application names, kind/name pairs beyond the enumerated event keys, Argo CD URLs, kubeconfig data, or tokens via product telemetry, consistent with the **Never send** list above.

--- a/.ai/specs/argocd-diagram-interface.spec.md
+++ b/.ai/specs/argocd-diagram-interface.spec.md
@@ -159,6 +159,17 @@ Interface validation should include graph layout readability, selectable tiles, 
 
 Build and packaging checks should run the existing repository commands for the affected scope: `npm run compile`, `npm run build`, `npm run test:unit`, and `npm run package` as appropriate for implementation changes. Packaging review should confirm Argo CD webview scripts, CSS, React Flow styles, and shared webview header CSS are present in the VSIX, and bundle-size changes to `media/argocd-application/main.js` remain within the documented target or are explicitly justified.
 
+**M16 close-out validation matrix (issue #225):**
+
+| Area | Module / suite or command | Must prove |
+|------|----------------------|------------|
+| Automated suites | `npm run test:unit` | All existing graph unit/component suites pass (protocol, capabilities, accessibility helpers, layout, filters, grouping — see matrices above) |
+| Build | `npm run compile`, `npm run build` | Both invoke `build:webview`; Argo CD webview bundle and CSS rebuild without errors |
+| Packaging assets | `npm run package` then `scripts/verify-vsix-argocd-media.sh` (`npm run verify:vsix-argocd-media`) | VSIX contains `extension/media/argocd-application/main.js`, `style.css` (React Flow), and `styles.css` (application styles); CI runs this in the same job as `verify:vsix-header-css` |
+| Bundle size | `ls -lh media/argocd-application/main.js` after `npm run build` | Recorded in PR description when graph deps/webview source change; target ≤ 450 KB minified per `.ai/operations/build_packaging.md`; overage justified in PR and release notes, not CI-blocked |
+| Manual accessibility | Extension Development Host + Argo CD Application | Full sweep in `.ai/interface/accessibility.md` **Resolved (#225 M16 close-out sweep)**: #224 steps plus filters, large-app grouping keyboard path, reduced-motion, high-contrast |
+| Telemetry (optional) | `docs/telemetry-event-catalog.md` review + code review of graph action/navigation paths | Any new graph event keys/payloads are cataloged before emit; no cluster-identifying payloads (namespace, Application name, resource name, URL, kubeconfig, token) leave the extension via product telemetry |
+
 ## References
 
 - `.ai/business_logic/domain_model.md`


### PR DESCRIPTION
## Summary

Completes the `.ai` contract updates for `/refine-issue` on #225 (Validate ArgoCD diagram accessibility, packaging, and bundle impact), the last open M16 issue.

- `.ai/operations/build_packaging.md` — resolves **ArgoCD diagram delivery checks** into timeless prose: validation-tier ordering (unit/component → packaged-build assertions → manual review), the three required VSIX entries for Argo CD media (`main.js`, `style.css`, `styles.css`), and the bundle-size spot-check/record process (target unchanged at ≤ 450 KB, no hard CI gate).
- `.ai/operations/observability.md` — resolves **ArgoCD diagram telemetry**: existing `argocd_application` webview_open event is sufficient; any new graph event keys must be cataloged in `docs/telemetry-event-catalog.md` before emit; defines the #225 negative-check scope.
- `.ai/interface/accessibility.md` — adds **Resolved (#225 M16 close-out sweep)**: extends the #224 tile pass with filter controls, large-application grouping keyboard path, reduced-motion, and high-contrast checks, without reopening the #224 pass itself.
- `.ai/specs/argocd-diagram-interface.spec.md` — adds the **M16 close-out validation matrix (issue #225)** to Testing Strategy, aligned with the existing #222/#224 matrices.

No `Open Implementation Decisions` bullets remain for #225 scope in any of these files.

## Test plan

- [x] `.ai`-only diff (no application code changed)
- [x] Cross-referenced against `package.json` scripts, `.github/workflows/ci.yml`, `.nvmrc`, and `scripts/verify-vsix-header-css.sh` for factual accuracy
- [x] Issue #225 refined in the same session with matching inline detail (no path-only `.ai` deferrals)