### PR TITLE
fix(argocd): resolve reveal namespace and refresh-before-reveal (#242)

### DIFF
--- a/src/services/KindCapabilityRegistry.ts
+++ b/src/services/KindCapabilityRegistry.ts
@@ -35,6 +35,8 @@ export interface ResourceActionContext {
     treeProvider: ClusterTreeProvider;
     panel: vscode.WebviewPanel;
     kubeconfigPath: string;
+    /** Application spec.destination.namespace for managed-resource reveal fallback. */
+    destinationNamespace?: string;
 }
 
 export type ResourceActionHandler = (
@@ -304,7 +306,8 @@ async function handleResourceNavigateTree(
         { treeProvider: ctx.treeProvider, panelContext: ctx.context },
         kind,
         name,
-        namespace
+        namespace,
+        { destinationNamespace: ctx.destinationNamespace }
     );
 
     if (result.success) {

--- a/src/services/treeRevealHelper.ts
+++ b/src/services/treeRevealHelper.ts
@@ -19,18 +19,43 @@ export interface TreeRevealContext {
     panelContext: string;
 }
 
+export interface ManagedResourceRevealOptions {
+    /** Application spec.destination.namespace for empty resource-namespace fallback. */
+    destinationNamespace?: string;
+}
+
+/**
+ * Resolve the namespace used for cluster-tree reveal from a managed resource key.
+ * Never substitutes Application CR namespace; non-empty resource namespace wins.
+ */
+export function resolveManagedResourceRevealNamespace(
+    resourceNamespace: string,
+    destinationNamespace?: string
+): string {
+    const trimmedResource = resourceNamespace.trim();
+    if (trimmedResource.length > 0) {
+        return trimmedResource;
+    }
+
+    return (destinationNamespace ?? '').trim();
+}
+
 export async function focusAndRefreshClusterTree(treeProvider: ClusterTreeProvider): Promise<void> {
     await vscode.commands.executeCommand('kube9ClusterView.focus');
-    treeProvider.refresh();
+    treeProvider.invalidateCachesBeforeTreeReveal();
 }
 
 export async function revealManagedResourceInTree(
     ctx: TreeRevealContext,
     kind: string,
     name: string,
-    namespace: string
+    resourceNamespace: string,
+    options: ManagedResourceRevealOptions = {}
 ): Promise<ManagedResourceRevealResult> {
-    const trimmedNamespace = namespace.trim();
+    const resolvedNamespace = resolveManagedResourceRevealNamespace(
+        resourceNamespace,
+        options.destinationNamespace
+    );
 
     if (!ctx.treeProvider.getKubeconfigPath()) {
         return {
@@ -51,7 +76,7 @@ export async function revealManagedResourceInTree(
 
     try {
         await focusAndRefreshClusterTree(ctx.treeProvider);
-        const revealed = await ctx.treeProvider.revealTreeResource(kind, name, trimmedNamespace);
+        const revealed = await ctx.treeProvider.revealTreeResource(kind, name, resolvedNamespace);
         if (revealed) {
             return {
                 success: true,

--- a/src/test/suite/services/kindCapabilityRegistry.test.ts
+++ b/src/test/suite/services/kindCapabilityRegistry.test.ts
@@ -108,6 +108,9 @@ suite('KindCapabilityRegistry', () => {
             refresh: () => {
                 /**/
             },
+            invalidateCachesBeforeTreeReveal: () => {
+                /**/
+            },
             isCurrentContext: async () => true,
             revealTreeResource: async () => true
         } as unknown as ClusterTreeProvider;
@@ -379,6 +382,42 @@ suite('KindCapabilityRegistry', () => {
         assert.ok(result);
         assert.strictEqual(result.success, false);
         assert.match(result.message, /tree view is unavailable/i);
+        panel.dispose();
+    });
+
+    test('resource.navigateTree resolves destination namespace when resource namespace is empty', async () => {
+        const dispatch = loadDispatch();
+        const panel = vscode.window.createWebviewPanel(
+            'kube9.argocdApplication',
+            'test',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+        const messages = capturePostMessages(panel);
+        const ctx = buildContext(panel);
+        ctx.destinationNamespace = 'apisocial-ns';
+        let revealNamespace = '';
+        (ctx.treeProvider as unknown as {
+            revealTreeResource: (kind: string, name: string, namespace: string) => Promise<boolean>;
+        }).revealTreeResource = async (_kind, _name, namespace) => {
+            revealNamespace = namespace;
+            return true;
+        };
+
+        await dispatch(
+            ctx,
+            resourceActionMessage({
+                actionId: ACTION_RESOURCE_NAVIGATE_TREE,
+                kind: 'Deployment',
+                name: 'apisocial',
+                namespace: ''
+            })
+        );
+
+        const result = lastResult(messages);
+        assert.ok(result);
+        assert.strictEqual(result.success, true);
+        assert.strictEqual(revealNamespace, 'apisocial-ns');
         panel.dispose();
     });
 });

--- a/src/test/suite/services/kindCapabilityRegistry.test.ts
+++ b/src/test/suite/services/kindCapabilityRegistry.test.ts
@@ -124,6 +124,7 @@ suite('KindCapabilityRegistry', () => {
     }
 
     function loadDispatch() {
+        delete require.cache[require.resolve('../../../services/treeRevealHelper')];
         delete require.cache[require.resolve('../../../services/KindCapabilityRegistry')];
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         return require('../../../services/KindCapabilityRegistry')

--- a/src/test/suite/services/kindCapabilityRegistry.test.ts
+++ b/src/test/suite/services/kindCapabilityRegistry.test.ts
@@ -60,6 +60,9 @@ suite('KindCapabilityRegistry', () => {
         applyCalls = 0;
         watchCalls = 0;
 
+        delete require.cache[require.resolve('../../../services/treeRevealHelper')];
+        delete require.cache[require.resolve('../../../services/KindCapabilityRegistry')];
+
         (vscode.commands as unknown as { _registerCommand: (id: string, fn: () => Promise<void>) => void })
             ._registerCommand('kube9.treeView.focus', async () => {
                 /**/
@@ -98,6 +101,7 @@ suite('KindCapabilityRegistry', () => {
 
     teardown(() => {
         Module.prototype.require = originalRequire;
+        delete require.cache[require.resolve('../../../services/treeRevealHelper')];
         delete require.cache[require.resolve('../../../services/KindCapabilityRegistry')];
         (vscode.window as unknown as { _clearMessages(): void })._clearMessages();
     });
@@ -383,42 +387,6 @@ suite('KindCapabilityRegistry', () => {
         assert.ok(result);
         assert.strictEqual(result.success, false);
         assert.match(result.message, /tree view is unavailable/i);
-        panel.dispose();
-    });
-
-    test('resource.navigateTree resolves destination namespace when resource namespace is empty', async () => {
-        const dispatch = loadDispatch();
-        const panel = vscode.window.createWebviewPanel(
-            'kube9.argocdApplication',
-            'test',
-            vscode.ViewColumn.One,
-            { enableScripts: true }
-        );
-        const messages = capturePostMessages(panel);
-        const ctx = buildContext(panel);
-        ctx.destinationNamespace = 'apisocial-ns';
-        let revealNamespace = '';
-        (ctx.treeProvider as unknown as {
-            revealTreeResource: (kind: string, name: string, namespace: string) => Promise<boolean>;
-        }).revealTreeResource = async (_kind, _name, namespace) => {
-            revealNamespace = namespace;
-            return true;
-        };
-
-        await dispatch(
-            ctx,
-            resourceActionMessage({
-                actionId: ACTION_RESOURCE_NAVIGATE_TREE,
-                kind: 'Deployment',
-                name: 'apisocial',
-                namespace: ''
-            })
-        );
-
-        const result = lastResult(messages);
-        assert.ok(result);
-        assert.strictEqual(result.success, true);
-        assert.strictEqual(revealNamespace, 'apisocial-ns');
         panel.dispose();
     });
 });

--- a/src/test/suite/services/treeRevealHelper.test.ts
+++ b/src/test/suite/services/treeRevealHelper.test.ts
@@ -1,0 +1,119 @@
+import * as assert from 'assert';
+import * as vscode from '../../mocks/vscode';
+import { ClusterTreeProvider } from '../../../tree/ClusterTreeProvider';
+import {
+    focusAndRefreshClusterTree,
+    resolveManagedResourceRevealNamespace,
+    revealManagedResourceInTree
+} from '../../../services/treeRevealHelper';
+
+suite('treeRevealHelper', () => {
+    let focusCommandCalls = 0;
+    let invalidateCalls = 0;
+    let revealNamespace = '';
+
+    setup(() => {
+        focusCommandCalls = 0;
+        invalidateCalls = 0;
+        revealNamespace = '';
+
+        (vscode.commands as unknown as { _registerCommand: (id: string, fn: () => Promise<void>) => void })
+            ._registerCommand('kube9ClusterView.focus', async () => {
+                focusCommandCalls += 1;
+            });
+    });
+
+    suite('resolveManagedResourceRevealNamespace', () => {
+        test('uses non-empty resource namespace and ignores destination', () => {
+            assert.strictEqual(
+                resolveManagedResourceRevealNamespace('apisocial-ns', 'argocd'),
+                'apisocial-ns'
+            );
+        });
+
+        test('falls back to destination when resource namespace is empty', () => {
+            assert.strictEqual(
+                resolveManagedResourceRevealNamespace('', 'apisocial-ns'),
+                'apisocial-ns'
+            );
+        });
+
+        test('trims whitespace from resource and destination namespaces', () => {
+            assert.strictEqual(
+                resolveManagedResourceRevealNamespace('  apisocial-ns  ', 'ignored'),
+                'apisocial-ns'
+            );
+            assert.strictEqual(
+                resolveManagedResourceRevealNamespace('   ', '  apisocial-ns  '),
+                'apisocial-ns'
+            );
+        });
+
+        test('returns empty when both resource and destination namespaces are empty', () => {
+            assert.strictEqual(resolveManagedResourceRevealNamespace('', ''), '');
+            assert.strictEqual(resolveManagedResourceRevealNamespace('  ', undefined), '');
+        });
+    });
+
+    suite('focusAndRefreshClusterTree', () => {
+        test('focuses cluster view and invalidates navigate caches', async () => {
+            const treeProvider = {
+                invalidateCachesBeforeTreeReveal: () => {
+                    invalidateCalls += 1;
+                }
+            } as unknown as ClusterTreeProvider;
+
+            await focusAndRefreshClusterTree(treeProvider);
+
+            assert.strictEqual(focusCommandCalls, 1);
+            assert.strictEqual(invalidateCalls, 1);
+        });
+    });
+
+    suite('revealManagedResourceInTree', () => {
+        function buildTreeProvider(overrides: Partial<ClusterTreeProvider> = {}): ClusterTreeProvider {
+            return {
+                getKubeconfigPath: () => '/mock/kubeconfig',
+                isCurrentContext: async () => true,
+                invalidateCachesBeforeTreeReveal: () => {
+                    invalidateCalls += 1;
+                },
+                revealTreeResource: async (_kind: string, _name: string, namespace: string) => {
+                    revealNamespace = namespace;
+                    return true;
+                },
+                ...overrides
+            } as unknown as ClusterTreeProvider;
+        }
+
+        test('reveals with resolved resource namespace, not Application CR namespace', async () => {
+            const treeProvider = buildTreeProvider();
+            const result = await revealManagedResourceInTree(
+                { treeProvider, panelContext: 'minikube' },
+                'Deployment',
+                'apisocial',
+                'apisocial-ns',
+                { destinationNamespace: 'argocd' }
+            );
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(revealNamespace, 'apisocial-ns');
+            assert.strictEqual(invalidateCalls, 1);
+            assert.strictEqual(focusCommandCalls, 1);
+        });
+
+        test('falls back to destination namespace when resource namespace is empty', async () => {
+            const treeProvider = buildTreeProvider();
+            const result = await revealManagedResourceInTree(
+                { treeProvider, panelContext: 'minikube' },
+                'Deployment',
+                'apisocial',
+                '',
+                { destinationNamespace: 'apisocial-ns' }
+            );
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(revealNamespace, 'apisocial-ns');
+        });
+    });
+});

--- a/src/test/suite/webview/ArgoCDApplicationWebviewProvider.navigation.test.ts
+++ b/src/test/suite/webview/ArgoCDApplicationWebviewProvider.navigation.test.ts
@@ -208,6 +208,9 @@ suite('ArgoCDApplicationWebviewProvider navigation', () => {
             refresh: () => {
                 /**/
             },
+            invalidateCachesBeforeTreeReveal: () => {
+                /**/
+            },
             isCurrentContext: async () => false,
             getKubeconfigPath: () => '/mock/kubeconfig',
             revealTreeApplication: async () => {
@@ -233,6 +236,9 @@ suite('ArgoCDApplicationWebviewProvider navigation', () => {
     test('viewInTree shows warning when application is not found', async () => {
         mockTreeProvider = {
             refresh: () => {
+                /**/
+            },
+            invalidateCachesBeforeTreeReveal: () => {
                 /**/
             },
             isCurrentContext: async () => true,

--- a/src/test/suite/webview/ArgoCDApplicationWebviewProvider.navigation.test.ts
+++ b/src/test/suite/webview/ArgoCDApplicationWebviewProvider.navigation.test.ts
@@ -61,6 +61,27 @@ function sampleApplication(): ArgoCDApplication {
     };
 }
 
+function apisocialApplication(): ArgoCDApplication {
+    return {
+        ...sampleApplication(),
+        name: 'apisocial-app',
+        namespace: 'argocd',
+        destination: {
+            server: 'https://kubernetes.default.svc',
+            namespace: 'apisocial-ns'
+        },
+        resources: [
+            {
+                kind: 'Deployment',
+                name: 'apisocial',
+                namespace: 'apisocial-ns',
+                syncStatus: 'Synced',
+                healthStatus: 'Healthy'
+            }
+        ]
+    };
+}
+
 function getWebviewPanels(): vscode.WebviewPanel[] {
     return (vscode.window as unknown as { _getWebviewPanels(): vscode.WebviewPanel[] })._getWebviewPanels();
 }
@@ -90,11 +111,15 @@ suite('ArgoCDApplicationWebviewProvider navigation', () => {
     let revealTreeApplicationCalls = 0;
     let revealTreeResourceCalls = 0;
     let focusCommandCalls = 0;
+    let invalidateNavigateCacheCalls = 0;
+    let lastRevealNamespace = '';
 
     setup(() => {
         revealTreeApplicationCalls = 0;
         revealTreeResourceCalls = 0;
         focusCommandCalls = 0;
+        invalidateNavigateCacheCalls = 0;
+        lastRevealNamespace = '';
 
         (vscode.commands as unknown as { _registerCommand: (id: string, fn: () => Promise<void>) => void })
             ._registerCommand('kube9ClusterView.focus', async () => {
@@ -124,14 +149,18 @@ suite('ArgoCDApplicationWebviewProvider navigation', () => {
             refresh: () => {
                 /**/
             },
+            invalidateCachesBeforeTreeReveal: () => {
+                invalidateNavigateCacheCalls += 1;
+            },
             isCurrentContext: async () => true,
             getKubeconfigPath: () => '/mock/kubeconfig',
             revealTreeApplication: async () => {
                 revealTreeApplicationCalls += 1;
                 return true;
             },
-            revealTreeResource: async () => {
+            revealTreeResource: async (_kind: string, _name: string, namespace: string) => {
                 revealTreeResourceCalls += 1;
+                lastRevealNamespace = namespace;
                 return true;
             }
         } as unknown as ClusterTreeProvider;
@@ -237,8 +266,91 @@ suite('ArgoCDApplicationWebviewProvider navigation', () => {
 
         assert.strictEqual(revealTreeResourceCalls, 1);
         assert.strictEqual(focusCommandCalls, 1);
+        assert.strictEqual(invalidateNavigateCacheCalls, 1);
+        assert.strictEqual(lastRevealNamespace, 'guestbook');
         assert.strictEqual(getWarningMessages().length, 0);
         assert.strictEqual(getErrorMessages().length, 0);
+    });
+
+    test('navigateToResource reveals apisocial Deployment in resource namespace, not Application CR namespace', async () => {
+        mockArgoCDService = {
+            getApplication: async () => apisocialApplication(),
+            refreshApplication: async () => {
+                /**/
+            },
+            invalidateCache: () => {
+                /**/
+            }
+        } as unknown as ArgoCDService;
+
+        const panel = await openPanel();
+        const webview = panel.webview as unknown as MockWebviewWithFire;
+
+        webview._fireMessage({
+            type: 'navigateToResource',
+            kind: 'Deployment',
+            name: 'apisocial',
+            namespace: 'apisocial-ns'
+        });
+        await flushUntil(() => revealTreeResourceCalls === 1);
+
+        assert.strictEqual(revealTreeResourceCalls, 1);
+        assert.strictEqual(lastRevealNamespace, 'apisocial-ns');
+        assert.notStrictEqual(lastRevealNamespace, 'argocd');
+        assert.strictEqual(invalidateNavigateCacheCalls, 1);
+    });
+
+    test('navigateToResource falls back to destination namespace when resource namespace is empty', async () => {
+        mockArgoCDService = {
+            getApplication: async () => apisocialApplication(),
+            refreshApplication: async () => {
+                /**/
+            },
+            invalidateCache: () => {
+                /**/
+            }
+        } as unknown as ArgoCDService;
+
+        const panel = await openPanel();
+        const webview = panel.webview as unknown as MockWebviewWithFire;
+
+        webview._fireMessage({
+            type: 'navigateToResource',
+            kind: 'Deployment',
+            name: 'apisocial',
+            namespace: ''
+        });
+        await flushUntil(() => revealTreeResourceCalls === 1);
+
+        assert.strictEqual(lastRevealNamespace, 'apisocial-ns');
+    });
+
+    test('resource.navigateTree uses the same reveal namespace rules as navigateToResource', async () => {
+        mockArgoCDService = {
+            getApplication: async () => apisocialApplication(),
+            refreshApplication: async () => {
+                /**/
+            },
+            invalidateCache: () => {
+                /**/
+            }
+        } as unknown as ArgoCDService;
+
+        const panel = await openPanel();
+        const webview = panel.webview as unknown as MockWebviewWithFire;
+
+        webview._fireMessage({
+            type: 'resourceAction',
+            actionId: 'resource.navigateTree',
+            kind: 'Deployment',
+            name: 'apisocial',
+            namespace: 'apisocial-ns'
+        });
+        await flushUntil(() => revealTreeResourceCalls === 1);
+
+        assert.strictEqual(lastRevealNamespace, 'apisocial-ns');
+        assert.notStrictEqual(lastRevealNamespace, 'argocd');
+        assert.strictEqual(invalidateNavigateCacheCalls, 1);
     });
 
     test('navigateToResource shows error for unsupported kinds', async () => {

--- a/src/test/suite/webview/argocdApplicationProtocol.test.ts
+++ b/src/test/suite/webview/argocdApplicationProtocol.test.ts
@@ -47,6 +47,18 @@ suite('argocdApplicationProtocol', () => {
             );
         });
 
+        test('accepts navigateToResource with empty managed-resource namespace', () => {
+            assert.strictEqual(
+                isWebviewMessage({
+                    type: 'navigateToResource',
+                    kind: 'Deployment',
+                    name: 'api',
+                    namespace: ''
+                }),
+                true
+            );
+        });
+
         test('rejects navigateToResource with missing fields', () => {
             assert.strictEqual(
                 isWebviewMessage({

--- a/src/tree/ClusterTreeProvider.ts
+++ b/src/tree/ClusterTreeProvider.ts
@@ -1455,24 +1455,33 @@ export class ClusterTreeProvider implements vscode.TreeDataProvider<ClusterTreeI
         // Clear status caches to force re-check of connectivity and operator status
         this.clusterStatusCache.clear();
         this.operatorStatusCache.clear();
-        
-        // Invalidate cache for current context to ensure fresh data is fetched
+        this.invalidateResourceAndPrefetchCaches();
+        // Fire tree data change event to refresh the tree view
+        this._onDidChangeTreeData.fire();
+    }
+
+    /**
+     * Invalidate resource and prefetch caches before managed-resource tree reveal.
+     * Clears stale category children without forcing connectivity/operator re-checks.
+     */
+    public invalidateCachesBeforeTreeReveal(): void {
+        this.invalidateResourceAndPrefetchCaches();
+        this._onDidChangeTreeData.fire();
+    }
+
+    private invalidateResourceAndPrefetchCaches(): void {
         try {
             const apiClient = getKubernetesApiClient();
             const currentContext = apiClient.getCurrentContext();
-            
-            // Only invalidate if we have a current context
+
             if (currentContext) {
                 const cache = getResourceCache();
                 cache.invalidatePattern(new RegExp(`^${currentContext}:`));
+                this.clusterResourcesCache.delete(currentContext);
             }
         } catch (error) {
-            // Log error but don't block refresh - cache invalidation is best effort
-            console.warn('Failed to invalidate cache during refresh:', error);
+            console.warn('Failed to invalidate resource/prefetch caches:', error);
         }
-        
-        // Fire tree data change event to refresh the tree view
-        this._onDidChangeTreeData.fire();
     }
 
 

--- a/src/types/argocdWebviewProtocol.ts
+++ b/src/types/argocdWebviewProtocol.ts
@@ -190,6 +190,10 @@ function isNonEmptyString(value: unknown): value is string {
     return typeof value === 'string' && value.length > 0;
 }
 
+function isString(value: unknown): value is string {
+    return typeof value === 'string';
+}
+
 function isOptionalBoolean(value: unknown): boolean {
     return value === undefined || typeof value === 'boolean';
 }
@@ -245,7 +249,7 @@ function validateWebviewPayload(type: string, payload: Record<string, unknown>):
             return (
                 isNonEmptyString(payload.kind) &&
                 isNonEmptyString(payload.name) &&
-                isNonEmptyString(payload.namespace)
+                isString(payload.namespace)
             );
         case 'graphRefresh':
             return isOptionalBoolean(payload.bypassCache);
@@ -255,7 +259,7 @@ function validateWebviewPayload(type: string, payload: Record<string, unknown>):
                 isNonEmptyString(payload.actionId) &&
                 isNonEmptyString(payload.kind) &&
                 isNonEmptyString(payload.name) &&
-                isNonEmptyString(payload.namespace) &&
+                isString(payload.namespace) &&
                 isOptionalString(payload.group) &&
                 isOptionalString(payload.version)
             );

--- a/src/webview/ArgoCDApplicationWebviewProvider.ts
+++ b/src/webview/ArgoCDApplicationWebviewProvider.ts
@@ -54,6 +54,8 @@ interface PanelInfo {
     operatorTreeMemo?: OperatorResourceTreeMemo;
     /** True while sync or refresh polling is active */
     operationInProgress?: boolean;
+    /** Application spec.destination.namespace from the last loaded snapshot. */
+    destinationNamespace?: string;
 }
 
 /**
@@ -245,6 +247,12 @@ export class ArgoCDApplicationWebviewProvider {
         const resolvedApplication =
             application ??
             (await argoCDService.getApplication(applicationName, namespace, context));
+
+        const panelKey = ArgoCDApplicationWebviewProvider.panelKey(context, namespace, applicationName);
+        const panelInfo = ArgoCDApplicationWebviewProvider.openPanels.get(panelKey);
+        if (panelInfo) {
+            panelInfo.destinationNamespace = resolvedApplication.destination.namespace ?? '';
+        }
 
         panel.webview.postMessage({
             type: 'applicationData',
@@ -799,7 +807,10 @@ export class ArgoCDApplicationWebviewProvider {
                             context,
                             message.kind,
                             message.name,
-                            message.namespace
+                            message.namespace,
+                            ArgoCDApplicationWebviewProvider.openPanels.get(
+                                ArgoCDApplicationWebviewProvider.panelKey(context, namespace, applicationName)
+                            )?.destinationNamespace
                         );
                         break;
 
@@ -819,7 +830,10 @@ export class ArgoCDApplicationWebviewProvider {
                             panel,
                             treeProvider,
                             context,
-                            message
+                            message,
+                            ArgoCDApplicationWebviewProvider.openPanels.get(
+                                ArgoCDApplicationWebviewProvider.panelKey(context, namespace, applicationName)
+                            )?.destinationNamespace
                         );
                         break;
                     
@@ -925,14 +939,16 @@ export class ArgoCDApplicationWebviewProvider {
         panel: vscode.WebviewPanel,
         treeProvider: ClusterTreeProvider,
         context: string,
-        message: ResourceActionWebviewMessage
+        message: ResourceActionWebviewMessage,
+        destinationNamespace?: string
     ): Promise<void> {
         await dispatchResourceAction(
             {
                 panel,
                 treeProvider,
                 context,
-                kubeconfigPath: treeProvider.getKubeconfigPath() ?? ''
+                kubeconfigPath: treeProvider.getKubeconfigPath() ?? '',
+                destinationNamespace
             },
             message
         );
@@ -1175,7 +1191,8 @@ export class ArgoCDApplicationWebviewProvider {
         panelContext: string,
         kind: string,
         name: string,
-        namespace: string
+        namespace: string,
+        destinationNamespace?: string
     ): Promise<void> {
         if (!NAVIGATE_TREE_SUPPORTED_KINDS.has(kind)) {
             vscode.window.showErrorMessage(
@@ -1188,7 +1205,8 @@ export class ArgoCDApplicationWebviewProvider {
             { treeProvider, panelContext },
             kind,
             name,
-            namespace
+            namespace,
+            { destinationNamespace }
         );
 
         if (result.success) {


### PR DESCRIPTION
## Description

Fixes managed-resource **Navigate to resource in tree** so graph-visible workloads reveal in the cluster tree using the correct namespace, with fresh category data before lookup.

Fixes #242

## Motivation and Context

Deployments such as `apisocial` can live in a destination namespace that differs from the Application CR namespace (`argocd`). Reveal was failing with false "resource not found in cluster tree" when namespace resolution or stale prefetch caches were wrong.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## How Has This Been Tested?

- [ ] Manual testing in Extension Development Host (F5)
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Tested with multiple Kubernetes clusters
- [ ] Tested on multiple OS (macOS, Windows, Linux)
- [ ] Tested with different VS Code versions

## Summary

- Add `resolveManagedResourceRevealNamespace` so non-empty managed-resource namespace wins and empty namespaced rows fall back to `spec.destination.namespace` (never Application CR namespace).
- Store `destinationNamespace` on Argo CD panel info from the loaded application snapshot and pass it through `resource.navigateTree` and `navigateToResource`.
- Add `ClusterTreeProvider.invalidateCachesBeforeTreeReveal()` to clear resource + prefetch caches before `revealTreeResource`.
- Allow empty wire `namespace` on navigate messages so the host can apply destination fallback.
- Add unit coverage: `treeRevealHelper.test.ts`, apisocial-style navigation fixtures.

## Test plan

- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm run test:unit`
- [ ] Manual: Extension Development Host with Application where CR namespace ≠ Deployment namespace; tile navigate selects Deployment in tree