### PR TITLE
feat(argocd): operator resource-tree topology for #241

### DIFF
--- a/src/kubernetes/OperatorStatusTypes.ts
+++ b/src/kubernetes/OperatorStatusTypes.ts
@@ -174,6 +174,20 @@ export interface ArgoCDStatus {
      * @example "2025-11-20T15:30:00Z"
      */
     lastChecked: string;
+
+    /**
+     * Whether on-demand resource-tree enrichment is available via operator CLI.
+     * Omitted when Argo CD is not detected.
+     */
+    resourceTreeCapable?: boolean;
+
+    /**
+     * Bounded last global demotion reason when resourceTreeCapable is false.
+     */
+    resourceTreeLastError?: {
+        code: string;
+        message: string;
+    };
 }
 
 /**

--- a/src/services/ApplicationResourceGraphBuilder.ts
+++ b/src/services/ApplicationResourceGraphBuilder.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode';
 import type { ArgoCDApplication } from '../types/argocd';
-import type { ApplicationKey, ApplicationResourceGraph, TopologySource } from '../types/applicationResourceGraph';
+import type {
+    ApplicationKey,
+    ApplicationResourceGraph,
+    LimitedTopologyReason,
+    TopologySource
+} from '../types/applicationResourceGraph';
 import {
     buildCrdFlatApplicationResourceGraph,
     buildOwnerRefApplicationResourceGraph,
@@ -9,14 +14,35 @@ import {
 } from './ApplicationResourceGraphAssembler';
 import { fetchApplicationResourceTree } from './ArgoCDRestClient';
 import { ArgoCDRestAuthResolver } from './ArgoCDRestAuthResolver';
-import { fetchManagedResourceOwnerReferences } from './ManagedResourceOwnerRefReader';
 import type { ArgoCDService } from './ArgoCDService';
+import { fetchManagedResourceOwnerReferences } from './ManagedResourceOwnerRefReader';
+import { OperatorStatusClient } from './OperatorStatusClient';
+import { OperatorStatusMode } from '../kubernetes/OperatorStatusTypes';
+import type { ArgoCDResourceTreeResponse } from '../types/argocdResourceTree';
+import {
+    OperatorResourceTreeClient,
+    RESOURCE_TREE_ENRICHMENT_LOG_PREFIX
+} from './OperatorResourceTreeClient';
 
 export interface BuildApplicationResourceGraphInput {
     application: ArgoCDApplication;
     applicationKey: ApplicationKey;
     argoCDService: ArgoCDService;
     extensionContext: vscode.ExtensionContext;
+    options?: BuildApplicationResourceGraphOptions;
+}
+
+export interface OperatorResourceTreeMemo {
+    applicationKey: ApplicationKey;
+    fetchedAt: string;
+    resourceTree: ArgoCDResourceTreeResponse;
+}
+
+export interface BuildApplicationResourceGraphOptions {
+    cancellationToken?: vscode.CancellationToken;
+    bypassOperatorCache?: boolean;
+    operatorTreeMemo?: OperatorResourceTreeMemo | null;
+    onOperatorTreeMemoUpdate?: (memo: OperatorResourceTreeMemo) => void;
 }
 
 export interface BuildApplicationResourceGraphResult {
@@ -26,8 +52,36 @@ export interface BuildApplicationResourceGraphResult {
     skippedInvalidResourceRows: boolean;
 }
 
+export interface ApplicationResourceGraphBuilderDeps {
+    operatorStatusClient?: OperatorStatusClient;
+    operatorResourceTreeClient?: OperatorResourceTreeClient;
+}
+
 function getOutputChannel(): vscode.OutputChannel {
     return vscode.window.createOutputChannel('kube9 ArgoCD Service');
+}
+
+function applicationKeysEqual(a: ApplicationKey, b: ApplicationKey): boolean {
+    return a.context === b.context && a.namespace === b.namespace && a.name === b.name;
+}
+
+function withLimitedTopologyReason(
+    graph: ApplicationResourceGraph,
+    reason: LimitedTopologyReason
+): ApplicationResourceGraph {
+    if (graph.topologyMode === 'full') {
+        return graph;
+    }
+    return { ...graph, limitedTopologyReason: reason };
+}
+
+function logResourceTreeUnavailable(code: string | undefined, detail: string): void {
+    const channel = getOutputChannel();
+    if (code) {
+        channel.appendLine(`${RESOURCE_TREE_ENRICHMENT_LOG_PREFIX}: ${code} (${detail})`);
+        return;
+    }
+    channel.appendLine(`${RESOURCE_TREE_ENRICHMENT_LOG_PREFIX}: ${detail}`);
 }
 
 export function logAssemblyWarnings(prefix: string, warnings: string[]): void {
@@ -41,12 +95,61 @@ export function logAssemblyWarnings(prefix: string, warnings: string[]): void {
     }
 }
 
+async function resolveOperatorTopologyContext(
+    input: BuildApplicationResourceGraphInput,
+    operatorStatusClient: OperatorStatusClient
+): Promise<{
+    isOperatedMode: boolean;
+    argocdDetected: boolean;
+    resourceTreeCapable: boolean;
+}> {
+    const unavailable = {
+        isOperatedMode: false,
+        argocdDetected: false,
+        resourceTreeCapable: false
+    };
+
+    try {
+        const kubeconfigPath =
+            typeof input.argoCDService.getKubeconfigPath === 'function'
+                ? input.argoCDService.getKubeconfigPath()
+                : '';
+        if (kubeconfigPath.trim() === '') {
+            return unavailable;
+        }
+
+        const operatorStatus = await operatorStatusClient.getStatus(
+            kubeconfigPath,
+            input.applicationKey.context
+        );
+        const isOperatedMode =
+            operatorStatus.mode === OperatorStatusMode.Operated ||
+            operatorStatus.mode === OperatorStatusMode.Enabled;
+        const argocdStatus = operatorStatus.status?.argocd;
+        const argocdDetected = argocdStatus?.detected === true;
+        const resourceTreeCapable = argocdStatus?.resourceTreeCapable === true;
+
+        return { isOperatedMode, argocdDetected, resourceTreeCapable };
+    } catch {
+        return unavailable;
+    }
+}
+
 export async function buildApplicationResourceGraph(
-    input: BuildApplicationResourceGraphInput
+    input: BuildApplicationResourceGraphInput,
+    deps: ApplicationResourceGraphBuilderDeps = {}
 ): Promise<BuildApplicationResourceGraphResult> {
     const observedAt = new Date().toISOString();
     const authResolver = new ArgoCDRestAuthResolver(input.extensionContext, input.argoCDService);
     const auth = await authResolver.resolve(input.applicationKey.context);
+    const operatorStatusClient = deps.operatorStatusClient ?? new OperatorStatusClient();
+    const operatorResourceTreeClient =
+        deps.operatorResourceTreeClient ?? new OperatorResourceTreeClient();
+    const operatorTopology = await resolveOperatorTopologyContext(
+        input,
+        operatorStatusClient
+    );
+    const { isOperatedMode, argocdDetected, resourceTreeCapable } = operatorTopology;
 
     if (auth.available) {
         try {
@@ -74,15 +177,40 @@ export async function buildApplicationResourceGraph(
             };
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
-            getOutputChannel().appendLine(
-                `[INFO] Argo CD resource-tree enrichment unavailable; falling back to CRD-flat graph: ${message}`
-            );
+            logResourceTreeUnavailable(undefined, message);
         }
     } else if (auth.reason) {
         getOutputChannel().appendLine(
             `[INFO] Argo CD resource-tree enrichment skipped: ${auth.reason}`
         );
     }
+
+    if (isOperatedMode && argocdDetected && resourceTreeCapable) {
+        const operatorAttempt = await tryBuildOperatorResourceTreeApplicationResourceGraph(
+            input,
+            operatorResourceTreeClient,
+            observedAt
+        );
+        if (operatorAttempt) {
+            for (const warning of operatorAttempt.assemblyWarnings) {
+                getOutputChannel().appendLine(`[WARNING] resource-tree graph assembly: ${warning}`);
+            }
+
+            return {
+                graph: operatorAttempt.graph,
+                topologySource: 'argocd_resource_tree',
+                assemblyWarnings: operatorAttempt.assemblyWarnings,
+                skippedInvalidResourceRows: hasSkippedInvalidResourceRows(operatorAttempt.assemblyWarnings)
+            };
+        }
+    }
+
+    const limitedReasonBeforeFallback = resolveLimitedTopologyReasonBeforeFallback({
+        isOperatedMode,
+        argocdDetected,
+        resourceTreeCapable,
+        restAvailable: auth.available
+    });
 
     const ownerRefAttempt = await tryBuildOwnerRefApplicationResourceGraph(input, observedAt);
     if (ownerRefAttempt) {
@@ -91,7 +219,7 @@ export async function buildApplicationResourceGraph(
         }
 
         return {
-            graph: ownerRefAttempt.graph,
+            graph: withLimitedTopologyReason(ownerRefAttempt.graph, 'owner_ref'),
             topologySource: 'kubernetes_owner_ref',
             assemblyWarnings: ownerRefAttempt.assemblyWarnings,
             skippedInvalidResourceRows: hasSkippedInvalidResourceRows(ownerRefAttempt.assemblyWarnings)
@@ -107,11 +235,81 @@ export async function buildApplicationResourceGraph(
     logAssemblyWarnings('crd_flat graph assembly', assemblyWarnings);
 
     return {
-        graph,
+        graph: withLimitedTopologyReason(graph, limitedReasonBeforeFallback),
         topologySource: 'crd_flat',
         assemblyWarnings,
         skippedInvalidResourceRows: hasSkippedInvalidResourceRows(assemblyWarnings)
     };
+}
+
+function resolveLimitedTopologyReasonBeforeFallback(input: {
+    isOperatedMode: boolean;
+    argocdDetected: boolean;
+    resourceTreeCapable: boolean;
+    restAvailable: boolean;
+}): LimitedTopologyReason {
+    if (input.isOperatedMode && input.argocdDetected && !input.resourceTreeCapable) {
+        return 'operator_not_capable';
+    }
+    if (!input.isOperatedMode || !input.argocdDetected) {
+        return 'rest_unavailable';
+    }
+    return 'enrichment_failed';
+}
+
+async function tryBuildOperatorResourceTreeApplicationResourceGraph(
+    input: BuildApplicationResourceGraphInput,
+    operatorResourceTreeClient: OperatorResourceTreeClient,
+    observedAt: string
+): Promise<ReturnType<typeof buildResourceTreeApplicationResourceGraph> | null> {
+    const options = input.options;
+    const memo = options?.operatorTreeMemo;
+    if (
+        memo &&
+        !options?.bypassOperatorCache &&
+        applicationKeysEqual(memo.applicationKey, input.applicationKey)
+    ) {
+        return buildResourceTreeApplicationResourceGraph({
+            application: input.application,
+            applicationKey: input.applicationKey,
+            resourceTree: memo.resourceTree,
+            observedAt
+        });
+    }
+
+    try {
+        const result = await operatorResourceTreeClient.fetchResourceTree({
+            clusterContext: input.applicationKey.context,
+            applicationName: input.application.name,
+            applicationNamespace: input.application.namespace,
+            cancellationToken: options?.cancellationToken
+        });
+
+        if (!result.ok) {
+            logResourceTreeUnavailable(result.code, result.message);
+            return null;
+        }
+
+        options?.onOperatorTreeMemoUpdate?.({
+            applicationKey: input.applicationKey,
+            fetchedAt: new Date().toISOString(),
+            resourceTree: result.resourceTree
+        });
+
+        return buildResourceTreeApplicationResourceGraph({
+            application: input.application,
+            applicationKey: input.applicationKey,
+            resourceTree: result.resourceTree,
+            observedAt
+        });
+    } catch (error) {
+        if (error instanceof vscode.CancellationError) {
+            throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        logResourceTreeUnavailable(undefined, message);
+        return null;
+    }
 }
 
 async function tryBuildOwnerRefApplicationResourceGraph(

--- a/src/services/ArgoCDService.ts
+++ b/src/services/ArgoCDService.ts
@@ -200,6 +200,10 @@ export class ArgoCDService {
         private kubeconfigPath: string
     ) {}
 
+    getKubeconfigPath(): string {
+        return this.kubeconfigPath;
+    }
+
     /**
      * Checks if ArgoCD is installed in the specified cluster context.
      * 

--- a/src/services/OperatorResourceTreeClient.ts
+++ b/src/services/OperatorResourceTreeClient.ts
@@ -1,0 +1,285 @@
+import * as k8s from '@kubernetes/client-node';
+import * as vscode from 'vscode';
+import { Writable } from 'stream';
+import type { ArgoCDResourceTreeResponse } from '../types/argocdResourceTree';
+import { getKubernetesApiClient, type KubernetesApiClient } from '../kubernetes/apiClient';
+import { getOperatorNamespaceResolver } from './OperatorNamespaceResolver';
+
+export const OPERATOR_RESOURCE_TREE_DEFAULT_TIMEOUT_MS = 30_000;
+
+export const RESOURCE_TREE_ENRICHMENT_LOG_PREFIX =
+    '[INFO] Argo CD resource-tree enrichment unavailable';
+
+export interface OperatorResourceTreeFetchInput {
+    clusterContext: string;
+    applicationName: string;
+    applicationNamespace: string;
+    cancellationToken?: vscode.CancellationToken;
+    timeoutMs?: number;
+}
+
+export interface OperatorResourceTreeSuccess {
+    ok: true;
+    resourceTree: ArgoCDResourceTreeResponse;
+}
+
+export interface OperatorResourceTreeFailure {
+    ok: false;
+    code?: string;
+    message: string;
+}
+
+export type OperatorResourceTreeResult = OperatorResourceTreeSuccess | OperatorResourceTreeFailure;
+
+export interface OperatorExecResult {
+    stdout: string;
+    stderr: string;
+}
+
+export type OperatorExecFn = (
+    clusterContext: string,
+    commandArgs: string[],
+    options: {
+        cancellationToken?: vscode.CancellationToken;
+        timeoutMs?: number;
+    }
+) => Promise<OperatorExecResult>;
+
+let operatorExecFnOverride: OperatorExecFn | undefined;
+
+/** Test hook: override kubectl exec behavior for operator CLI calls. */
+export function setOperatorExecFnForTesting(fn: OperatorExecFn | undefined): void {
+    operatorExecFnOverride = fn;
+}
+
+export function buildResourceTreeQueryArgs(
+    applicationName: string,
+    applicationNamespace: string
+): string[] {
+    return [
+        'kube9-operator',
+        'query',
+        'argocd',
+        'resource-tree',
+        'get',
+        applicationName,
+        `--namespace=${applicationNamespace}`,
+        '--format=json'
+    ];
+}
+
+export function parseOperatorResourceTreeStdout(stdout: string): ArgoCDResourceTreeResponse | null {
+    const trimmed = stdout.trim();
+    if (trimmed === '') {
+        return null;
+    }
+
+    try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            return null;
+        }
+        return parsed as ArgoCDResourceTreeResponse;
+    } catch {
+        return null;
+    }
+}
+
+export function parseOperatorResourceTreeStderr(stderr: string): { code?: string; message: string } {
+    const trimmed = stderr.trim();
+    if (trimmed === '') {
+        return { message: 'Operator resource-tree query failed' };
+    }
+
+    try {
+        const envelope = JSON.parse(trimmed) as { ok?: boolean; code?: string; message?: string };
+        if (envelope.ok === false) {
+            return {
+                code: typeof envelope.code === 'string' ? envelope.code : undefined,
+                message:
+                    typeof envelope.message === 'string' && envelope.message.trim() !== ''
+                        ? envelope.message
+                        : envelope.code ?? 'Operator resource-tree query failed'
+            };
+        }
+    } catch {
+        // Fall through to raw stderr text.
+    }
+
+    return { message: trimmed };
+}
+
+function throwIfCancelled(token?: vscode.CancellationToken): void {
+    if (token?.isCancellationRequested) {
+        throw new vscode.CancellationError();
+    }
+}
+
+async function defaultOperatorExec(
+    clusterContext: string,
+    commandArgs: string[],
+    options: {
+        cancellationToken?: vscode.CancellationToken;
+        timeoutMs?: number;
+    }
+): Promise<OperatorExecResult> {
+    throwIfCancelled(options.cancellationToken);
+
+    const apiClient = getKubernetesApiClient();
+    apiClient.setContext(clusterContext);
+
+    const resolver = getOperatorNamespaceResolver();
+    const namespace = await resolver.resolveNamespace(clusterContext);
+    const podName = await getOperatorPodName(apiClient, namespace);
+
+    const exec = new k8s.Exec(apiClient.getKubeConfig());
+    const timeoutMs = options.timeoutMs ?? OPERATOR_RESOURCE_TREE_DEFAULT_TIMEOUT_MS;
+
+    return new Promise<OperatorExecResult>((resolve, reject) => {
+        let stdout = '';
+        let stderr = '';
+        let settled = false;
+
+        const finish = (error?: Error, result?: OperatorExecResult): void => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            clearTimeout(timeoutHandle);
+            options.cancellationToken?.onCancellationRequested(() => undefined);
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve(result ?? { stdout, stderr });
+        };
+
+        const timeoutHandle = setTimeout(() => {
+            finish(new Error('TIMEOUT'));
+        }, timeoutMs);
+
+        options.cancellationToken?.onCancellationRequested(() => {
+            finish(new vscode.CancellationError());
+        });
+
+        const stdoutStream = new Writable({
+            highWaterMark: 1024 * 1024,
+            write(chunk: Buffer, _encoding: string, callback: () => void) {
+                stdout += chunk.toString();
+                callback();
+            }
+        });
+
+        const stderrStream = new Writable({
+            highWaterMark: 1024 * 1024,
+            write(chunk: Buffer, _encoding: string, callback: () => void) {
+                stderr += chunk.toString();
+                callback();
+            }
+        });
+
+        exec.exec(
+            namespace,
+            podName,
+            'operator',
+            commandArgs,
+            stdoutStream,
+            stderrStream,
+            null,
+            false,
+            (status) => {
+                throwIfCancelled(options.cancellationToken);
+                if (status.status === 'Success') {
+                    finish(undefined, { stdout, stderr });
+                    return;
+                }
+                finish(new Error(stderr.trim() || status.message || 'Operator CLI failed'));
+            }
+        ).catch((error: Error) => {
+            finish(new Error(`Failed to execute operator CLI: ${error.message}`));
+        });
+    });
+}
+
+async function getOperatorPodName(
+    apiClient: KubernetesApiClient,
+    namespace: string
+): Promise<string> {
+    const pods = await apiClient.core.listNamespacedPod({ namespace });
+
+    const operatorPods = pods.items.filter((pod) => {
+        const labels = pod.metadata?.labels;
+        const hasLabel =
+            labels?.['app.kubernetes.io/name'] === 'kube9-operator' ||
+            labels?.['app'] === 'kube9-operator';
+        const isRunning = pod.status?.phase === 'Running';
+        const hasContainerReady = pod.status?.containerStatuses?.some(
+            (containerStatus) => containerStatus.name === 'operator' && containerStatus.ready === true
+        );
+        return hasLabel && isRunning && hasContainerReady;
+    });
+
+    if (operatorPods.length === 0) {
+        throw new Error(
+            `No running kube9-operator pod found in namespace '${namespace}'. Ensure the operator is deployed and running.`
+        );
+    }
+
+    const operatorPod = operatorPods[0];
+    if (!operatorPod.metadata?.name) {
+        throw new Error(`kube9-operator pod has no name in namespace '${namespace}'`);
+    }
+
+    return operatorPod.metadata.name;
+}
+
+export class OperatorResourceTreeClient {
+    async fetchResourceTree(
+        input: OperatorResourceTreeFetchInput
+    ): Promise<OperatorResourceTreeResult> {
+        throwIfCancelled(input.cancellationToken);
+
+        const commandArgs = buildResourceTreeQueryArgs(
+            input.applicationName,
+            input.applicationNamespace
+        );
+        const execFn = operatorExecFnOverride ?? defaultOperatorExec;
+
+        try {
+            const { stdout, stderr } = await execFn(input.clusterContext, commandArgs, {
+                cancellationToken: input.cancellationToken,
+                timeoutMs: input.timeoutMs ?? OPERATOR_RESOURCE_TREE_DEFAULT_TIMEOUT_MS
+            });
+
+            throwIfCancelled(input.cancellationToken);
+
+            const resourceTree = parseOperatorResourceTreeStdout(stdout);
+            if (!resourceTree) {
+                const parsedStderr = parseOperatorResourceTreeStderr(stderr);
+                return {
+                    ok: false,
+                    code: parsedStderr.code ?? 'INTERNAL_ERROR',
+                    message: parsedStderr.message
+                };
+            }
+
+            return { ok: true, resourceTree };
+        } catch (error) {
+            if (error instanceof vscode.CancellationError) {
+                throw error;
+            }
+
+            const message = error instanceof Error ? error.message : String(error);
+            if (message === 'TIMEOUT') {
+                return { ok: false, code: 'TIMEOUT', message: 'Resource-tree query timed out' };
+            }
+
+            const parsedStderr = parseOperatorResourceTreeStderr(message);
+            return {
+                ok: false,
+                code: parsedStderr.code ?? 'INTERNAL_ERROR',
+                message: parsedStderr.message
+            };
+        }
+    }
+}

