### PR TITLE
docs(ai): refine issue #243 contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -90,17 +90,17 @@ The registry is extensible: new kinds add capability entries without changing th
 - Mutating actions (sync, restart rollout) require **explicit user intent** via menu or command invocation.
 - Actions target the **specific node** the user selected; they do not implicitly cascade to unrelated nodes unless the underlying operation naturally affects dependents (for example, sync at Application root).
 - Read-only or insufficient RBAC must block write actions while preserving read-only graph inspection where permitted.
-- **View In Tree** from a managed-resource graph node resolves that node's `ManagedResourceKey` to the existing Kubernetes tree navigation path when a tree item can be mapped. Failure to map a node is a navigation limitation, not permission to mutate or invent resource identity.
+- **Navigate to resource in tree** from a managed-resource graph node resolves that node's `ManagedResourceKey` to the existing Kubernetes tree navigation path when a tree item can be mapped. Failure to map a node is a navigation limitation, not permission to mutate or invent resource identity. Application-level View In Tree is not offered from the Application panel.
 
 ## Webview page-level actions
 
-Page-level commands on webview panels (header, **Actions** overflow, documented sub-header rows) follow a frozen semantics rule: **handlers and message payloads do not change** for this initiative; only placement, grouping, and chrome change.
+Page-level commands on webview panels (header, **Actions** overflow, documented sub-header rows) follow a frozen semantics rule for the header-unification initiative: **handlers and message payloads do not change** for that work; only placement, grouping, and chrome change. **Exception (M17 / issue #243):** Application-level View In Tree is intentionally removed from the Application panel (UI and `viewInTree` protocol), so managed-resource Navigate remains the sole in-panel graph-to-tree path.
 
 ### Global header rules
 
 - **Primary cap:** At most **three** labeled primary header buttons per panel (excluding Help and the overflow control). Additional page-level operations use the **Actions** overflow menu.
 - **Help:** Only where **`helpContext`** or an equivalent help link exists; Help posts `openHelp` with that context and is **trailing**, outside overflow. Help failures must not break the panel.
-- **No capability removal:** Every action reachable before header unification remains reachable (primary, overflow, or documented sub-header/toolbar slot).
+- **No capability removal:** Every action reachable before header unification remains reachable (primary, overflow, or documented sub-header/toolbar slot), except Application-level View In Tree removed per issue #243.
 
 ### Action tiers (placement)
 
@@ -119,7 +119,7 @@ Page-level commands on webview panels (header, **Actions** overflow, documented 
 
 **Disabled actions:** Remain **visible** when inapplicable (for example Clear Filters with no active filters) unless a future story chooses hide-when-inapplicable.
 
-Argo CD application-level **sync**, **refresh**, and **hard refresh** stay **page-level** (header/sub-header), not on the graph canvas toolbar. Graph node overflow, canvas zoom/fit toolbar, and **graph filter controls** remain separate surfaces. Application-level **View In Tree** is demoted or removed from page-level chrome; managed-resource **Navigate to resource in tree** remains on tile overflow.
+Argo CD application-level **sync**, **refresh**, and **hard refresh** stay **page-level** (header/sub-header), not on the graph canvas toolbar. Graph node overflow, canvas zoom/fit toolbar, and **graph filter controls** remain separate surfaces. Application-level **View In Tree** is **removed** from Application panel chrome (sub-header, Application root overflow, Details Overview); managed-resource **Navigate to resource in tree** is the only in-panel graph-to-tree path.
 
 ## Resource inspection and mutation surfaces
 
@@ -158,7 +158,7 @@ Rules below are the **kube9-vscode reference baseline** for built-in Kubernetes 
 4. Resource views should degrade gracefully when optional integrations are unavailable.
 5. Resource identity and scope must remain consistent across tree items, command routing, detail providers, YAML views, and Resource Graph Nodes.
 6. The Application Resource Graph must remain usable when dependency topology is partial; missing edges or unknown parentage must not prevent rendering available nodes and status.
-7. Application-level sync, refresh, and hard refresh remain available from the webview header/sub-header; they are not replaced by the graph canvas toolbar. Application-level View In Tree is demoted or removed from sub-header and Application root overflow; managed-resource tree navigation via `resource.navigateTree` is the primary graph-first path.
+7. Application-level sync, refresh, and hard refresh remain available from the webview header/sub-header; they are not replaced by the graph canvas toolbar. Application-level View In Tree is removed from the Application panel; managed-resource tree navigation via `resource.navigateTree` is the only in-panel graph-to-tree path.
 8. Graph presentation and actions must not require the user to leave VS Code or open the native Argo CD server UI.
 9. **Extension-owned graph assembly:** the extension owns `ApplicationResourceGraph` DTO assembly, webview rendering, graph filters, and tree reveal. In **operated clusters**, kube9-operator supplies on-demand Argo CD resource-tree JSON (raw passthrough); the extension normalizes via existing `buildResourceTreeApplicationResourceGraph` and emits `topologySource: argocd_resource_tree`. CRD-flat baseline remains when all enrichment tiers fail. Kind Capability Registry rules are unchanged by topology source or filters.
 
@@ -178,12 +178,18 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 **Resolved (tree navigation, M17 / issue #242):**
 
-- **Application-level View In Tree** (`viewInTree` message) is **removed or demoted** from sub-header, Application root overflow, and related page-level chrome. It does not receive selection-aware behavior.
 - **Managed-resource navigation** routes through `resource.navigateTree` with the tile's `ManagedResourceKey`. The host maps supported kinds to cluster-tree categories via `ClusterTreeProvider.revealTreeResource`.
 - **Reveal namespace:** trimmed `ManagedResourceKey.namespace` is authoritative. Never use `ApplicationKey.namespace`. Do not override a non-empty resource namespace with Application `spec.destination.namespace`. Empty namespaced-kind namespace may fall back to `spec.destination.namespace`; cluster-scoped stays empty. Full rules in `.ai/interface/interaction_flow.md`.
 - **Refresh before reveal:** focus tree; invalidate resource cache and tree prefetch/category caches for the current context; fire tree data change; then await reveal lookup in the same async chain. No debounce. Do not depend on TreeView re-render for correctness.
 - **Details tab parity:** `navigateToResource` from the Details view uses the same reveal helper and namespace rules as `resource.navigateTree` for supported kinds.
 - **Failure is non-mutating:** When no tree item can be mapped, the extension reports navigation failure with user-facing copy; it must not create tree nodes or alter resource identity. False "not found in cluster tree" for a supported kind present under the resolved reveal namespace is a defect.
+
+**Resolved (Application View In Tree removal, M17 / issue #243):**
+
+- **Full remove** from the Application panel: sub-header, Application root overflow, and Details Overview action buttons. No Application-reveal affordance remains in the panel for empty selection, Application-root-only selection, or non-navigable kinds.
+- **Protocol:** Webview→host `viewInTree` is removed from the accepted protocol; host `handleViewInTree` and unused `revealApplicationInTree` helper are removed with the UI. `ClusterTreeProvider.revealTreeApplication` may remain as a tree-provider utility for cluster-tree tests or future non-panel UX; it is not wired through the Application webview.
+- **Keyboard:** No dedicated Application View In Tree shortcut. In-panel tree navigation is managed-resource overflow (Context Menu / Shift+F10 → Navigate to resource in tree) plus Details drift navigate links.
+- Application-level sync, refresh, and hard refresh stay on header/sub-header unchanged.
 
 **Resolved (operator topology affordances, issue #241):**
 

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -173,7 +173,6 @@ JSON messages over `webview.postMessage` / `onDidReceiveMessage`. Types are stri
 | `sync` | — | Patch Application, track operation, refresh data + graph |
 | `refresh` | — | Refresh annotation path, reload data + graph |
 | `hardRefresh` | — | Confirm, patch hard refresh, reload |
-| `viewInTree` | — | Focus `kube9ClusterView`, refresh tree, reveal open Application as `argocdApplication` item when context matches |
 | `navigateToResource` | `kind`, `name`, `namespace` | Same reveal path as `resource.navigateTree` for supported kinds; explicit error for unsupported kinds |
 | `graphRefresh` | optional `bypassCache?: boolean` | Reload Application and rebuild `ApplicationResourceGraph` |
 | `resourceAction` | `actionId`, `kind`, `name`, `namespace`, optional `group`, `version` | Run registry action; emit progress/result. Wire uses `group` (not `apiGroup`); maps from `ManagedResourceKey.apiGroup` at the webview boundary. No `nodeId` on the wire — identity is the resource reference fields above. |
@@ -252,7 +251,6 @@ The report does not shell out beyond the existing operator status read path. It 
 | Resource action denied | `resourceActionResult` success false | Error message |
 | Tree reveal: context mismatch | `resourceActionResult` success false | Graph action-notice + result message |
 | Tree reveal: resource not in tree | `resourceActionResult` success false | Graph action-notice; message includes `not found in cluster tree` |
-| Application `viewInTree`: app not found | _(no webview message)_ | `showWarningMessage` naming application |
 | Network / timeout on CRD get | `error` | Warning or error per severity |
 
 ### Tree reveal mapping (host)
@@ -268,7 +266,7 @@ The report does not shell out beyond the existing operator status read path. It 
 
 Before managed-resource reveal, the host focuses the cluster tree, invalidates the current-context resource cache and any prefetch/category children cache used by tree loading, fires tree data change, then awaits this lookup (issue #242). No debounce.
 
-`ClusterTreeProvider.revealTreeApplication(name, namespace)` resolves under **ArgoCD Applications** (`argocd` → `argocdApplication`) by matching `resourceName` and application namespace. Returns `false` when the category, application list, or matching item is unavailable.
+`ClusterTreeProvider.revealTreeApplication(name, namespace)` resolves under **ArgoCD Applications** (`argocd` → `argocdApplication`) by matching `resourceName` and application namespace. Returns `false` when the category, application list, or matching item is unavailable. The Application webview does **not** expose this path (issue #243 removed `viewInTree`); the method may remain for cluster-tree utilities or tests outside the panel.
 
 ## Open Implementation Decisions
 

--- a/.ai/integration/messaging_async.md
+++ b/.ai/integration/messaging_async.md
@@ -13,7 +13,7 @@ See [api_contracts.md](./api_contracts.md#argo-cd-application-webview-protocol) 
 
 | Direction | Types | Purpose |
 |-----------|-------|---------|
-| Webview → host | `ready`, `sync`, `refresh`, `hardRefresh`, `viewInTree`, `navigateToResource` | Load signal, GitOps actions, tree navigation |
+| Webview → host | `ready`, `sync`, `refresh`, `hardRefresh`, `navigateToResource` | Load signal, GitOps actions, managed-resource tree navigation |
 | Host → webview | `applicationData`, `updateStatus`, `operationProgress`, `error` | CRD snapshot, status deltas, sync/refresh progress |
 
 `hardRefresh` requires host-side confirmation before patch.

--- a/.ai/interface/accessibility.md
+++ b/.ai/interface/accessibility.md
@@ -69,10 +69,17 @@ Manual acceptance before marking #224 done (full M16 packaging/high-contrast swe
 2. Tab through header actions → graph toolbar (Zoom in, Zoom out, Fit) → first tile → second tile. Confirm visible `:focus-visible` rings.
 3. Press **Enter** on a tile; confirm selected styling (`argocd-graph-node--selected`) without triggering a cluster mutation.
 4. On a Deployment tile, press **Shift+F10** (or Context Menu); confirm overflow opens, **ArrowDown** moves between items, **Escape** closes and focus returns to the tile.
-5. Activate **Navigate to resource in tree** from overflow; confirm focus moves to cluster tree when reveal succeeds (failure copy per #221).
+5. Activate **Navigate to resource in tree** from overflow; confirm focus moves to cluster tree when reveal succeeds (failure copy per #221 / #242).
 6. Trigger a denied action (for example restart without permission in a test cluster) or use unit-tested unknown `actionId` path; confirm the dismissible action-notice banner exposes non-empty text to assistive APIs (`role="status"`).
 7. Switch **Graph | Details** tabs with keyboard; confirm `aria-selected` on the active tab.
 8. In a high-contrast theme, confirm sync/health badges are not color-only (icon + visible label in accessible name on the tile group).
+
+**Resolved (Application View In Tree removal, issue #243):**
+
+- Sub-header and Details Overview must not expose Application View In Tree; Application root overflow is empty/hidden.
+- Tab order through header/sub-header must not include an Application-reveal control.
+- In-panel keyboard tree navigation is managed-resource overflow only (Context Menu / Shift+F10 → **Navigate to resource in tree**) plus Details drift navigate links. There is no dedicated Application View In Tree shortcut.
+- Empty selection or Application-root-only selection has no Application-reveal fallback in the panel.
 
 **Edge semantics:** Parent/child relationships do not require per-edge accessible descriptions in v1; tile accessible names plus **Details** drift table navigation are sufficient.
 

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -5,7 +5,7 @@
 1. **Inspect**: choose context -> expand namespace/resource -> open describe or YAML/logs.
 2. **Operate**: select resource -> execute scale/restart/delete/apply action -> refresh affected tree nodes.
 3. **Debug**: open events/logs -> correlate with resource health/status -> iterate on YAML or workload commands.
-4. **GitOps (application detail):** select Argo CD Application in the **tree** (unchanged list/category) -> webview opens on the **resource graph** -> scan topology and per-tile sync/health -> use tile overflow or header for sync/refresh/hard-refresh/view-in-tree -> optional **Details** tab for metadata and drift table -> graph refreshes after operations without closing the panel.
+4. **GitOps (application detail):** select Argo CD Application in the **tree** (unchanged list/category) -> webview opens on the **resource graph** -> scan topology and per-tile sync/health -> use header/sub-header for sync/refresh/hard-refresh and managed-resource tile overflow for **Navigate to resource in tree** -> optional **Details** tab for metadata and drift table -> graph refreshes after operations without closing the panel.
 5. **AI conformance readiness:** select operated cluster -> Reports -> Kubernetes AI Conformance -> webview opens with summary rollups and grouped requirements -> expand non-passing or evidence-needed rows -> refresh when operator status changes.
 
 ## Resource describe and YAML flows (reference for kube9-desktop)
@@ -51,7 +51,7 @@ The tree **does not** embed the graph; it continues to list applications with st
 
 ### Operate from tiles and header
 
-- **Application-level:** **Sync** and **Refresh** on the **primary webview header**; **Hard refresh** on the **sub-header row** directly below (disabled while an operation is in progress). Application-level View In Tree is removed or demoted in M17.
+- **Application-level:** **Sync** and **Refresh** on the **primary webview header**; **Hard refresh** on the **sub-header row** directly below (disabled while an operation is in progress). Application-level View In Tree is **removed** from the Application panel (issue #243).
 - **Per-resource overflow (⋮):** Actions are **kind-driven** via a capability registry (not ad hoc per screen). Initial set:
   - **Deployment:** restart rollout (pods), with progress/error feedback through existing extension notification patterns.
   - **Supported workload/kinds:** navigate to resource in tree; open describe where the extension already supports that kind.
@@ -97,7 +97,9 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 ### Tree navigation and reveal (M17)
 
-Managed-resource tree reveal is the primary graph-first navigation path. Application-level `viewInTree` is removed or demoted from sub-header and Application root overflow.
+Managed-resource tree reveal is the only in-panel graph-to-tree path. Application-level `viewInTree` is **removed** from sub-header, Application root overflow, Details Overview action buttons, and the accepted webview→host protocol (issue #243). Empty selection, Application-root-only selection, and non-navigable kinds do not offer an Application-reveal fallback in the panel. Users locate the Application in the cluster tree outside this panel.
+
+**Keyboard (in-panel tree navigation):** Select a navigable managed-resource tile → Context Menu or Shift+F10 → **Navigate to resource in tree**. Details drift navigate links remain keyboard-activable. There is no dedicated Application View In Tree shortcut and no Application-reveal control in the tab order.
 
 | Source | Message / action | Host behavior | User feedback |
 |--------|------------------|---------------|---------------|

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -96,7 +96,7 @@ Tiles have separate focus and selected states. Primary activation selects the ti
 
 **Status iconography:** Sync and health badges reuse the **same visual language** as the tree and the existing drift table: codicon-based sync indicators, health-colored badge backgrounds mapped through `testing.iconPassed`, `testing.iconFailed`, `testing.iconQueued`, and related VS Code tokens. Unknown or missing health uses muted/description styling, not a false-positive green.
 
-**Application root tile:** Mirrors application-level sync and health on the tile; application-level **sync** and **refresh** sit on the **primary webview header**; **hard refresh** sits on the **sub-header row** under the primary header. Application-level View In Tree is removed or demoted in M17; managed-resource overflow remains the primary tree-navigation path.
+**Application root tile:** Mirrors application-level sync and health on the tile; application-level **sync** and **refresh** sit on the **primary webview header**; **hard refresh** sits on the **sub-header row** under the primary header. Application-level View In Tree is **removed** from the sub-header, Application root overflow, Details Overview action buttons, and all other Application panel chrome (issue #243). Managed-resource overflow **Navigate to resource in tree** is the only in-panel graph-to-tree path.
 
 ### Graph toolbar filters (M17)
 
@@ -181,6 +181,11 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 - Sync and health badges, kind icon, truncated name, and ⋮ overflow align with the **Graph tiles (nodes)** table above in this document.
 - **Limited-topology and large-application hints** — resolved under **Large applications** and **Limited-topology copy tiers** above (issues #222 and #241). Limited-topology affordance is **suppressed** when `topologyMode: full`. No enrichment-pending banner during in-flight operator/REST fetch.
+
+**Resolved (Application View In Tree removal, issue #243):**
+
+- Sub-header shows Hard Refresh only (no View In Tree). Application root overflow is empty/hidden. Details Overview action buttons omit View In Tree.
+- Managed-resource overflow remains the only in-panel tree-navigation path.
 
 **Deferred (M17 graph filters, sibling #244):**
 

--- a/.ai/runtime/execution_model.md
+++ b/.ai/runtime/execution_model.md
@@ -44,7 +44,6 @@ See [Startup and bootstrap](startup_bootstrap.md): the extension may send `appli
 | `sync` | Application-level sync (CRD patch) |
 | `refresh` | Normal refresh |
 | `hardRefresh` | Hard refresh (confirmation in host) |
-| `viewInTree` | Reveal open Application under ArgoCD Applications in cluster tree |
 | `navigateToResource` | `kind`, `name`, `namespace` — reveal matching cluster-tree resource when kind is in `NAVIGATE_TREE_SUPPORTED_KINDS` |
 
 ### Webview → extension (resource graph extension)

--- a/.ai/specs/argocd-diagram-interface.spec.md
+++ b/.ai/specs/argocd-diagram-interface.spec.md
@@ -12,7 +12,7 @@ Opening an Argo CD Application from the cluster tree presents Graph as the defau
 
 Each graph tile shows kind, name, Argo CD sync status, Argo CD health status, and an overflow control for eligible actions. Tile selection is a visible, keyboard-operable state that scopes resource-aware actions. Selection does not mutate cluster state by itself; mutating actions require explicit menu or command intent and host-side validation.
 
-Application-level sync, refresh, and hard refresh remain available from the webview header and sub-header. **Application-level View In Tree** is demoted or removed from sub-header, Application root overflow, and related page-level chrome; **managed-resource** "Navigate to resource in tree" (`resource.navigateTree`) is the primary graph-first navigation affordance. Managed-resource tiles support tree reveal and open describe/detail where resource identity can be mapped into the existing Kubernetes tree and describe surfaces. Deployment tiles may expose rollout restart through the Kind Capability Registry when RBAC and action eligibility allow it.
+Application-level sync, refresh, and hard refresh remain available from the webview header and sub-header. **Application-level View In Tree is removed** from sub-header, Application root overflow, Details Overview action buttons, and all other Application panel chrome. The webview→host `viewInTree` message is not part of the accepted protocol. **Managed-resource** "Navigate to resource in tree" (`resource.navigateTree`) is the only in-panel graph-to-tree path. Managed-resource tiles support tree reveal and open describe/detail where resource identity can be mapped into the existing Kubernetes tree and describe surfaces. Deployment tiles may expose rollout restart through the Kind Capability Registry when RBAC and action eligibility allow it.
 
 The graph toolbar exposes **presentation-only filters** for resource name search, kind, and sync status (minimum parity with native Argo CD resource graph filtering). Active filters use **AND** semantics across dimensions. The host continues posting the **complete** `resourceGraph` DTO; filters hide or de-emphasize non-matching managed-resource tiles without mutating cluster state or trimming the host payload.
 
@@ -125,7 +125,7 @@ Interface validation should include graph layout readability, selectable tiles, 
 
 | Area | Module / suite | Must prove |
 |------|----------------|------------|
-| Overflow registry | `argocdGraphNodeCapabilities.test.ts` | Deployment exposes restart + navigate; application root exposes view-in-tree only; unknown kinds return empty actions; webview navigate kinds match host `NAVIGATE_TREE_SUPPORTED_KINDS` |
+| Overflow registry | `argocdGraphNodeCapabilities.test.ts` | Deployment exposes restart + navigate; application root returns empty actions (no View In Tree); unknown kinds return empty actions; webview navigate kinds match host `NAVIGATE_TREE_SUPPORTED_KINDS` |
 | Host dispatch | `kindCapabilityRegistry.test.ts` | Unknown `actionId` and unsupported kind post `resourceActionResult` with explicit messages; restart progress/result sequence; cancelled restart does not throw |
 | Protocol | `argocdApplicationProtocol.test.ts` | `resourceAction` / progress / result shapes validate |
 | Accessibility helpers | `argocdGraphAccessibility.test.ts` | Accessible name format; focus order sort; overflow roving index; reduced-motion zoom duration |
@@ -146,6 +146,16 @@ Interface validation should include graph layout readability, selectable tiles, 
 | Provider stubs | `ArgoCDApplicationWebviewProvider.navigation.test.ts` | `navigateToResource` delegates to same reveal helper and namespace rules as `resource.navigateTree` |
 | Parity | `argocdGraphNodeCapabilities.test.ts` | Webview navigate kinds still match host `NAVIGATE_TREE_SUPPORTED_KINDS`; Application root overflow no longer exposes `viewInTree` (covered by #243; #242 must not regress registry kinds) |
 | Manual | Extension Development Host + Argo CD cluster | Open Application that manages Deployment `apisocial` in destination namespace ≠ Application CR namespace; tile **Navigate to resource in tree** selects that Deployment in the cluster tree (not "resource not found"); Job tile has no overflow; wrong-context cluster shows context-mismatch message |
+
+**Application View In Tree removal test matrix (M17 / issue #243):**
+
+| Area | Module / suite | Must prove |
+|------|----------------|------------|
+| Overflow registry | `argocdGraphNodeCapabilities.test.ts` | `getOverflowActions('application', …)` returns `[]`; no `viewInTree` messageType |
+| Protocol | `argocdApplicationProtocol.test.ts` | `viewInTree` is **not** an accepted webview→host message |
+| Host | `ArgoCDApplicationWebviewProvider.navigation.test.ts` | No `viewInTree` handler path; managed-resource / `navigateToResource` coverage unchanged |
+| Chrome | Component or manual | Sub-header has Hard Refresh only (no View In Tree); Details Overview has no View In Tree link; primary header still has Sync and Refresh |
+| Keyboard / no-selection | Manual | Empty or Application-only selection has no Application-reveal control; keyboard tree nav is managed-resource overflow (Context Menu / Shift+F10 → Navigate) plus Details drift links |
 
 **Operator topology test matrix (issue #241):**
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #243
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.