### PR TITLE
docs(ai): refine issue #242 contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -176,12 +176,14 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - **Managed-resource overflow labels (v1):** Deployment — **Restart rollout**, **Navigate to resource in tree**; other navigate-supported kinds — **Navigate to resource in tree** only. Labels match `graphNodeCapabilities.ts` and host `actionId` registry entries.
 - **Progressive disclosure for very large Applications** — resolved in `.ai/interface/presentation.md` and `.ai/data/consistency.md` (issue #222): webview kind-based grouping over complete DTO; threshold 40 managed resources.
 
-**Resolved (tree navigation, M17):**
+**Resolved (tree navigation, M17 / issue #242):**
 
 - **Application-level View In Tree** (`viewInTree` message) is **removed or demoted** from sub-header, Application root overflow, and related page-level chrome. It does not receive selection-aware behavior.
-- **Managed-resource navigation** routes through `resource.navigateTree` with the tile's `ManagedResourceKey`. The host maps supported kinds to cluster-tree categories via `ClusterTreeProvider.revealTreeResource`, using **destination namespace** for workload lookup where the managed resource key differs from the Application namespace. The host **refreshes the cluster tree before reveal lookup**.
-- **Details tab parity:** `navigateToResource` from the Details view uses the same reveal helper as `resource.navigateTree` for supported kinds.
-- **Failure is non-mutating:** When no tree item can be mapped, the extension reports navigation failure with user-facing copy; it must not create tree nodes or alter resource identity.
+- **Managed-resource navigation** routes through `resource.navigateTree` with the tile's `ManagedResourceKey`. The host maps supported kinds to cluster-tree categories via `ClusterTreeProvider.revealTreeResource`.
+- **Reveal namespace:** trimmed `ManagedResourceKey.namespace` is authoritative. Never use `ApplicationKey.namespace`. Do not override a non-empty resource namespace with Application `spec.destination.namespace`. Empty namespaced-kind namespace may fall back to `spec.destination.namespace`; cluster-scoped stays empty. Full rules in `.ai/interface/interaction_flow.md`.
+- **Refresh before reveal:** focus tree; invalidate resource cache and tree prefetch/category caches for the current context; fire tree data change; then await reveal lookup in the same async chain. No debounce. Do not depend on TreeView re-render for correctness.
+- **Details tab parity:** `navigateToResource` from the Details view uses the same reveal helper and namespace rules as `resource.navigateTree` for supported kinds.
+- **Failure is non-mutating:** When no tree item can be mapped, the extension reports navigation failure with user-facing copy; it must not create tree nodes or alter resource identity. False "not found in cluster tree" for a supported kind present under the resolved reveal namespace is a defect.
 
 **Resolved (operator topology affordances, issue #241):**
 
@@ -196,6 +198,6 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 **Deferred (M17):**
 
 - **Graph filter UX:** Widget shape (chips vs dropdown), zero-match empty state, selection-when-filtered behavior, filter visibility (hide vs de-emphasize), and a11y live-region announcements (sibling issue #244).
-- **Supported reveal kinds expansion:** Whether resource-tree-only kinds (ReplicaSet, etc.) gain overflow navigate actions (sibling issue #242).
+- **Supported reveal kinds expansion:** Whether resource-tree-only kinds (ReplicaSet, etc.) gain overflow navigate actions. **Out of scope for issue #242** (that issue fixes reveal for existing `NAVIGATE_TREE_SUPPORTED_KINDS` only). Defer until product expands the Kind Capability Registry.
 
 - **`resource.openDescribe` on graph tiles** — registry entry exists for future direct describe routing from `ManagedResourceKey`; v1 graph overflow does not expose it. Users open describe via tree reveal or Details tab navigate affordances.

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -76,12 +76,12 @@ Canonical key for a managed Kubernetes object referenced by an Application:
 
 | Property | Required | Notes |
 |----------|----------|-------|
-| `namespace` | yes | Empty string only for cluster-scoped kinds when CRD omits namespace |
+| `namespace` | yes | Workload / object namespace from the managed resource row (destination namespace). Empty string only for cluster-scoped kinds when CRD omits namespace. Distinct from `ApplicationKey.namespace` (Application CR location). |
 | `kind` | yes | Kubernetes kind string (e.g. `Deployment`, `Service`) |
 | `name` | yes | Resource name |
 | `apiGroup` | no | Include when known (CRDs, multi-version ambiguity); omit or empty for core group |
 
-Two `ArgoCDResource` rows match when `namespace`, `kind`, and `name` are equal and `apiGroup` matches when both sides provide it.
+Two `ArgoCDResource` rows match when `namespace`, `kind`, and `name` are equal and `apiGroup` matches when both sides provide it. Tree reveal and graph identity both use this key's namespace, not the Application CR namespace (see interaction_flow reveal rules, issue #242).
 
 ### ApplicationKey
 

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -151,9 +151,10 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 ### ArgoCD graph DTO details
 
-**Resolved (tree reveal v1, issue #221):**
+**Resolved (tree reveal v1, issue #221 / namespace fix #242):**
 
-- **`apiGroup` for tree navigation:** Not required for v1 reveal of core kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`. Host reveal uses `kind`, `name`, and trimmed `namespace` from `ManagedResourceKey`. When `apiGroup` is present on the key, forward it for future CRD-kind routing; omitting it must not block core-kind reveal.
+- **`apiGroup` for tree navigation:** Not required for v1 reveal of core kinds in `NAVIGATE_TREE_SUPPORTED_KINDS`. Host reveal uses `kind`, `name`, and trimmed `namespace` from `ManagedResourceKey` (resolved per interaction_flow namespace rules). When `apiGroup` is present on the key, forward it for future CRD-kind routing; omitting it must not block core-kind reveal.
+- **Namespace on wire:** `resourceAction` / `navigateToResource` `namespace` must be the managed resource's namespace (destination workload namespace), not the Application CR namespace. Host may apply destination fallback only when the payload namespace is empty for a namespaced navigate-supported kind.
 - **`group` vs `apiGroup` on the wire (issue #223):** DTO field `apiGroup`; webview protocol field `group` on `resourceAction` and `ResourceNodeRef`. Map at the webview boundary (`buildResourceActionPayload` / `buildResourceNodeRef`). Validators reject `apiGroup` on webview messages. Do not emit both fields on the same message.
 
 - **Large-application grouping (issue #222):** Remains an **interface-only transform** over the complete flat DTO node set in v1. Kind group tiles are synthetic webview nodes; they are not serialized in `ApplicationResourceGraph.nodes`. The host does not set `truncated: true` to omit managed-resource nodes.

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -257,7 +257,7 @@ The report does not shell out beyond the existing operator status read path. It 
 
 ### Tree reveal mapping (host)
 
-`ClusterTreeProvider.revealTreeResource(kind, name, namespace)` resolves existing tree items only:
+`ClusterTreeProvider.revealTreeResource(kind, name, namespace)` resolves existing tree items only. The `namespace` argument is the **resolved reveal namespace** from `.ai/interface/interaction_flow.md` (managed resource key; never Application CR namespace).
 
 | Kind | Tree path |
 |------|-----------|
@@ -265,6 +265,8 @@ The report does not shell out beyond the existing operator status read path. It 
 | Deployment, StatefulSet, DaemonSet, CronJob | Workloads → matching subcategory |
 | Service | Networking → Services |
 | ConfigMap, Secret | Configuration → ConfigMaps / Secrets |
+
+Before managed-resource reveal, the host focuses the cluster tree, invalidates the current-context resource cache and any prefetch/category children cache used by tree loading, fires tree data change, then awaits this lookup (issue #242). No debounce.
 
 `ClusterTreeProvider.revealTreeApplication(name, namespace)` resolves under **ArgoCD Applications** (`argocd` → `argocdApplication`) by matching `resourceName` and application namespace. Returns `false` when the category, application list, or matching item is unavailable.
 

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -101,10 +101,30 @@ Managed-resource tree reveal is the primary graph-first navigation path. Applica
 
 | Source | Message / action | Host behavior | User feedback |
 |--------|------------------|---------------|---------------|
-| Managed-resource tile overflow | `resourceAction` with `actionId: resource.navigateTree` | Kubeconfig available, active context matches panel context; focus tree, **refresh tree**, `revealTreeResource(kind, name, namespace)` using **destination namespace** for workload lookup when applicable | `resourceActionProgress` then terminal `resourceActionResult`; failures show dismissible graph action-notice banner |
+| Managed-resource tile overflow | `resourceAction` with `actionId: resource.navigateTree` | Kubeconfig available, active context matches panel context; run **refresh-before-reveal** then `revealTreeResource(kind, name, namespace)` with **resolved reveal namespace** | `resourceActionProgress` then terminal `resourceActionResult`; failures show dismissible graph action-notice banner |
 | Details tab navigate affordance | `navigateToResource` with `kind`, `name`, `namespace` | Delegate to the same reveal helper as `resource.navigateTree` for kinds in `NAVIGATE_TREE_SUPPORTED_KINDS` | Same messages as `resource.navigateTree` result text |
 
-**Identity for reveal:** Use `ManagedResourceKey.namespace` (trimmed; destination namespace for workloads in multi-destination apps), `kind`, and `name`. The host refreshes the cluster tree before lookup. Optional `apiGroup` is forwarded when present.
+#### Namespace resolution for reveal
+
+Reveal identity uses `kind`, `name`, and a **resolved reveal namespace** derived as follows (issue #242):
+
+1. Start from the managed resource's `ManagedResourceKey.namespace` (from the tile key / `resourceAction` / `navigateToResource` payload). Trim whitespace.
+2. **Never** substitute `ApplicationKey.namespace` (Application CR location, often `argocd`) for managed-resource reveal.
+3. When the trimmed resource namespace is **non-empty**, use it as-is. Do **not** override it with Application `spec.destination.namespace` (multi-namespace / multi-destination apps keep per-row namespaces).
+4. When the trimmed resource namespace is **empty** and the kind is namespaced and in `NAVIGATE_TREE_SUPPORTED_KINDS`, fall back to Application `spec.destination.namespace` when that field is non-empty after trim; otherwise leave empty and allow not-found.
+5. Cluster-scoped kinds keep empty namespace; match tree items whose namespace is empty. Do not apply destination fallback for cluster-scoped kinds.
+6. Optional `apiGroup` / wire `group` is forwarded when present; omitting it must not block core-kind reveal.
+
+#### Refresh before reveal
+
+User-initiated managed-resource navigate runs this **single async chain** (no debounce):
+
+1. Focus `kube9ClusterView`.
+2. Invalidate caches that feed category children for the current context: the shared resource cache pattern **and** any tree prefetch / category children cache used by `getCategoryChildren` (or equivalent).
+3. Fire tree data change so the visible tree stays consistent.
+4. Await `revealTreeResource(kind, name, resolvedNamespace)`, which loads children through provider APIs **after** invalidation.
+
+Correctness is provider-side fresh children after invalidation. The host must not require waiting for TreeView UI re-render, and must not look up against stale prefetch data from before the invalidate step.
 
 **Failure copy (managed resource, terminal result message):**
 
@@ -115,7 +135,7 @@ Managed-resource tree reveal is the primary graph-first navigation path. Applica
 | Supported kind, no matching tree item | false | `resource.navigateTree failed for {kind} {name}: resource not found in cluster tree` |
 | Reveal succeeded | true | `Focused {kind} {name} in cluster tree` |
 
-Mapping failure is a navigation limitation: the host must not fabricate tree items or resource identity. List RBAC gaps that prevent category expansion may surface as "not found in cluster tree" when no item can be resolved.
+Mapping failure is a navigation limitation: the host must not fabricate tree items or resource identity. List RBAC gaps that prevent category expansion may surface as "not found in cluster tree" when no item can be resolved. False not-found for a supported kind that exists under the resolved reveal namespace is a defect (issue #242).
 
 ## Kubernetes AI Conformance Flow
 

--- a/.ai/specs/argocd-diagram-interface.spec.md
+++ b/.ai/specs/argocd-diagram-interface.spec.md
@@ -37,7 +37,14 @@ Basic mode (no operator):
   3. crd_flat
 ```
 
-On operator or REST success, the host emits `topologySource: argocd_resource_tree` and `topologyMode: full` (operator is transport only; do not emit `operator_snapshot`). Enrichment failure falls back to lower tiers without failing the whole panel when the Application CRD remains readable. `resource.navigateTree` / `ClusterTreeProvider.revealTreeResource` must map managed resources to the correct **destination namespace** workloads, refresh the cluster tree before lookup, and surface actionable failure copy when reveal fails.
+On operator or REST success, the host emits `topologySource: argocd_resource_tree` and `topologyMode: full` (operator is transport only; do not emit `operator_snapshot`). Enrichment failure falls back to lower tiers without failing the whole panel when the Application CRD remains readable.
+
+**Managed-resource tree reveal (issue #242):** `resource.navigateTree` / `ClusterTreeProvider.revealTreeResource` must:
+
+- Resolve reveal namespace from the managed resource key per `.ai/interface/interaction_flow.md` (**Namespace resolution for reveal**): trimmed `ManagedResourceKey.namespace` is authoritative; never `ApplicationKey.namespace`; do not override a non-empty resource namespace with Application `spec.destination.namespace`; empty namespaced-kind namespace may fall back to destination namespace; cluster-scoped stays empty.
+- Run **refresh-before-reveal** in one async chain (focus → invalidate resource + prefetch/category caches → fire tree change → await reveal). No debounce. Lookup must use provider children loaded after invalidation, not stale prefetch data.
+- Surface existing failure copy for context mismatch, tree unavailable, and true not-found; do not emit false "resource not found in cluster tree" when a supported kind exists under the resolved reveal namespace.
+- Keep `NAVIGATE_TREE_SUPPORTED_KINDS` unchanged unless a reported failure requires a registry fix; kind expansion is out of scope for #242.
 
 **Operator CLI path (issue #241):**
 
@@ -126,15 +133,19 @@ Interface validation should include graph layout readability, selectable tiles, 
 
 **Implementation polish (#224):** Add tile `:hover` and `argocd-graph-node--overflow-open` styling; wire overflow-open class from `ResourceGraphNodeTile` when menu is open; suppress action-notice banner when result message is `Cancelled`.
 
-**Tree navigation test matrix (M17):**
+**Tree navigation test matrix (M17 / issue #242):**
 
 | Area | Module / suite | Must prove |
 |------|----------------|------------|
-| Registry (existing) | `kindCapabilityRegistry.test.ts` | `resource.navigateTree` success when `revealTreeResource` returns true; failure when false; context mismatch and tree-unavailable paths |
-| Tree provider | `ClusterTreeProvider.reveal.test.ts` (or extend existing tree suite) | `revealTreeResource` maps Deployment/Pod/Service/ConfigMap to correct categories using **destination namespace** for workload lookup; returns false when item missing after tree refresh |
-| Provider stubs | `ArgoCDApplicationWebviewProvider.navigation.test.ts` | `navigateToResource` delegates to shared reveal helper; destination-namespace Deployment fixture (e.g. apisocial) reveals successfully |
-| Parity | `argocdGraphNodeCapabilities.test.ts` | Webview navigate kinds still match host `NAVIGATE_TREE_SUPPORTED_KINDS`; Application root overflow no longer exposes `viewInTree` |
-| Manual | Extension Development Host + Argo CD cluster | Deployment tile Navigate reveals workload in destination namespace; Job tile has no overflow; wrong-context cluster shows context-mismatch message |
+| Registry (existing) | `kindCapabilityRegistry.test.ts` | `resource.navigateTree` success when `revealTreeResource` returns true; failure when false; context mismatch and tree-unavailable paths; failure copy strings unchanged |
+| Tree provider | `ClusterTreeProvider.reveal.test.ts` (or extend existing tree suite) | `revealTreeResource` maps Deployment/Pod/Service/ConfigMap to correct categories; lookup uses **resolved reveal namespace** (resource key, not Application CR namespace); returns false when item missing after refresh-before-reveal invalidation |
+| Namespace resolution | `treeRevealHelper` tests or navigation suite | Non-empty resource namespace wins over Application CR namespace and over `spec.destination.namespace`; empty namespaced-kind namespace falls back to destination; Application CR namespace alone never used for Deployment reveal |
+| Destination-namespace fixture | `ArgoCDApplicationWebviewProvider.navigation.test.ts` | Deployment **apisocial** (or equivalent) where Application CR namespace ≠ resource namespace reveals successfully via shared helper; wrong namespace (Application CR ns) must not be passed to `revealTreeResource` |
+| Multi-namespace | Tree reveal or helper unit test | Two Deployments in different namespaces under one Application each reveal with their own resource namespace |
+| Refresh before reveal | `treeRevealHelper` / provider unit test | Navigate path invalidates resource + prefetch/category caches before `revealTreeResource`; after seeding a stale miss, post-invalidate lookup finds the resource; no debounce timer |
+| Provider stubs | `ArgoCDApplicationWebviewProvider.navigation.test.ts` | `navigateToResource` delegates to same reveal helper and namespace rules as `resource.navigateTree` |
+| Parity | `argocdGraphNodeCapabilities.test.ts` | Webview navigate kinds still match host `NAVIGATE_TREE_SUPPORTED_KINDS`; Application root overflow no longer exposes `viewInTree` (covered by #243; #242 must not regress registry kinds) |
+| Manual | Extension Development Host + Argo CD cluster | Open Application that manages Deployment `apisocial` in destination namespace ≠ Application CR namespace; tile **Navigate to resource in tree** selects that Deployment in the cluster tree (not "resource not found"); Job tile has no overflow; wrong-context cluster shows context-mismatch message |
 
 **Operator topology test matrix (issue #241):**
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #242
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.