--- a/src/test/suite/services/OperatorResourceTreeClient.test.ts
+++ b/src/test/suite/services/OperatorResourceTreeClient.test.ts
@@ -1,0 +1,118 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import {
+    OperatorResourceTreeClient,
+    buildResourceTreeQueryArgs,
+    parseOperatorResourceTreeStderr,
+    parseOperatorResourceTreeStdout,
+    setOperatorExecFnForTesting,
+    type OperatorExecFn
+} from '../../../services/OperatorResourceTreeClient';
+
+suite('OperatorResourceTreeClient', () => {
+    teardown(() => {
+        setOperatorExecFnForTesting(undefined);
+    });
+
+    test('buildResourceTreeQueryArgs matches kube9-operator#151 CLI shape', () => {
+        assert.deepStrictEqual(buildResourceTreeQueryArgs('guestbook', 'argocd'), [
+            'kube9-operator',
+            'query',
+            'argocd',
+            'resource-tree',
+            'get',
+            'guestbook',
+            '--namespace=argocd',
+            '--format=json'
+        ]);
+    });
+
+    test('parseOperatorResourceTreeStdout accepts raw Argo CD JSON', () => {
+        const parsed = parseOperatorResourceTreeStdout(
+            JSON.stringify({
+                nodes: [{ kind: 'Deployment', name: 'ui', namespace: 'guestbook' }]
+            })
+        );
+        assert.ok(parsed);
+        assert.strictEqual(parsed?.nodes?.length, 1);
+    });
+
+    test('parseOperatorResourceTreeStderr maps structured error envelope code', () => {
+        const parsed = parseOperatorResourceTreeStderr(
+            JSON.stringify({
+                ok: false,
+                code: 'APPLICATION_NOT_FOUND',
+                message: 'Application not found'
+            })
+        );
+        assert.strictEqual(parsed.code, 'APPLICATION_NOT_FOUND');
+        assert.strictEqual(parsed.message, 'Application not found');
+    });
+
+    test('fetchResourceTree returns parsed resource tree on success', async () => {
+        const execFn: OperatorExecFn = async () => ({
+            stdout: JSON.stringify({ nodes: [{ kind: 'Pod', name: 'ui-1', namespace: 'guestbook' }] }),
+            stderr: ''
+        });
+        setOperatorExecFnForTesting(execFn);
+
+        const client = new OperatorResourceTreeClient();
+        const result = await client.fetchResourceTree({
+            clusterContext: 'minikube',
+            applicationName: 'guestbook',
+            applicationNamespace: 'argocd'
+        });
+
+        assert.strictEqual(result.ok, true);
+        if (result.ok) {
+            assert.strictEqual(result.resourceTree.nodes?.length, 1);
+        }
+    });
+
+    test('fetchResourceTree maps structured stderr failure to result code', async () => {
+        const execFn: OperatorExecFn = async () => ({
+            stdout: '',
+            stderr: JSON.stringify({
+                ok: false,
+                code: 'APPLICATION_NOT_FOUND',
+                message: 'missing app'
+            })
+        });
+        setOperatorExecFnForTesting(execFn);
+
+        const client = new OperatorResourceTreeClient();
+        const result = await client.fetchResourceTree({
+            clusterContext: 'minikube',
+            applicationName: 'guestbook',
+            applicationNamespace: 'argocd'
+        });
+
+        assert.strictEqual(result.ok, false);
+        if (!result.ok) {
+            assert.strictEqual(result.code, 'APPLICATION_NOT_FOUND');
+        }
+    });
+
+    test('fetchResourceTree respects cancellation before exec', async () => {
+        let execCalled = false;
+        setOperatorExecFnForTesting(async () => {
+            execCalled = true;
+            return { stdout: '{}', stderr: '' };
+        });
+
+        const source = new vscode.CancellationTokenSource();
+        source.cancel();
+
+        const client = new OperatorResourceTreeClient();
+        await assert.rejects(
+            client.fetchResourceTree({
+                clusterContext: 'minikube',
+                applicationName: 'guestbook',
+                applicationNamespace: 'argocd',
+                cancellationToken: source.token
+            }),
+            vscode.CancellationError
+        );
+        assert.strictEqual(execCalled, false);
+    });
+});

--- a/src/test/suite/services/applicationResourceGraphBuilder.test.ts
+++ b/src/test/suite/services/applicationResourceGraphBuilder.test.ts
@@ -4,6 +4,12 @@ import type { ArgoCDApplication } from '../../../types/argocd';
 import { buildApplicationResourceGraph } from '../../../services/ApplicationResourceGraphBuilder';
 import { INVALID_RESOURCE_ROW_WARNING } from '../../../services/ApplicationResourceGraphAssembler';
 import type { ArgoCDService } from '../../../services/ArgoCDService';
+import { OperatorStatusMode } from '../../../kubernetes/OperatorStatusTypes';
+import type { OperatorStatusClient } from '../../../services/OperatorStatusClient';
+import {
+    OperatorResourceTreeClient,
+    setOperatorExecFnForTesting
+} from '../../../services/OperatorResourceTreeClient';
 
 const originalGetConfiguration = vscode.workspace.getConfiguration;
 
@@ -33,9 +39,54 @@ function sampleApplication(): ArgoCDApplication {
     };
 }
 
+function mockArgoCDService(): ArgoCDService {
+    return {
+        getKubeconfigPath: () => '/mock/kubeconfig'
+    } as ArgoCDService;
+}
+
+function mockOperatorStatusClient(input: {
+    mode: OperatorStatusMode;
+    argocd?: {
+        detected: boolean;
+        resourceTreeCapable?: boolean;
+    };
+}): OperatorStatusClient {
+    return {
+        getStatus: async () => ({
+            status:
+                input.argocd === undefined
+                    ? null
+                    : {
+                          mode: 'operated',
+                          version: '1.0.0',
+                          health: 'healthy',
+                          lastUpdate: new Date().toISOString(),
+                          error: null,
+                          collectionStats: {
+                              totalSuccessCount: 0,
+                              totalFailureCount: 0,
+                              collectionsStoredCount: 0,
+                              lastSuccessTime: null
+                          },
+                          argocd: {
+                              detected: input.argocd.detected,
+                              namespace: 'argocd',
+                              version: 'v2.8.0',
+                              lastChecked: new Date().toISOString(),
+                              resourceTreeCapable: input.argocd.resourceTreeCapable
+                          }
+                      },
+            timestamp: Date.now(),
+            mode: input.mode
+        })
+    } as unknown as OperatorStatusClient;
+}
+
 suite('ApplicationResourceGraphBuilder', () => {
     teardown(() => {
         vscode.workspace.getConfiguration = originalGetConfiguration;
+        setOperatorExecFnForTesting(undefined);
     });
 
     setup(() => {
@@ -53,16 +104,123 @@ suite('ApplicationResourceGraphBuilder', () => {
     });
 
     test('falls back to crd_flat when REST enrichment is disabled', async () => {
-        const result = await buildApplicationResourceGraph({
-            application: sampleApplication(),
-            applicationKey: { context: 'minikube', namespace: 'argocd', name: 'guestbook' },
-            argoCDService: {} as ArgoCDService,
-            extensionContext: { secrets: { get: async () => undefined } } as unknown as vscode.ExtensionContext
-        });
+        const result = await buildApplicationResourceGraph(
+            {
+                application: sampleApplication(),
+                applicationKey: { context: 'minikube', namespace: 'argocd', name: 'guestbook' },
+                argoCDService: mockArgoCDService(),
+                extensionContext: { secrets: { get: async () => undefined } } as unknown as vscode.ExtensionContext
+            },
+            {
+                operatorStatusClient: mockOperatorStatusClient({
+                    mode: OperatorStatusMode.Basic
+                })
+            }
+        );
 
         assert.strictEqual(result.topologySource, 'crd_flat');
         assert.strictEqual(result.graph.topologyMode, 'limited');
+        assert.strictEqual(result.graph.limitedTopologyReason, 'rest_unavailable');
         assert.strictEqual(result.graph.nodes.length, 2);
+    });
+
+    test('uses operator resource-tree when capable and REST is disabled', async () => {
+        setOperatorExecFnForTesting(async () => ({
+            stdout: JSON.stringify({
+                nodes: [
+                    {
+                        kind: 'Application',
+                        name: 'guestbook',
+                        namespace: 'argocd',
+                        group: 'argoproj.io'
+                    },
+                    {
+                        kind: 'Deployment',
+                        name: 'guestbook-ui',
+                        namespace: 'guestbook',
+                        parentRefs: [{ kind: 'Application', name: 'guestbook', namespace: 'argocd' }]
+                    }
+                ]
+            }),
+            stderr: ''
+        }));
+
+        const result = await buildApplicationResourceGraph(
+            {
+                application: sampleApplication(),
+                applicationKey: { context: 'minikube', namespace: 'argocd', name: 'guestbook' },
+                argoCDService: mockArgoCDService(),
+                extensionContext: { secrets: { get: async () => undefined } } as unknown as vscode.ExtensionContext
+            },
+            {
+                operatorStatusClient: mockOperatorStatusClient({
+                    mode: OperatorStatusMode.Operated,
+                    argocd: { detected: true, resourceTreeCapable: true }
+                }),
+                operatorResourceTreeClient: new OperatorResourceTreeClient()
+            }
+        );
+
+        assert.strictEqual(result.topologySource, 'argocd_resource_tree');
+        assert.strictEqual(result.graph.topologyMode, 'full');
+        assert.strictEqual(result.graph.limitedTopologyReason, undefined);
+    });
+
+    test('skips operator exec when resourceTreeCapable is false', async () => {
+        let execCalled = false;
+        setOperatorExecFnForTesting(async () => {
+            execCalled = true;
+            return { stdout: '{}', stderr: '' };
+        });
+
+        const result = await buildApplicationResourceGraph(
+            {
+                application: sampleApplication(),
+                applicationKey: { context: 'minikube', namespace: 'argocd', name: 'guestbook' },
+                argoCDService: mockArgoCDService(),
+                extensionContext: { secrets: { get: async () => undefined } } as unknown as vscode.ExtensionContext
+            },
+            {
+                operatorStatusClient: mockOperatorStatusClient({
+                    mode: OperatorStatusMode.Operated,
+                    argocd: { detected: true, resourceTreeCapable: false }
+                })
+            }
+        );
+
+        assert.strictEqual(execCalled, false);
+        assert.strictEqual(result.topologySource, 'crd_flat');
+        assert.strictEqual(result.graph.limitedTopologyReason, 'operator_not_capable');
+    });
+
+    test('falls back with enrichment_failed when operator CLI fails after capability true', async () => {
+        setOperatorExecFnForTesting(async () => ({
+            stdout: '',
+            stderr: JSON.stringify({
+                ok: false,
+                code: 'APPLICATION_NOT_FOUND',
+                message: 'missing app'
+            })
+        }));
+
+        const result = await buildApplicationResourceGraph(
+            {
+                application: sampleApplication(),
+                applicationKey: { context: 'minikube', namespace: 'argocd', name: 'guestbook' },
+                argoCDService: mockArgoCDService(),
+                extensionContext: { secrets: { get: async () => undefined } } as unknown as vscode.ExtensionContext
+            },
+            {
+                operatorStatusClient: mockOperatorStatusClient({
+                    mode: OperatorStatusMode.Operated,
+                    argocd: { detected: true, resourceTreeCapable: true }
+                }),
+                operatorResourceTreeClient: new OperatorResourceTreeClient()
+            }
+        );
+
+        assert.strictEqual(result.topologySource, 'crd_flat');
+        assert.strictEqual(result.graph.limitedTopologyReason, 'enrichment_failed');
     });
 
     test('logs crd_flat assembly warnings and flags skipped invalid rows', async () => {
@@ -70,29 +228,36 @@ suite('ApplicationResourceGraphBuilder', () => {
             _getContent(): string;
         };
 
-        const result = await buildApplicationResourceGraph({
-            application: {
-                ...sampleApplication(),
-                resources: [
-                    {
-                        kind: 'Deployment',
-                        name: 'guestbook-ui',
-                        namespace: 'guestbook',
-                        syncStatus: 'Synced',
-                        healthStatus: 'Healthy'
-                    },
-                    {
-                        kind: '',
-                        name: 'missing-kind',
-                        namespace: 'guestbook',
-                        syncStatus: 'Synced'
-                    }
-                ]
+        const result = await buildApplicationResourceGraph(
+            {
+                application: {
+                    ...sampleApplication(),
+                    resources: [
+                        {
+                            kind: 'Deployment',
+                            name: 'guestbook-ui',
+                            namespace: 'guestbook',
+                            syncStatus: 'Synced',
+                            healthStatus: 'Healthy'
+                        },
+                        {
+                            kind: '',
+                            name: 'missing-kind',
+                            namespace: 'guestbook',
+                            syncStatus: 'Synced'
+                        }
+                    ]
+                },
+                applicationKey: { context: 'minikube', namespace: 'argocd', name: 'guestbook' },
+                argoCDService: mockArgoCDService(),
+                extensionContext: { secrets: { get: async () => undefined } } as unknown as vscode.ExtensionContext
             },
-            applicationKey: { context: 'minikube', namespace: 'argocd', name: 'guestbook' },
-            argoCDService: {} as ArgoCDService,
-            extensionContext: { secrets: { get: async () => undefined } } as unknown as vscode.ExtensionContext
-        });
+            {
+                operatorStatusClient: mockOperatorStatusClient({
+                    mode: OperatorStatusMode.Basic
+                })
+            }
+        );
 
         assert.strictEqual(result.skippedInvalidResourceRows, true);
         assert.strictEqual(

--- a/src/test/suite/webview/ArgoCDApplicationWebviewProvider.graph.test.ts
+++ b/src/test/suite/webview/ArgoCDApplicationWebviewProvider.graph.test.ts
@@ -118,6 +118,7 @@ suite('ArgoCDApplicationWebviewProvider resource graph', () => {
         } as unknown as vscode.ExtensionContext;
 
         mockArgoCDService = {
+            getKubeconfigPath: () => '/mock/kubeconfig',
             getApplication: async () => {
                 getApplicationCalls += 1;
                 return currentApplication;

--- a/src/test/suite/webview/ArgoCDApplicationWebviewProvider.trackOperation.test.ts
+++ b/src/test/suite/webview/ArgoCDApplicationWebviewProvider.trackOperation.test.ts
@@ -146,6 +146,7 @@ suite('ArgoCDApplicationWebviewProvider trackOperation', () => {
         } as unknown as vscode.ExtensionContext;
 
         mockArgoCDService = {
+            getKubeconfigPath: () => '/mock/kubeconfig',
             getApplication: async () => {
                 getApplicationCallOrder.push('getApplication');
                 return currentApplication;

--- a/src/test/suite/webview/graphTopologyAffordances.test.ts
+++ b/src/test/suite/webview/graphTopologyAffordances.test.ts
@@ -6,9 +6,11 @@ import {
     type ResourceGraphNode
 } from '../../../types/applicationResourceGraph';
 import {
+    ENRICHMENT_FAILED_AFFORDANCE_MESSAGE,
     LARGE_APP_GROUPING_AFFORDANCE_MESSAGE,
-    LIMITED_TOPOLOGY_AFFORDANCE_MESSAGE,
+    OPERATOR_NOT_CAPABLE_AFFORDANCE_MESSAGE,
     OWNER_REF_TOPOLOGY_AFFORDANCE_MESSAGE,
+    REST_UNAVAILABLE_AFFORDANCE_MESSAGE,
     countManagedResourceNodes,
     getLimitedTopologyAffordanceMessage,
     hasVisibleManagedTopology,
@@ -129,13 +131,12 @@ suite('graph topology affordances', () => {
     });
 
     test('limited topology copy explains incomplete relationships', () => {
-        assert.match(LIMITED_TOPOLOGY_AFFORDANCE_MESSAGE, /parent\/child/i);
-        assert.match(LIMITED_TOPOLOGY_AFFORDANCE_MESSAGE, /resource-tree/i);
-        assert.doesNotMatch(LIMITED_TOPOLOGY_AFFORDANCE_MESSAGE, /fully equivalent/i);
+        assert.match(ENRICHMENT_FAILED_AFFORDANCE_MESSAGE, /parent\/child/i);
+        assert.match(ENRICHMENT_FAILED_AFFORDANCE_MESSAGE, /resource-tree enrichment was unavailable/i);
     });
 
     test('large-app grouping copy is distinct from limited topology copy', () => {
-        assert.notStrictEqual(LIMITED_TOPOLOGY_AFFORDANCE_MESSAGE, LARGE_APP_GROUPING_AFFORDANCE_MESSAGE);
+        assert.notStrictEqual(ENRICHMENT_FAILED_AFFORDANCE_MESSAGE, LARGE_APP_GROUPING_AFFORDANCE_MESSAGE);
         assert.match(LARGE_APP_GROUPING_AFFORDANCE_MESSAGE, /grouped by kind/i);
         assert.match(LARGE_APP_GROUPING_AFFORDANCE_MESSAGE, /Details tab/i);
     });
@@ -143,11 +144,37 @@ suite('graph topology affordances', () => {
     test('owner-ref topology uses inferred relationship copy', () => {
         const graph = {
             ...limitedGraphWithManagedResources(),
-            topologySource: 'kubernetes_owner_ref' as const
+            topologySource: 'kubernetes_owner_ref' as const,
+            limitedTopologyReason: 'owner_ref' as const
         };
         assert.strictEqual(getLimitedTopologyAffordanceMessage(graph), OWNER_REF_TOPOLOGY_AFFORDANCE_MESSAGE);
         assert.match(OWNER_REF_TOPOLOGY_AFFORDANCE_MESSAGE, /owner references/i);
         assert.match(OWNER_REF_TOPOLOGY_AFFORDANCE_MESSAGE, /inferred/i);
+    });
+
+    test('limitedTopologyReason selects exact affordance copy tiers', () => {
+        const base = limitedGraphWithManagedResources();
+        assert.strictEqual(
+            getLimitedTopologyAffordanceMessage({
+                ...base,
+                limitedTopologyReason: 'operator_not_capable'
+            }),
+            OPERATOR_NOT_CAPABLE_AFFORDANCE_MESSAGE
+        );
+        assert.strictEqual(
+            getLimitedTopologyAffordanceMessage({
+                ...base,
+                limitedTopologyReason: 'rest_unavailable'
+            }),
+            REST_UNAVAILABLE_AFFORDANCE_MESSAGE
+        );
+        assert.strictEqual(
+            getLimitedTopologyAffordanceMessage({
+                ...base,
+                limitedTopologyReason: 'enrichment_failed'
+            }),
+            ENRICHMENT_FAILED_AFFORDANCE_MESSAGE
+        );
     });
 
     test('shows assembly info banner only when invalid rows were skipped', () => {

--- a/src/types/applicationResourceGraph.ts
+++ b/src/types/applicationResourceGraph.ts
@@ -30,6 +30,12 @@ export type TopologySource =
 
 export type TopologyMode = 'full' | 'limited';
 
+export type LimitedTopologyReason =
+    | 'operator_not_capable'
+    | 'rest_unavailable'
+    | 'enrichment_failed'
+    | 'owner_ref';
+
 export type EdgeRelationship = 'manages' | 'owns' | 'depends_on';
 
 export type ResourceGraphNodeRole = 'application' | 'managed_resource';
@@ -62,6 +68,7 @@ export interface ApplicationResourceGraph {
     edges: ResourceGraphEdge[];
     topologySource: TopologySource;
     topologyMode: TopologyMode;
+    limitedTopologyReason?: LimitedTopologyReason;
     structureVersion: string;
     observedAt: string;
     layoutHint?: {

--- a/src/webview/ArgoCDApplicationWebviewProvider.ts
+++ b/src/webview/ArgoCDApplicationWebviewProvider.ts
@@ -3,7 +3,7 @@ import { ArgoCDService } from '../services/ArgoCDService';
 import { ClusterTreeProvider } from '../tree/ClusterTreeProvider';
 import { ArgoCDNotFoundError, ArgoCDPermissionError } from '../types/argocd';
 import type { ApplicationKey, ApplicationResourceGraph, TopologySource } from '../types/applicationResourceGraph';
-import { buildApplicationResourceGraph, logAssemblyWarnings } from '../services/ApplicationResourceGraphBuilder';
+import { buildApplicationResourceGraph, logAssemblyWarnings, type OperatorResourceTreeMemo } from '../services/ApplicationResourceGraphBuilder';
 import {
     buildCrdFlatApplicationResourceGraph,
     hasSkippedInvalidResourceRows
@@ -48,6 +48,10 @@ interface PanelInfo {
     lastGraph?: ApplicationResourceGraph;
     /** Cancels in-flight operation polling for this panel */
     operationCancellation?: vscode.CancellationTokenSource;
+    /** Cancels in-flight operator resource-tree fetch for this panel */
+    graphFetchCancellation?: vscode.CancellationTokenSource;
+    /** Optional memo for operator resource-tree payloads for this panel session */
+    operatorTreeMemo?: OperatorResourceTreeMemo;
     /** True while sync or refresh polling is active */
     operationInProgress?: boolean;
 }
@@ -168,6 +172,11 @@ export class ArgoCDApplicationWebviewProvider {
         panel.onDidDispose(
             () => {
                 ArgoCDApplicationWebviewProvider.cancelPanelOperation(panelKey);
+                ArgoCDApplicationWebviewProvider.cancelGraphFetch(panelKey);
+                const disposedPanelInfo = ArgoCDApplicationWebviewProvider.openPanels.get(panelKey);
+                if (disposedPanelInfo) {
+                    disposedPanelInfo.operatorTreeMemo = undefined;
+                }
                 ArgoCDApplicationWebviewProvider.openPanels.delete(panelKey);
             },
             null,
@@ -248,7 +257,7 @@ export class ArgoCDApplicationWebviewProvider {
             namespace,
             context,
             panel,
-            { application: resolvedApplication }
+            { application: resolvedApplication, invalidateOperatorTreeMemo: true }
         );
     }
 
@@ -372,6 +381,33 @@ export class ArgoCDApplicationWebviewProvider {
         }
         if (panelInfo) {
             panelInfo.operationInProgress = false;
+        }
+    }
+
+    private static cancelGraphFetch(panelKey: string): void {
+        const panelInfo = ArgoCDApplicationWebviewProvider.openPanels.get(panelKey);
+        if (panelInfo?.graphFetchCancellation) {
+            panelInfo.graphFetchCancellation.cancel();
+            panelInfo.graphFetchCancellation.dispose();
+            panelInfo.graphFetchCancellation = undefined;
+        }
+    }
+
+    private static beginGraphFetch(panelKey: string): vscode.CancellationToken {
+        ArgoCDApplicationWebviewProvider.cancelGraphFetch(panelKey);
+        const source = new vscode.CancellationTokenSource();
+        const panelInfo = ArgoCDApplicationWebviewProvider.openPanels.get(panelKey);
+        if (panelInfo) {
+            panelInfo.graphFetchCancellation = source;
+        }
+        return source.token;
+    }
+
+    private static endGraphFetch(panelKey: string): void {
+        const panelInfo = ArgoCDApplicationWebviewProvider.openPanels.get(panelKey);
+        if (panelInfo?.graphFetchCancellation) {
+            panelInfo.graphFetchCancellation.dispose();
+            panelInfo.graphFetchCancellation = undefined;
         }
     }
 
@@ -572,15 +608,28 @@ export class ArgoCDApplicationWebviewProvider {
         namespace: string,
         context: string,
         panel: vscode.WebviewPanel,
-        options?: { bypassCache?: boolean; application?: Awaited<ReturnType<ArgoCDService['getApplication']>> }
+        options?: {
+            bypassCache?: boolean;
+            application?: Awaited<ReturnType<ArgoCDService['getApplication']>>;
+            invalidateOperatorTreeMemo?: boolean;
+        }
     ): Promise<void> {
         const panelKey = ArgoCDApplicationWebviewProvider.panelKey(context, namespace, applicationName);
         const panelInfo = ArgoCDApplicationWebviewProvider.openPanels.get(panelKey);
         const extensionContext = panelInfo?.extensionContext;
 
+        if (options?.invalidateOperatorTreeMemo && panelInfo) {
+            panelInfo.operatorTreeMemo = undefined;
+        }
+
+        const graphFetchToken = ArgoCDApplicationWebviewProvider.beginGraphFetch(panelKey);
+
         try {
             if (options?.bypassCache) {
                 argoCDService.invalidateCache(context);
+                if (panelInfo) {
+                    panelInfo.operatorTreeMemo = undefined;
+                }
             }
 
             const application =
@@ -598,12 +647,24 @@ export class ArgoCDApplicationWebviewProvider {
             let skippedInvalidResourceRows = false;
 
             if (extensionContext) {
-                const built = await buildApplicationResourceGraph({
-                    application,
-                    applicationKey,
-                    argoCDService,
-                    extensionContext
-                });
+                const built = await buildApplicationResourceGraph(
+                    {
+                        application,
+                        applicationKey,
+                        argoCDService,
+                        extensionContext,
+                        options: {
+                            cancellationToken: graphFetchToken,
+                            bypassOperatorCache: options?.bypassCache === true,
+                            operatorTreeMemo: panelInfo?.operatorTreeMemo ?? null,
+                            onOperatorTreeMemoUpdate: (memo) => {
+                                if (panelInfo) {
+                                    panelInfo.operatorTreeMemo = memo;
+                                }
+                            }
+                        }
+                    }
+                );
                 incoming = built.graph;
                 topologySource = built.topologySource;
                 skippedInvalidResourceRows = built.skippedInvalidResourceRows;
@@ -631,6 +692,10 @@ export class ArgoCDApplicationWebviewProvider {
                 skippedInvalidResourceRows
             });
         } catch (error) {
+            if (error instanceof vscode.CancellationError) {
+                return;
+            }
+
             const userFriendlyMessage = ArgoCDApplicationWebviewProvider.formatGraphRebuildErrorMessage(
                 error,
                 applicationName,
@@ -654,6 +719,8 @@ export class ArgoCDApplicationWebviewProvider {
                 type: 'graphError',
                 message: userFriendlyMessage
             } satisfies ExtensionToWebviewMessage);
+        } finally {
+            ArgoCDApplicationWebviewProvider.endGraphFetch(panelKey);
         }
     }
 

--- a/src/webview/argocd-application/graph/graphTopologyAffordanceRules.ts
+++ b/src/webview/argocd-application/graph/graphTopologyAffordanceRules.ts
@@ -1,14 +1,33 @@
-import type { ApplicationResourceGraph } from '../../../types/applicationResourceGraph';
+import type {
+    ApplicationResourceGraph,
+    LimitedTopologyReason
+} from '../../../types/applicationResourceGraph';
 import { isKindGroupingActive } from './applyKindGrouping';
 
-export const LIMITED_TOPOLOGY_AFFORDANCE_MESSAGE =
-    'Limited topology: this graph may not show every parent/child relationship. Enable full resource-tree data when available for native Argo CD-style topology.';
+export const OPERATOR_NOT_CAPABLE_AFFORDANCE_MESSAGE =
+    'Limited topology: kube9-operator cannot fetch Argo CD resource-tree yet. Ask a platform admin to configure the operator Argo CD API token. Optionally enable kube9.argocd.restEnabled and set an extension API token for full topology.';
+
+export const REST_UNAVAILABLE_AFFORDANCE_MESSAGE =
+    'Limited topology: Argo CD resource-tree enrichment is not configured. Enable kube9.argocd.restEnabled and set an Argo CD API token, or use an operated cluster with resource-tree capability.';
+
+export const ENRICHMENT_FAILED_AFFORDANCE_MESSAGE =
+    'Limited topology: this graph may not show every parent/child relationship. Full resource-tree enrichment was unavailable for this application.';
 
 export const OWNER_REF_TOPOLOGY_AFFORDANCE_MESSAGE =
     'Inferred topology: parent/child links come from Kubernetes owner references, not Argo CD resource-tree. Some relationships may be missing when reads fail or owners are outside this application.';
 
+/** @deprecated Use reason-specific affordance messages from limitedTopologyReason. */
+export const LIMITED_TOPOLOGY_AFFORDANCE_MESSAGE = ENRICHMENT_FAILED_AFFORDANCE_MESSAGE;
+
 export const LARGE_APP_GROUPING_AFFORDANCE_MESSAGE =
     'Large application: resources are grouped by kind. Expand a group or open the Details tab to reach every managed resource.';
+
+const LIMITED_TOPOLOGY_MESSAGES: Record<LimitedTopologyReason, string> = {
+    operator_not_capable: OPERATOR_NOT_CAPABLE_AFFORDANCE_MESSAGE,
+    rest_unavailable: REST_UNAVAILABLE_AFFORDANCE_MESSAGE,
+    enrichment_failed: ENRICHMENT_FAILED_AFFORDANCE_MESSAGE,
+    owner_ref: OWNER_REF_TOPOLOGY_AFFORDANCE_MESSAGE
+};
 
 export function countManagedResourceNodes(graph: ApplicationResourceGraph): number {
     return graph.nodes.filter((node) => node.role === 'managed_resource').length;
@@ -28,8 +47,11 @@ export function shouldShowLargeAppGroupingAffordance(graph: ApplicationResourceG
 }
 
 export function getLimitedTopologyAffordanceMessage(graph: ApplicationResourceGraph): string {
+    if (graph.limitedTopologyReason) {
+        return LIMITED_TOPOLOGY_MESSAGES[graph.limitedTopologyReason];
+    }
     if (graph.topologySource === 'kubernetes_owner_ref') {
         return OWNER_REF_TOPOLOGY_AFFORDANCE_MESSAGE;
     }
-    return LIMITED_TOPOLOGY_AFFORDANCE_MESSAGE;
+    return ENRICHMENT_FAILED_AFFORDANCE_MESSAGE;
 }


### PR DESCRIPTION
## Summary
- Add `OperatorResourceTreeClient` to fetch raw Argo CD resource-tree JSON via `kubectl exec` into the kube9-operator CLI (#151 contract, mocked in tests).
- Extend `ApplicationResourceGraphBuilder` operated ladder: REST (when authorized) → operator (when `resourceTreeCapable`) → owner-ref → CRD-flat, with `limitedTopologyReason` on limited graphs.
- Wire four exact limited-topology banner tiers, panel graph-fetch cancellation/memo, and unit coverage for client, builder precedence, and affordances.

Fixes #241

## Test plan
- [x] `npm run lint`
- [x] `npm run test:unit` (1326 passing)
- [x] `npm run compile`
- [ ] Optional manual: operated cluster with `resourceTreeCapable: true` and `kube9.argocd.restEnabled: false` after kube9-operator#151 ships